### PR TITLE
Create SQL context for both python and scala sessions

### DIFF
--- a/remotespark/RemoteSparkMagics.py
+++ b/remotespark/RemoteSparkMagics.py
@@ -12,6 +12,7 @@ from IPython.core.magic_arguments import (argument, magic_arguments, parse_argst
 from livyclientlib.clientmanager import ClientManager
 from livyclientlib.livyclientfactory import LivyClientFactory
 from livyclientlib.log import Log
+from livyclientlib.constants import Constants
 
 
 @magics_class
@@ -27,7 +28,7 @@ class RemoteSparkMagics(Magics):
         self.client_factory = LivyClientFactory()
 
     @magic_arguments()
-    @argument("-l", "--language", help='The language to execute: "scala", "pyspark", "sql". Default is "scala".')
+    @argument("-l", "--language", help='The language to execute: "scala", "pyspark", "sql", "pysql". Default is "scala".')
     @argument("-m", "--mode", help='The mode to execute the magic in: "normal" or "debug". Default is "normal".')
     @argument("-c", "--client", help="The name of the Livy client to use. "
               "Add a session by using %sparkconfig. "
@@ -55,9 +56,9 @@ class RemoteSparkMagics(Magics):
 
         # Select language
         if not args.language:
-            args.language = "scala"
+            args.language = Constants.lang_scala
         args.language = args.language.lower()
-        if args.language not in ["scala", "pyspark", "sql"]:
+        if args.language not in Constants.lang_supported:
             raise ValueError("Language '{}' not supported.".format(args.language))
 
         # Select client
@@ -160,12 +161,14 @@ class RemoteSparkMagics(Magics):
         return "Possible endpoints are: {}".format(self.client_manager.get_endpoints_list())
 
     def _send_command(self, client, command, language):
-        if language == "scala":
+        if language == Constants.lang_scala:
             return client.execute_scala(command)
-        elif language == "pyspark":
+        elif language == Constants.lang_pyspark:
             return client.execute_pyspark(command)
-        elif language == "sql":
-            return client.execute_sql(command)
+        elif language == Constants.lang_sql:
+            return client.execute_scala_sql(command)
+        elif language == Constants.lang_pysql:
+            return client.execute_pyspark_sql(command)
         
 
 def load_ipython_extension(ip):

--- a/remotespark/livyclientlib/constants.py
+++ b/remotespark/livyclientlib/constants.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2015  aggftw@gmail.com
+# Distributed under the terms of the Modified BSD License.
+
+class Constants:
+    session_kind_spark = "spark"
+    session_kind_pyspark =  "pyspark"
+    session_supported_kinds = [session_kind_spark, session_kind_pyspark]
+
+    lang_scala = "scala"
+    lang_pyspark = "pyspark"
+    lang_sql = "sql"
+    lang_pysql = "pysql"
+    lang_supported = [lang_scala, lang_pyspark, lang_sql, lang_pysql]

--- a/remotespark/livyclientlib/livyclient.py
+++ b/remotespark/livyclientlib/livyclient.py
@@ -11,6 +11,7 @@ class LivyClient(object):
     def __init__(self, spark_session, pyspark_session):
         self._spark_session = spark_session
         self._pyspark_session = pyspark_session
+        self._executed_sql = False
 
     def execute_scala(self, commands):
         self._spark_session.wait_for_state("idle")
@@ -21,15 +22,52 @@ class LivyClient(object):
         return self._pyspark_session.execute(commands)
 
     def execute_sql(self, command):
-        return self.execute_scala(self._make_sql(command))
+        if not self._executed_sql:
+            self.execute_pyspark(self._create_sql_context())
+            self._executed_sql = True
+
+        records_text = self.execute_pyspark(self._make_sql_collect(command))
+        columns_text = self.execute_pyspark(self._make_sql_columns(command))
+
+        records = eval(records_text)
+        columns = eval(columns_text)
+
+        import pandas as pd
+        return pd.DataFrame.from_records(records, columns=columns)
 
     def close_sessions(self):
         self._spark_session.delete()
         self._pyspark_session.delete()
 
-    def _make_sql(self, command):
-        sql = ""
-        sql += "val sqlContext = new org.apache.spark.sql.SQLContext(sc)\nimport sqlContext.implicits._\n"
-        sql += 'sqlContext.sql("' + command + '").collect()'
-
+    def _create_sql_context(self):
+        # TODO(aggftw): Create sqlContext by default on session start
+        sql = "from pyspark.sql import SQLContext\nfrom pyspark.sql.types import *\nsqlContext = SQLContext(sc)"
         return sql
+
+    def _make_sql_collect(self, command):
+        sql = 'sqlContext.sql("' + command + '").collect()'
+        return sql
+
+    def _make_sql_columns(self, command):
+        sql = 'sqlContext.sql("' + command + '").columns'
+        return sql
+
+
+class Row(tuple):
+    def __new__(cls, *args, **kwargs):
+        if args and kwargs:
+            raise ValueError("Can not use both args "
+                             "and kwargs to create Row")
+        if args:
+            # create row class or objects
+            return tuple.__new__(cls, args)
+
+        elif kwargs:
+            # create row objects
+            names = sorted(kwargs.keys())
+            row = tuple.__new__(cls, [kwargs[n] for n in names])
+            row.__fields__ = names
+            return row
+
+        else:
+            raise ValueError("No args or kwargs")

--- a/remotespark/livyclientlib/livyclient.py
+++ b/remotespark/livyclientlib/livyclient.py
@@ -11,63 +11,23 @@ class LivyClient(object):
     def __init__(self, spark_session, pyspark_session):
         self._spark_session = spark_session
         self._pyspark_session = pyspark_session
-        self._executed_sql = False
 
     def execute_scala(self, commands):
         self._spark_session.wait_for_state("idle")
         return self._spark_session.execute(commands)
 
+    def execute_scala_sql(self, command):
+        self._spark_session.create_sql_context()
+        return self.execute_scala('sqlContext.sql("' + command + '").collect()')
+
     def execute_pyspark(self, commands):
         self._pyspark_session.wait_for_state("idle")
         return self._pyspark_session.execute(commands)
 
-    def execute_sql(self, command):
-        if not self._executed_sql:
-            self.execute_pyspark(self._create_sql_context())
-            self._executed_sql = True
-
-        records_text = self.execute_pyspark(self._make_sql_collect(command))
-        columns_text = self.execute_pyspark(self._make_sql_columns(command))
-
-        records = eval(records_text)
-        columns = eval(columns_text)
-
-        import pandas as pd
-        return pd.DataFrame.from_records(records, columns=columns)
+    def execute_pyspark_sql(self, command):
+        self._pyspark_session.create_sql_context()
+        return self.execute_pyspark("sqlContext.sql('" + command + "').collect()")
 
     def close_sessions(self):
         self._spark_session.delete()
         self._pyspark_session.delete()
-
-    def _create_sql_context(self):
-        # TODO(aggftw): Create sqlContext by default on session start
-        sql = "from pyspark.sql import SQLContext\nfrom pyspark.sql.types import *\nsqlContext = SQLContext(sc)"
-        return sql
-
-    def _make_sql_collect(self, command):
-        sql = 'sqlContext.sql("' + command + '").collect()'
-        return sql
-
-    def _make_sql_columns(self, command):
-        sql = 'sqlContext.sql("' + command + '").columns'
-        return sql
-
-
-class Row(tuple):
-    def __new__(cls, *args, **kwargs):
-        if args and kwargs:
-            raise ValueError("Can not use both args "
-                             "and kwargs to create Row")
-        if args:
-            # create row class or objects
-            return tuple.__new__(cls, args)
-
-        elif kwargs:
-            # create row objects
-            names = sorted(kwargs.keys())
-            row = tuple.__new__(cls, [kwargs[n] for n in names])
-            row.__fields__ = names
-            return row
-
-        else:
-            raise ValueError("No args or kwargs")

--- a/remotespark/livyclientlib/livyclientfactory.py
+++ b/remotespark/livyclientlib/livyclientfactory.py
@@ -1,13 +1,11 @@
 # Copyright (c) 2015  aggftw@gmail.com
 # Distributed under the terms of the Modified BSD License.
-
-from base64 import b64encode
-
 from .log import Log
 from .connectionstringutil import get_connection_string_elements
 from .livysession import LivySession
 from .livyclient import LivyClient
 from .reliablehttpclient import ReliableHttpClient
+from .constants import Constants
 
 
 class LivyClientFactory(object):
@@ -24,10 +22,15 @@ class LivyClientFactory(object):
 
         http_client = ReliableHttpClient(cso.url, headers, cso.username, cso.password)
 
-        spark_session = LivySession(http_client, "spark")
-        pyspark_session = LivySession(http_client, "pyspark")
+        spark_session = self._create_session(http_client, Constants.session_kind_spark)
+        pyspark_session = self._create_session(http_client, Constants.session_kind_pyspark)
 
         return LivyClient(spark_session, pyspark_session)
+
+    def _create_session(self, http_client, kind):
+        session = LivySession(http_client, kind)
+        session.start()
+        return session
 
     def _get_headers(self):
         return {"Content-Type": "application/json"}

--- a/tests/test_livyclient.py
+++ b/tests/test_livyclient.py
@@ -27,15 +27,27 @@ def test_execute_pyspark():
     mock_pysparksession.execute.assert_called_with(command)
 
 
-def test_execute_sql():
+def test_execute_scala_sql():
     mock_sparksession = MagicMock()
     mock_pysparksession = MagicMock()
     client = LivyClient(mock_sparksession, mock_pysparksession)
     command = "command"
 
-    client.execute_sql(command)
+    client.execute_scala_sql(command)
 
+    mock_sparksession.create_sql_context.assert_called_with()
     mock_sparksession.wait_for_state.assert_called_with("idle")
-    mock_sparksession.execute.assert_called_with("val sqlContext = new org.apache.spark.sql.SQLContext(sc)\nimport "
-                                                 "sqlContext.implicits._\nsqlContext.sql(\"{}\")"
-                                                 ".collect()".format(command))
+    mock_sparksession.execute.assert_called_with("sqlContext.sql(\"{}\").collect()".format(command))
+
+
+def test_execute_pyspark_sql():
+    mock_sparksession = MagicMock()
+    mock_pysparksession = MagicMock()
+    client = LivyClient(mock_sparksession, mock_pysparksession)
+    command = "command"
+
+    client.execute_pyspark_sql(command)
+
+    mock_pysparksession.create_sql_context.assert_called_with()
+    mock_pysparksession.wait_for_state.assert_called_with("idle")
+    mock_pysparksession.execute.assert_called_with("sqlContext.sql('{}').collect()".format(command))

--- a/tests/test_livysession.py
+++ b/tests/test_livysession.py
@@ -169,6 +169,8 @@ class TestLivySession:
         http_client.reset_mock()
 
         session.create_sql_context()
+
+        # Second call should not issue a post request
         session.create_sql_context()
 
         http_client.post.assert_called_once_with("/sessions/0/statements", [201],

--- a/tests/test_livysession.py
+++ b/tests/test_livysession.py
@@ -6,7 +6,7 @@ from mock import MagicMock
 from remotespark.livyclientlib.livysession import LivySession
 
 
-class DummyResponse():
+class DummyResponse:
     def __init__(self, status_code, json_text):
         self._status_code = status_code
         self._json_text = json_text
@@ -22,11 +22,34 @@ class TestLivySession:
     pi_result = "Pi is roughly 3.14336"
 
     session_create_json = '{"id":0,"state":"starting","kind":"spark","log":[]}'
-    ready_sessions_json = '{"from":0,"total":1,"sessions":[{"id":0,"state":"idle","kind":"spark","log":["16:23:01,151 |-INFO in ch.qos.logback.core.joran.action.AppenderAction - Naming appender as [STDOUT]","16:23:01,213 |-INFO in ch.qos.logback.core.joran.action.NestedComplexPropertyIA - Assuming default type [ch.qos.logback.access.PatternLayoutEncoder] for [encoder] property","16:23:01,368 |-INFO in ch.qos.logback.core.joran.action.AppenderRefAction - Attaching appender named [STDOUT] to null","16:23:01,368 |-INFO in ch.qos.logback.access.joran.action.ConfigurationAction - End of configuration.","16:23:01,371 |-INFO in ch.qos.logback.access.joran.JoranConfigurator@53799e55 - Registering current configuration as safe fallback point","","15/09/04 16:23:01 INFO server.ServerConnector: Started ServerConnector@388859e4{HTTP/1.1}{0.0.0.0:37394}","15/09/04 16:23:01 INFO server.Server: Started @27514ms","15/09/04 16:23:01 INFO livy.WebServer: Starting server on 37394","Starting livy-repl on http://10.0.0.11:37394"]}]}'
-    busy_sessions_json = '{"from":0,"total":1,"sessions":[{"id":0,"state":"busy","kind":"spark","log":["16:23:01,151 |-INFO in ch.qos.logback.core.joran.action.AppenderAction - Naming appender as [STDOUT]","16:23:01,213 |-INFO in ch.qos.logback.core.joran.action.NestedComplexPropertyIA - Assuming default type [ch.qos.logback.access.PatternLayoutEncoder] for [encoder] property","16:23:01,368 |-INFO in ch.qos.logback.core.joran.action.AppenderRefAction - Attaching appender named [STDOUT] to null","16:23:01,368 |-INFO in ch.qos.logback.access.joran.action.ConfigurationAction - End of configuration.","16:23:01,371 |-INFO in ch.qos.logback.access.joran.JoranConfigurator@53799e55 - Registering current configuration as safe fallback point","","15/09/04 16:23:01 INFO server.ServerConnector: Started ServerConnector@388859e4{HTTP/1.1}{0.0.0.0:37394}","15/09/04 16:23:01 INFO server.Server: Started @27514ms","15/09/04 16:23:01 INFO livy.WebServer: Starting server on 37394","Starting livy-repl on http://10.0.0.11:37394"]}]}'
+    ready_sessions_json = '{"from":0,"total":1,"sessions":[{"id":0,"state":"idle","kind":"spark","log":["16:23:01,15' \
+                          '1 |-INFO in ch.qos.logback.core.joran.action.AppenderAction - Naming appender as [STDOUT]' \
+                          '","16:23:01,213 |-INFO in ch.qos.logback.core.joran.action.NestedComplexPropertyIA - As' \
+                          'suming default type [ch.qos.logback.access.PatternLayoutEncoder] for [encoder] propert' \
+                          'y","16:23:01,368 |-INFO in ch.qos.logback.core.joran.action.AppenderRefAction - Attachin' \
+                          'g appender named [STDOUT] to null","16:23:01,368 |-INFO in ch.qos.logback.access.joran.act' \
+                          'ion.ConfigurationAction - End of configuration.","16:23:01,371 |-INFO in ch.qos.logback.ac' \
+                          'cess.joran.JoranConfigurator@53799e55 - Registering current configuration as safe fallback' \
+                          ' point","","15/09/04 16:23:01 INFO server.ServerConnector: Started ServerConnector@388859' \
+                          'e4{HTTP/1.1}{0.0.0.0:37394}","15/09/04 16:23:01 INFO server.Server: Started @27514ms","' \
+                          '15/09/04 16:23:01 INFO livy.WebServer: Starting server on 37394","Starting livy-repl on' \
+                          ' http://10.0.0.11:37394"]}]}'
+    busy_sessions_json = '{"from":0,"total":1,"sessions":[{"id":0,"state":"busy","kind":"spark","log":["16:23:01,151' \
+                         ' |-INFO in ch.qos.logback.core.joran.action.AppenderAction - Naming appender as [STDOUT]",' \
+                         '"16:23:01,213 |-INFO in ch.qos.logback.core.joran.action.NestedComplexPropertyIA - Assumin' \
+                         'g default type [ch.qos.logback.access.PatternLayoutEncoder] for [encoder] property","16:23' \
+                         ':01,368 |-INFO in ch.qos.logback.core.joran.action.AppenderRefAction - Attaching appender ' \
+                         'named [STDOUT] to null","16:23:01,368 |-INFO in ch.qos.logback.access.joran.action.Configu' \
+                         'rationAction - End of configuration.","16:23:01,371 |-INFO in ch.qos.logback.access.joran.' \
+                         'JoranConfigurator@53799e55 - Registering current configuration as safe fallback point","",' \
+                         '"15/09/04 16:23:01 INFO server.ServerConnector: Started ServerConnector@388859e4{HTTP/1.1}' \
+                         '{0.0.0.0:37394}","15/09/04 16:23:01 INFO server.Server: Started @27514ms","15/09/04 16:23:' \
+                         '01 INFO livy.WebServer: Starting server on 37394","Starting livy-repl on http://10.0.0.11:' \
+                         '37394"]}]}'
     post_statement_json = '{"id":0,"state":"running","output":null}'
     running_statement_json = '{"total_statements":1,"statements":[{"id":0,"state":"running","output":null}]}'
-    ready_statement_json = '{"total_statements":1,"statements":[{"id":0,"state":"available","output":{"status":"ok","execution_count":0,"data":{"text/plain":"Pi is roughly 3.14336"}}}]}'
+    ready_statement_json = '{"total_statements":1,"statements":[{"id":0,"state":"available","output":{"status":"ok",' \
+                           '"execution_count":0,"data":{"text/plain":"Pi is roughly 3.14336"}}}]}'
     
     get_responses = []
     post_responses = []
@@ -128,6 +151,29 @@ class TestLivySession:
         http_client.get.assert_called_with("/sessions/0/statements", [200])
         assert_equals(2, http_client.get.call_count)
         assert_equals(self.pi_result, result)
+
+    def test_create_sql_context_happens_once(self):
+        kind = "spark"
+        http_client = MagicMock()
+        self.post_responses = [DummyResponse(201, self.session_create_json),
+                               DummyResponse(201, self.post_statement_json)]
+        http_client.post.side_effect = self._next_response_post
+        self.get_responses = [DummyResponse(200, self.ready_sessions_json),
+                              DummyResponse(200, self.running_statement_json),
+                              DummyResponse(200, self.ready_statement_json)]
+        http_client.get.side_effect = self._next_response_get
+        session = LivySession(http_client, kind)
+        session.start()
+
+        # Reset the mock so that post called count is accurate
+        http_client.reset_mock()
+
+        session.create_sql_context()
+        session.create_sql_context()
+
+        http_client.post.assert_called_once_with("/sessions/0/statements", [201],
+                                                 {"code": "val sqlContext = new org.apache.spark.sql.SQLContext(sc)\n"
+                                                          "import sqlContext.implicits._"})
 
     def test_create_sql_context_spark(self):
         kind = "spark"


### PR DESCRIPTION
SQL is not a language in Spark. It's a feature tied to python/scala. Adding sql context for both languages.