### PR TITLE
Separated magics into controller class and magics class

### DIFF
--- a/remotespark/RemoteSparkMagics.py
+++ b/remotespark/RemoteSparkMagics.py
@@ -6,13 +6,11 @@ Provides the %spark magic."""
 
 from __future__ import print_function
 
-from IPython.core.magic import (Magics, magics_class, line_magic, line_cell_magic)
+from IPython.core.magic import (Magics, magics_class, line_cell_magic)
 from IPython.core.magic_arguments import (argument, magic_arguments, parse_argstring)
 
-from .livyclientlib.clientmanager import ClientManager
-from .livyclientlib.livyclientfactory import LivyClientFactory
+from .livyclientlib.sparkcontroller import SparkController
 from .livyclientlib.log import Log
-from .livyclientlib.constants import Constants
 
 
 @magics_class
@@ -23,9 +21,7 @@ class RemoteSparkMagics(Magics):
     def __init__(self, shell, data=None, mode="normal"):
         # You must call the parent constructor
         super(RemoteSparkMagics, self).__init__(shell)
-        Log.mode = mode
-        self.client_manager = ClientManager()
-        self.client_factory = LivyClientFactory()
+        self.spark_controller = SparkController(mode)
 
     @magic_arguments()
     @argument("-s", "--sql", type=bool, default=False, help='Whether to use SQL.')
@@ -58,17 +54,17 @@ class RemoteSparkMagics(Magics):
         user_input = line
         args = parse_argstring(self.spark, user_input)
 
-
         subcommand = args.command[0].lower()
 
         # info
         if subcommand == "info":
-            pass #info is printed by default
+            # Info is printed by default
+            pass
         # mode
         elif subcommand == "mode":
             if len(args.command) != 2:
                 raise ValueError("Subcommand 'mode' requires an argument. {}".format(usage))
-            self.log_mode(args.command[1])
+            self.spark_controller.set_log_mode(args.command[1])
         # add
         elif subcommand == "add":
             if len(args.command) != 4:
@@ -76,23 +72,23 @@ class RemoteSparkMagics(Magics):
             name = args.command[1].lower()
             language = args.command[2]
             connection_string = args.command[3]
-            self.add_endpoint(name, language, connection_string)
+            self.spark_controller.add_endpoint(name, language, connection_string)
         # delete
         elif subcommand == "delete":
             if len(args.command) != 2:
                 raise ValueError("Subcommand 'delete' requires an argument. {}".format(usage))
             name = args.command[1].lower()
-            self.delete_endpoint(name)  
+            self.spark_controller.delete_endpoint(name)
         # cleanup 
         elif subcommand == "cleanup":
-            self.cleanup()
+            self.spark_controller.cleanup()
         # run
-        elif len(subcommand) == 0:    
+        elif len(subcommand) == 0:
             self.logger.debug("line: " + line)
             self.logger.debug("cell: " + cell)
             self.logger.debug("args: " + str(args))
-            return self.run_cell(args.client, args.sql, cell)
-        #error
+            return self.spark_controller.run_cell(args.client, args.sql, cell)
+        # error
         else:
             raise ValueError("Subcommand '{}' not found. {}".format(subcommand, usage))
         
@@ -103,47 +99,10 @@ class RemoteSparkMagics(Magics):
                 print(usage)
             self._print_info()
 
-    def run_cell(self, client_name, sql, cell):
-        # Select client
-        if client_name is None:
-            client_to_use = self.client_manager.get_any_client()
-        else:
-            client_name= client_name.lower()
-            client_to_use = self.client_manager.get_client(client_name)
-
-        # Execute
-        return self._send_command(client_to_use, cell, sql)
-
-    def cleanup(self):
-        self.client_manager.clean_up_all()
-
-    def log_mode(self, mode):
-        Log.mode = mode
-
-    def delete_endpoint(self, name):
-        self.client_manager.delete_client(name)
-
-    def add_endpoint(self, name, language, connection_string):
-        session = self.client_factory.create_session(language, connection_string, "-1", False)
-        session.start()
-        livy_client = self.client_factory.build_client(language, session)
-        self.client_manager.add_client(name, livy_client)
-
     def _print_info(self):
-        print("Info for running sparkmagic:\n    mode={}\n    {}\n".format(Log.mode, self._get_client_keys()))
-
-    def _get_client_keys(self):
-        return "Possible endpoints are: {}".format(self.client_manager.get_endpoints_list())
-
-    def _send_command(self, client, command, sql):
-        if sql:
-            res = client.execute_sql(command)
-        else:
-            res = client.execute(command)
-
-        return res
+        print("Info for running Spark:\n    mode={}\n    {}\n"
+              .format(self.spark_controller.get_log_mode(), self.spark_controller.get_client_keys()))
 
         
-
 def load_ipython_extension(ip):
     ip.register_magics(RemoteSparkMagics)

--- a/remotespark/livyclientlib/sparkcontroller.py
+++ b/remotespark/livyclientlib/sparkcontroller.py
@@ -1,0 +1,58 @@
+"""Runs Scala, PySpark and SQL statement through Spark using a REST endpoint in remote cluster.
+Provides the %spark magic."""
+
+# Copyright (c) 2015  aggftw@gmail.com
+# Distributed under the terms of the Modified BSD License.
+
+from .clientmanager import ClientManager
+from .livyclientfactory import LivyClientFactory
+from .log import Log
+
+
+class SparkController(object):
+
+    logger = Log()
+
+    def __init__(self, mode):
+        self.set_log_mode(mode)
+        self.client_manager = ClientManager()
+        self.client_factory = LivyClientFactory()
+
+    @staticmethod
+    def get_log_mode():
+        return Log.mode
+
+    @staticmethod
+    def set_log_mode(mode):
+        Log.mode = mode
+
+    def run_cell(self, client_name, sql, cell):
+        # Select client
+        if client_name is None:
+            client_to_use = self.client_manager.get_any_client()
+        else:
+            client_name = client_name.lower()
+            client_to_use = self.client_manager.get_client(client_name)
+
+        # Execute
+        if sql:
+            res = client_to_use.execute_sql(cell)
+        else:
+            res = client_to_use.execute(cell)
+
+        return res
+
+    def cleanup(self):
+        self.client_manager.clean_up_all()
+
+    def delete_endpoint(self, name):
+        self.client_manager.delete_client(name)
+
+    def add_endpoint(self, name, language, connection_string):
+        session = self.client_factory.create_session(language, connection_string, "-1", False)
+        session.start()
+        livy_client = self.client_factory.build_client(language, session)
+        self.client_manager.add_client(name, livy_client)
+
+    def get_client_keys(self):
+        return self.client_manager.get_endpoints_list()

--- a/tests/test_remotesparkmagics.py
+++ b/tests/test_remotesparkmagics.py
@@ -4,15 +4,13 @@ from mock import MagicMock
 from remotespark.RemoteSparkMagics import RemoteSparkMagics
 
 
-ip = get_ipython()
 magic = None
 spark_controller = None
 
 
 def _setup():
     global magic, spark_controller
-    magic = RemoteSparkMagics(shell=ip)
-    ip.register_magics(magic)
+    magic = RemoteSparkMagics(shell=None)
 
     spark_controller = MagicMock()
     magic.spark_controller = spark_controller
@@ -28,7 +26,7 @@ def test_info_command_parses():
     magic._print_info = print_info_mock
     command = "info"
 
-    ip.run_line_magic("spark", command)
+    magic.spark(command)
 
     print_info_mock.assert_called_once_with()
 
@@ -43,7 +41,7 @@ def test_add_endpoint_command_parses():
     connection_string = "url=http://location:port;username=name;password=word"
     line = " ".join([command, name, language, connection_string])
 
-    ip.run_line_magic("spark", line)
+    magic.spark(line)
 
     add_endpoint_mock.assert_called_once_with(name, language, connection_string)
 
@@ -56,7 +54,7 @@ def test_delete_endpoint_command_parses():
     name = "name"
     line = " ".join([command, name])
 
-    ip.run_line_magic("spark", line)
+    magic.spark(line)
 
     mock_method.assert_called_once_with(name)
 
@@ -70,7 +68,7 @@ def test_mode_command_parses():
 
     line = " ".join([command, mode])
 
-    ip.run_line_magic("spark", line)
+    magic.spark(line)
 
     mock_method.assert_called_once_with(mode)
 
@@ -79,9 +77,9 @@ def test_mode_command_parses():
 def test_cleanup_command_parses():
     mock_method = MagicMock()
     spark_controller.cleanup = mock_method
-    command = "cleanup"
+    line = "cleanup"
 
-    ip.run_line_magic("spark", command)
+    magic.spark(line)
 
     mock_method.assert_called_once_with()
 
@@ -89,9 +87,9 @@ def test_cleanup_command_parses():
 @raises(ValueError)
 @with_setup(_setup, _teardown)
 def test_bad_command_throws_exception():
-    command = "bad_command"
+    line = "bad_command"
 
-    ip.run_line_magic("spark", command)
+    magic.spark(line)
 
 
 @with_setup(_setup, _teardown)
@@ -103,6 +101,6 @@ def test_run_cell_command_parses():
     line = " ".join([command, name])
     cell = "cell code"
 
-    ip.run_cell_magic("spark", line, cell)
+    magic.spark(line, cell)
 
     mock_method.assert_called_once_with(name, False, cell)

--- a/tests/test_remotesparkmagics.py
+++ b/tests/test_remotesparkmagics.py
@@ -1,167 +1,108 @@
-from nose.tools import raises, with_setup, assert_equals
+from nose.tools import raises, with_setup
 from mock import MagicMock
 
-from remotespark.livyclientlib.log import Log
 from remotespark.RemoteSparkMagics import RemoteSparkMagics
-
 
 
 ip = get_ipython()
 magic = None
-client_manager = None
-client_factory = None
+spark_controller = None
+
 
 def _setup():
-	global magic, client_manager, client_factory
-	magic = RemoteSparkMagics(shell=ip)
-	ip.register_magics(magic)
+    global magic, spark_controller
+    magic = RemoteSparkMagics(shell=ip)
+    ip.register_magics(magic)
 
-	client_manager = MagicMock()
-	client_factory = MagicMock()
-	magic.client_manager = client_manager
-	magic.client_factory = client_factory
+    spark_controller = MagicMock()
+    magic.spark_controller = spark_controller
+
 
 def _teardown():
-	pass
+    pass
+
 
 @with_setup(_setup, _teardown)
 def test_info_command_parses():
-	mock_method = MagicMock()
-	magic._print_info = mock_method
-	command = "info"
+    print_info_mock = MagicMock()
+    magic._print_info = print_info_mock
+    command = "info"
 
-	ip.run_line_magic("spark", command)
+    ip.run_line_magic("spark", command)
 
-	mock_method.assert_called_once_with()
+    print_info_mock.assert_called_once_with()
+
 
 @with_setup(_setup, _teardown)
 def test_add_endpoint_command_parses():
-	mock_method = MagicMock()
-	magic.add_endpoint = mock_method
-	command = "add"
-	name = "name"
-	language = "python"
-	connection_string = "url=http://location:port;username=name;password=word"
-	line = " ".join([command, name, language, connection_string])
+    add_endpoint_mock = MagicMock()
+    spark_controller.add_endpoint = add_endpoint_mock
+    command = "add"
+    name = "name"
+    language = "python"
+    connection_string = "url=http://location:port;username=name;password=word"
+    line = " ".join([command, name, language, connection_string])
 
-	ip.run_line_magic("spark", line)
+    ip.run_line_magic("spark", line)
 
-	mock_method.assert_called_once_with(name, language, connection_string)
-
-@with_setup(_setup, _teardown)
-def test_add_endpoint():
-	name = "name"
-	language = "python"
-	connection_string = "url=http://location:port;username=name;password=word"
-	client = "client"
-	session = MagicMock()
-	client_factory.create_session = MagicMock(return_value=session)
-	client_factory.build_client = MagicMock(return_value=client)
-
-	magic.add_endpoint(name, language, connection_string)
-
-	client_factory.create_session.assert_called_once_with(language, connection_string, "-1", False)
-	client_factory.build_client.assert_called_once_with(language, session)
-	client_manager.add_client.assert_called_once_with(name, client)
-	session.start.assert_called_once_with()
+    add_endpoint_mock.assert_called_once_with(name, language, connection_string)
 
 
 @with_setup(_setup, _teardown)
 def test_delete_endpoint_command_parses():
-	mock_method = MagicMock()
-	magic.delete_endpoint = mock_method
-	command = "delete"
-	name = "name"
-	line = " ".join([command, name])
+    mock_method = MagicMock()
+    spark_controller.delete_endpoint = mock_method
+    command = "delete"
+    name = "name"
+    line = " ".join([command, name])
 
-	ip.run_line_magic("spark", line)
+    ip.run_line_magic("spark", line)
 
-	mock_method.assert_called_once_with(name)
+    mock_method.assert_called_once_with(name)
 
-@with_setup(_setup, _teardown)
-def test_delete_endpoint():
-	name = "name"
-
-	magic.delete_endpoint(name)
-
-	client_manager.delete_client.assert_called_once_with(name)
 
 @with_setup(_setup, _teardown)
 def test_mode_command_parses():
-	mock_method = MagicMock()
-	magic.log_mode = mock_method
-	command = "mode"
-	mode = "debug"
+    mock_method = MagicMock()
+    spark_controller.set_log_mode = mock_method
+    command = "mode"
+    mode = "debug"
 
-	line = " ".join([command, mode])
+    line = " ".join([command, mode])
 
-	ip.run_line_magic("spark", line)
+    ip.run_line_magic("spark", line)
 
-	mock_method.assert_called_once_with(mode)
+    mock_method.assert_called_once_with(mode)
 
-@with_setup(_setup, _teardown)
-def test_delete_endpoint():
-	mode = "debug"
-
-	magic.log_mode(mode)
-
-	assert_equals(mode, Log.mode)
 
 @with_setup(_setup, _teardown)
 def test_cleanup_command_parses():
-	mock_method = MagicMock()
-	magic.cleanup = mock_method
-	command = "cleanup"
+    mock_method = MagicMock()
+    spark_controller.cleanup = mock_method
+    command = "cleanup"
 
-	ip.run_line_magic("spark", command)
+    ip.run_line_magic("spark", command)
 
-	mock_method.assert_called_once_with()
+    mock_method.assert_called_once_with()
 
-@with_setup(_setup, _teardown)
-def test_cleanup():
-	magic.cleanup()
-	client_manager.clean_up_all.assert_called_once_with()
 
 @raises(ValueError)
 @with_setup(_setup, _teardown)
 def test_bad_command_throws_exception():
-	command = "bad_command"
+    command = "bad_command"
 
-	ip.run_line_magic("spark", command)
+    ip.run_line_magic("spark", command)
+
 
 @with_setup(_setup, _teardown)
 def test_run_cell_command_parses():
-	mock_method = MagicMock()
-	magic.run_cell = mock_method
-	command = "-c"
-	name = "endpoint_name"
-	line = " ".join([command, name])
-	cell = "cell code"
+    mock_method = MagicMock()
+    spark_controller.run_cell = mock_method
+    command = "-c"
+    name = "endpoint_name"
+    line = " ".join([command, name])
+    cell = "cell code"
 
-	ip.run_cell_magic("spark", line, cell)
+    ip.run_cell_magic("spark", line, cell)
 
-	mock_method.assert_called_once_with(name, False, cell)
-
-@with_setup(_setup, _teardown)
-def test_run_cell():
-	default_client = MagicMock()
-	chosen_client = MagicMock()
-	client_manager.get_any_client = MagicMock(return_value=default_client)
-	client_manager.get_client = MagicMock(return_value=chosen_client)
-	name = "endpoint_name"
-	sql = False
-	cell = "cell code"
-
-	magic.run_cell(name, sql, cell)
-	chosen_client.execute.assert_called_with(cell)
-
-	magic.run_cell(None, sql, cell)
-	default_client.execute.assert_called_with(cell)
-
-	sql = True
-
-	magic.run_cell(name, sql, cell)
-	chosen_client.execute_sql.assert_called_with(cell)
-
-	magic.run_cell(None, sql, cell)
-	default_client.execute_sql.assert_called_with(cell)
+    mock_method.assert_called_once_with(name, False, cell)

--- a/tests/test_sparkcontroller.py
+++ b/tests/test_sparkcontroller.py
@@ -1,0 +1,97 @@
+from nose.tools import with_setup, assert_equals
+from mock import MagicMock
+
+from remotespark.livyclientlib.log import Log
+from remotespark.livyclientlib.sparkcontroller import SparkController
+
+
+client_manager = None
+client_factory = None
+controller = None
+
+
+def _setup():
+    global client_manager, client_factory, controller
+
+    client_manager = MagicMock()
+    client_factory = MagicMock()
+    controller = SparkController("normal")
+    controller.client_manager = client_manager
+    controller.client_factory = client_factory
+
+
+def _teardown():
+    pass
+
+
+@with_setup(_setup, _teardown)
+def test_add_endpoint():
+    name = "name"
+    language = "python"
+    connection_string = "url=http://location:port;username=name;password=word"
+    client = "client"
+    session = MagicMock()
+    client_factory.create_session = MagicMock(return_value=session)
+    client_factory.build_client = MagicMock(return_value=client)
+
+    controller.add_endpoint(name, language, connection_string)
+
+    client_factory.create_session.assert_called_once_with(language, connection_string, "-1", False)
+    client_factory.build_client.assert_called_once_with(language, session)
+    client_manager.add_client.assert_called_once_with(name, client)
+    session.start.assert_called_once_with()
+
+
+@with_setup(_setup, _teardown)
+def test_delete_endpoint():
+    name = "name"
+
+    controller.delete_endpoint(name)
+
+    client_manager.delete_client.assert_called_once_with(name)
+
+
+@with_setup(_setup, _teardown)
+def test_log_mode():
+    mode = "debug"
+
+    controller.set_log_mode(mode)
+
+    assert_equals(mode, Log.mode)
+    assert_equals(mode, controller.get_log_mode())
+
+
+@with_setup(_setup, _teardown)
+def test_cleanup():
+    controller.cleanup()
+    client_manager.clean_up_all.assert_called_once_with()
+
+
+@with_setup(_setup, _teardown)
+def test_run_cell():
+    default_client = MagicMock()
+    chosen_client = MagicMock()
+    client_manager.get_any_client = MagicMock(return_value=default_client)
+    client_manager.get_client = MagicMock(return_value=chosen_client)
+    name = "endpoint_name"
+    sql = False
+    cell = "cell code"
+
+    controller.run_cell(name, sql, cell)
+    chosen_client.execute.assert_called_with(cell)
+
+    controller.run_cell(None, sql, cell)
+    default_client.execute.assert_called_with(cell)
+
+    sql = True
+
+    controller.run_cell(name, sql, cell)
+    chosen_client.execute_sql.assert_called_with(cell)
+
+    controller.run_cell(None, sql, cell)
+    default_client.execute_sql.assert_called_with(cell)
+
+@with_setup(_setup, _teardown)
+def test_get_client_keys():
+    controller.get_client_keys()
+    client_manager.get_endpoints_list.assert_called_once_with()


### PR DESCRIPTION
Good thing you did separate parsing and functional tests @alope107! =)

I'll work on introducing "viewer" now. Essentially, on the magic, when run is called, we'll want to pass the result to one of several possible viewers. The first one will give the raw result (pandas or string). The second one would be an Altair viewer that automatically renders pandas dataframes into graphs.

I'm checking this in now but can take comments later on. This is so that later commits do not affect the PR.