### PR TITLE
Various bug fixes

### DIFF
--- a/remotespark/RemoteSparkMagics.py
+++ b/remotespark/RemoteSparkMagics.py
@@ -26,7 +26,7 @@ class RemoteSparkMagics(Magics):
         super(RemoteSparkMagics, self).__init__(shell)
 
         # Suppress Altair pandas Future Warning
-        warnings.simplefilter(action = "ignore", category = FutureWarning)
+        warnings.simplefilter(action="ignore", category=FutureWarning)
 
         self.logger = Log("RemoteSparkMagics")
         self.interactive = interactive

--- a/remotespark/livyclientlib/altairviewer.py
+++ b/remotespark/livyclientlib/altairviewer.py
@@ -10,7 +10,7 @@ from .log import Log
 class AltairViewer(object):
 
     def __init__(self):
-        self.logger = Log()
+        self.logger = Log("AltairViewer")
 
     """A viewer that returns results as they are."""
     def visualize(self, result, chart_type="area"):

--- a/remotespark/livyclientlib/altairviewer.py
+++ b/remotespark/livyclientlib/altairviewer.py
@@ -19,6 +19,10 @@ class AltairViewer(object):
 
         columns = result.columns.values
 
+        # Always return table for show tables
+        if "isTemporary" in columns and "name" in columns:
+            return result
+
         # Simply return dataframe if only 1 column is available
         if len(columns) <= 1 or chart_type == "table":
             return result

--- a/remotespark/livyclientlib/clientmanager.py
+++ b/remotespark/livyclientlib/clientmanager.py
@@ -66,6 +66,9 @@ class ClientManager(object):
         for name in self.get_endpoints_list():
             self._remove_endpoint(name)
 
+        if self._serializer is not None:
+            self._serialize_state()
+
     def _remove_endpoint(self, name):
         if name in self.get_endpoints_list():
             self._livy_clients[name].close_session()

--- a/remotespark/livyclientlib/clientmanager.py
+++ b/remotespark/livyclientlib/clientmanager.py
@@ -8,11 +8,12 @@ from .log import Log
 
 class ClientManager(object):
     """Livy client manager"""
-    logger = Log()
 
     def __init__(self, serializer=None, serialize_periodically=False, serialize_period=10.0):
         if serializer is None and serialize_periodically is True:
             raise ValueError("Will not be able to serialize periodically without serializer.")
+
+        self.logger = Log("ClientManager")
 
         self._livy_clients = dict()
         self._serializer = serializer
@@ -26,6 +27,8 @@ class ClientManager(object):
                 self._serialize_state_periodically(serialize_period)
 
     def _serialize_state_periodically(self, serialize_period):
+        self.logger.debug("Starting state serialize timer.")
+
         self._serialize_timer = Timer(serialize_period, self._serialize_state)
         self._serialize_timer.start()
 

--- a/remotespark/livyclientlib/clientmanagerstateserializer.py
+++ b/remotespark/livyclientlib/clientmanagerstateserializer.py
@@ -44,9 +44,11 @@ class ClientManagerStateSerializer(object):
 
                 # Do not start session automatically. Just create it but skip is not existent.
                 try:
-                    if session.status == "idle":
-                        client_obj = self._client_factory.build_client(language, session)
-                        clients_to_return.append((name, client_obj))
+                    # Get status to know if it's alive or not. No exception means it is.
+                    s = session.status
+
+                    client_obj = self._client_factory.build_client(language, session)
+                    clients_to_return.append((name, client_obj))
                 except (ValueError, ConnectionError) as e:
                     self.logger.error("Skipping serialized session '{}' because {}".format(session.id, str(e)))
         else:

--- a/remotespark/livyclientlib/filesystemreaderwriter.py
+++ b/remotespark/livyclientlib/filesystemreaderwriter.py
@@ -1,17 +1,23 @@
 # Copyright (c) 2015  aggftw@gmail.com
 # Distributed under the terms of the Modified BSD License.
+import os
+
+from .utils import expand_path
 
 
 class FileSystemReaderWriter(object):
 
     def __init__(self, path):
         assert path is not None
-        self._path = path
+        self._path = expand_path(path)
 
     def read_lines(self):
-        with open(self._path, "r") as f:
-            return f.readlines()
+        if os.path.isfile(self._path):
+            with open(self._path, "r+") as f:
+                return f.readlines()
+        else:
+            return ""
 
     def overwrite_with_line(self, line):
-        with open(self._path, "w") as f:
+        with open(self._path, "w+") as f:
             f.writelines(line)

--- a/remotespark/livyclientlib/livyclient.py
+++ b/remotespark/livyclientlib/livyclient.py
@@ -6,9 +6,10 @@ from .log import Log
 
 class LivyClient(object):
     """Spark client for Livy endpoint"""
-    logger = Log()
 
     def __init__(self, session, execute_timeout_seconds=3600):
+        self.logger = Log("LivyClient")
+
         self._session = session
         self._session.create_sql_context()
         self._execute_timeout_seconds = execute_timeout_seconds
@@ -29,3 +30,7 @@ class LivyClient(object):
     @property
     def language(self):
         return self._session.language
+
+    @property
+    def session_id(self):
+        return self._session.id

--- a/remotespark/livyclientlib/livyclientfactory.py
+++ b/remotespark/livyclientlib/livyclientfactory.py
@@ -12,17 +12,18 @@ from .linearretrypolicy import LinearRetryPolicy
 
 class LivyClientFactory(object):
     """Spark client for Livy endpoint"""
-    logger = Log()
-    max_results = 2500
 
-    @staticmethod
-    def build_client(language, session):
+    def __init__(self):
+        self.logger = Log("LivyClientFactory")
+        self.max_results = 2500
+
+    def build_client(self, language, session):
         assert session is not None
 
         if language == Constants.lang_python:
-            return PandasPysparkLivyClient(session, LivyClientFactory.max_results)
+            return PandasPysparkLivyClient(session, self.max_results)
         elif language == Constants.lang_scala:
-            return PandasScalaLivyClient(session, LivyClientFactory.max_results)
+            return PandasScalaLivyClient(session, self.max_results)
         else:
             raise ValueError("Language '{}' is not supported.".format(language))
 

--- a/remotespark/livyclientlib/livyclientfactory.py
+++ b/remotespark/livyclientlib/livyclientfactory.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2015  aggftw@gmail.com
 # Distributed under the terms of the Modified BSD License.
 from .log import Log
-from .connectionstringutil import get_connection_string_elements
+from .utils import get_connection_string_elements
 from .livysession import LivySession
 from .pandaspysparklivyclient import PandasPysparkLivyClient
 from .pandasscalalivyclient import PandasScalaLivyClient

--- a/remotespark/livyclientlib/livysession.py
+++ b/remotespark/livyclientlib/livysession.py
@@ -153,7 +153,7 @@ class LivySession(object):
         filtered_sessions = [s for s in sessions if s["id"] == int(self.id)]
                     
         if len(filtered_sessions) != 1:
-            raise AssertionError("Expected one session of id {} but got {} sessions."
+            raise ValueError("Expected one session of id {} but got {} sessions."
                                  .format(self.id, len(filtered_sessions)))
             
         session = filtered_sessions[0]

--- a/remotespark/livyclientlib/log.py
+++ b/remotespark/livyclientlib/log.py
@@ -3,19 +3,25 @@
 
 from __future__ import print_function
 from datetime import datetime
-from os import path
+
+from .utils import join_paths, get_magics_home_path
 
 
 class Log(object):
     """Logger."""
 
     def __init__(self):
+        try:
+            magics_home_path = get_magics_home_path()
+            self.path_to_serialize = join_paths(magics_home_path, "logs/log.txt")
+        except KeyError:
+            self.path_to_serialize = None
+
         self._mode = "normal"
-        self._path_to_logs = "~/sparkmagic/log/log.txt"
-                
+
     @property
     def mode(self):
-        """One of: 'debug', 'normal', 'error'"""
+        """One of: 'debug', 'normal'"""
         return self._mode
 
     @mode.setter
@@ -26,8 +32,6 @@ class Log(object):
 
         if val == "debug":
             self._mode = "debug"
-        elif val == "error":
-            self._mode = "error"
         else:
             self._mode = "normal"
 
@@ -37,15 +41,16 @@ class Log(object):
             self._handle_message("DEBUG", message)
 
     def error(self, message):
-        """Prints if in debug mode."""
-        if self.mode == "debug" or self.mode == "error":
-            self._handle_message("ERROR", message)
+        """Always shows."""
+        self._handle_message("ERROR", message)
 
     def _handle_message(self, level, message):
             message = "{}\t{}\t{}\n".format(str(datetime.utcnow()), level, message)
-            # print(message)
-            self._write_to_disk(message)
+            if self.path_to_serialize is not None:
+                self._write_to_disk(message)
+            else:
+                print(message)
 
     def _write_to_disk(self, message):
-        with open(path.expanduser(self._path_to_logs), "a+") as f:
+        with open(self.path_to_serialize, "a+") as f:
             f.write(message)

--- a/remotespark/livyclientlib/pandaspysparklivyclient.py
+++ b/remotespark/livyclientlib/pandaspysparklivyclient.py
@@ -10,23 +10,17 @@ from .livyclient import LivyClient
 
 class PandasPysparkLivyClient(LivyClient):
     """Spark client for Livy endpoint"""
-    logger = Log()
 
     def __init__(self, session, max_take_rows):
         super(PandasPysparkLivyClient, self).__init__(session)
         self._max_take_rows = max_take_rows
 
-    def execute(self, commands):
-        return super(PandasPysparkLivyClient, self).execute(commands)
-
     def execute_sql(self, command):
         records_text = self.execute(self._make_sql_json_take(command))
-        self.logger.debug("Records: " + records_text)
 
         if records_text == "[]":
             # If there are no records, show some columns at least.
             columns_text = self.execute(self._make_sql_columns(command))
-            self.logger.debug("Columns: " + columns_text)
 
             records = list()
             columns = eval(columns_text)
@@ -37,13 +31,6 @@ class PandasPysparkLivyClient(LivyClient):
             jsonArray = "[{}]".format(",".join(jsonData))
 
             return pd.DataFrame(json.loads(jsonArray))
-
-    def close_session(self):
-        super(PandasPysparkLivyClient, self).close_session()
-
-    @property
-    def language(self):
-        return super(PandasPysparkLivyClient, self).language
 
     def _make_sql_json_take(self, command):
         return 'sqlContext.sql("{}").toJSON().take({})'.format(command, str(self._max_take_rows))

--- a/remotespark/livyclientlib/pandasscalalivyclient.py
+++ b/remotespark/livyclientlib/pandasscalalivyclient.py
@@ -11,23 +11,16 @@ from .livyclient import LivyClient
 
 class PandasScalaLivyClient(LivyClient):
     """Spark client for Livy endpoint"""
-    logger = Log()
-
     def __init__(self, session, max_take_rows):
         super(PandasScalaLivyClient, self).__init__(session)
         self._max_take_rows = max_take_rows
 
-    def execute(self, commands):
-        return super(PandasScalaLivyClient, self).execute(commands)
-
     def execute_sql(self, command):
         records_text = self.execute(self._make_sql_json_take(command))
-        self.logger.debug("Records: " + records_text)
 
         if records_text == "":
             # If there are no records, show some columns at least.
             columns_text = self.execute(self._make_sql_columns(command))
-            self.logger.debug("Columns: " + columns_text)
 
             records = list()
 
@@ -52,13 +45,6 @@ class PandasScalaLivyClient(LivyClient):
         else:
             json_array = "[{}]".format(",".join(records_text.split("\n")))
             return pd.DataFrame(json.loads(json_array))
-
-    def close_session(self):
-        super(PandasScalaLivyClient, self).close_session()
-
-    @property
-    def language(self):
-        return super(PandasScalaLivyClient, self).language
 
     def _make_sql_json_take(self, command):
         return 'sqlContext.sql("{}").toJSON.take({}).foreach(println)'.format(command, str(self._max_take_rows))

--- a/remotespark/livyclientlib/reliablehttpclient.py
+++ b/remotespark/livyclientlib/reliablehttpclient.py
@@ -5,7 +5,7 @@ import json
 import requests
 from time import sleep
 
-from .connectionstringutil import get_connection_string
+from .utils import get_connection_string
 
 
 class ReliableHttpClient(object):

--- a/remotespark/livyclientlib/sparkcontroller.py
+++ b/remotespark/livyclientlib/sparkcontroller.py
@@ -5,17 +5,25 @@ Provides the %spark magic."""
 # Distributed under the terms of the Modified BSD License.
 
 from .clientmanager import ClientManager
-from .livyclientfactory import LivyClientFactory
 from .log import Log
+from .livyclientfactory import LivyClientFactory
+from .filesystemreaderwriter import FileSystemReaderWriter
+from .clientmanagerstateserializer import ClientManagerStateSerializer
 
 
 class SparkController(object):
 
-    logger = Log()
-
-    def __init__(self):
-        self.client_manager = ClientManager()
+    def __init__(self, serialize_path=None):
         self.client_factory = LivyClientFactory()
+
+        if serialize_path is not None:
+            serializer = ClientManagerStateSerializer(self.client_factory, FileSystemReaderWriter(serialize_path))
+            self.client_manager = ClientManager(serializer, True)
+        else:
+            self.client_manager = ClientManager()
+
+        self.logger = Log()
+
 
     @staticmethod
     def get_log_mode():

--- a/remotespark/livyclientlib/utils.py
+++ b/remotespark/livyclientlib/utils.py
@@ -6,6 +6,7 @@
 # Distributed under the terms of the Modified BSD License.
 
 from collections import namedtuple
+import os
 
 
 def get_connection_string(url, username, password):
@@ -56,3 +57,19 @@ def get_connection_string_elements(connection_string):
     cs = connectionstring(d["url"], d["username"], d["password"])
        
     return cs
+
+
+def read_environment_variable(name):
+    return os.environ[name]
+
+
+def expand_path(path):
+    return os.path.expanduser(path)
+
+
+def join_paths(p1, p2):
+    return os.path.join(p1, p2)
+
+
+def get_magics_home_path():
+    return expand_path(read_environment_variable("SPARKMAGIC_HOME"))

--- a/remotespark/sparkkernelbase.py
+++ b/remotespark/sparkkernelbase.py
@@ -3,6 +3,7 @@
 from ipykernel.ipkernel import IPythonKernel
 import altair.api as alt
 import pandas as pd
+import requests
 
 from remotespark.livyclientlib.log import Log
 from remotespark.livyclientlib.utils import get_connection_string, read_environment_variable
@@ -26,18 +27,30 @@ class SparkKernelBase(IPythonKernel):
 
     def __init__(self, **kwargs):
         super(SparkKernelBase, self).__init__(**kwargs)
-        self.logger = Log()
+        self.logger = Log(self.client_name)
         self.already_ran_once = False
 
+        # Disable warnings for test env in HDI
+        requests.packages.urllib3.disable_warnings()
+
         try:
+            # Try to initialize altair
+            # from lightning.visualization import VisualizationLocal
+            # from IPython.core.getipython import get_ipython
+            # from IPython.display import display, Javascript, HTML
+            # ip = get_ipython()
+            # formatter = ip.display_formatter.formatters['text/html']
+            # js = VisualizationLocal.load_embed()
+            # display(HTML("<script>" + js + "</script>"))
+            # formatter.for_type(VisualizationLocal, lambda viz, kwds=None: viz.get_html())
+
             # Use lightning here so that the graphic doesn't display later when magics are registered
             # alt.use_renderer('lightning')
 
             # Create a dumb viz so that comparison warning is not shown
-            # dummy_records = [{u'date': u'6/1/13', u'temp_diff': 8, u'buildingID': u'4'}]
-            # dummy_df = pd.DataFrame(dummy_records)
-            # alt.Viz(dummy_df)
-            pass
+            dummy_records = [{u'date': u'6/1/13', u'temp_diff': 8, u'buildingID': u'4'}]
+            dummy_df = pd.DataFrame(dummy_records)
+            alt.Viz(dummy_df)
         except:
             self.logger.error("Could not initialize renderer or create dummy records")
 
@@ -62,17 +75,14 @@ class SparkKernelBase(IPythonKernel):
     def initialize_magics(self, username, password, url):
         connection_string = get_connection_string(url, username, password)
 
-        register_magics_code = "%load_ext remotespark\nimport requests\nrequests.packages.urllib3.disable_warnings()"
+        register_magics_code = "%load_ext remotespark"
         self.execute_cell_for_user(register_magics_code, True, False)
+        self.logger.debug("Loaded magics.")
 
-        debug_magics_code = "%spark mode debug"
-        self.execute_cell_for_user(debug_magics_code, True, False)
-
-        try:
-            add_endpoint_code = "%spark add {} {} {}".format(self.client_name, self.session_language, connection_string)
-            self.execute_cell_for_user(add_endpoint_code, True, False)
-        except ValueError:
-            self.logger.error("No need to add new endpoint since it already exists.")
+        add_endpoint_code = "%spark add {} {} {} skip".format(
+            self.client_name, self.session_language, connection_string)
+        self.execute_cell_for_user(add_endpoint_code, True, False)
+        self.logger.debug("Added endpoint.")
 
         self.already_ran_once = True
 

--- a/remotespark/sparkkernelbase.py
+++ b/remotespark/sparkkernelbase.py
@@ -31,12 +31,13 @@ class SparkKernelBase(IPythonKernel):
 
         try:
             # Use lightning here so that the graphic doesn't display later when magics are registered
-            alt.use_renderer('lightning')
+            # alt.use_renderer('lightning')
 
             # Create a dumb viz so that comparison warning is not shown
-            dummy_records = [{u'date': u'6/1/13', u'temp_diff': 8, u'buildingID': u'4'}]
-            dummy_df = pd.DataFrame(dummy_records)
-            alt.Viz(dummy_df)
+            # dummy_records = [{u'date': u'6/1/13', u'temp_diff': 8, u'buildingID': u'4'}]
+            # dummy_df = pd.DataFrame(dummy_records)
+            # alt.Viz(dummy_df)
+            pass
         except:
             self.logger.error("Could not initialize renderer or create dummy records")
 
@@ -64,8 +65,14 @@ class SparkKernelBase(IPythonKernel):
         register_magics_code = "%load_ext remotespark\nimport requests\nrequests.packages.urllib3.disable_warnings()"
         self.execute_cell_for_user(register_magics_code, True, False)
 
-        add_endpoint_code = "%spark add {} {} {}".format(self.client_name, self.session_language, connection_string)
-        self.execute_cell_for_user(add_endpoint_code, True, False)
+        debug_magics_code = "%spark mode debug"
+        self.execute_cell_for_user(debug_magics_code, True, False)
+
+        try:
+            add_endpoint_code = "%spark add {} {} {}".format(self.client_name, self.session_language, connection_string)
+            self.execute_cell_for_user(add_endpoint_code, True, False)
+        except ValueError:
+            self.logger.error("No need to add new endpoint since it already exists.")
 
         self.already_ran_once = True
 

--- a/remotespark/sparkkernelbase.py
+++ b/remotespark/sparkkernelbase.py
@@ -1,8 +1,6 @@
 # Copyright (c) 2015  aggftw@gmail.com
 # Distributed under the terms of the Modified BSD License.
 from ipykernel.ipkernel import IPythonKernel
-import altair.api as alt
-import pandas as pd
 import requests
 
 from remotespark.livyclientlib.log import Log
@@ -45,12 +43,9 @@ class SparkKernelBase(IPythonKernel):
             # formatter.for_type(VisualizationLocal, lambda viz, kwds=None: viz.get_html())
 
             # Use lightning here so that the graphic doesn't display later when magics are registered
+            # import altair.api as alt
             # alt.use_renderer('lightning')
-
-            # Create a dumb viz so that comparison warning is not shown
-            dummy_records = [{u'date': u'6/1/13', u'temp_diff': 8, u'buildingID': u'4'}]
-            dummy_df = pd.DataFrame(dummy_records)
-            alt.Viz(dummy_df)
+            pass
         except:
             self.logger.error("Could not initialize renderer or create dummy records")
 

--- a/remotespark/sparkkernelbase.py
+++ b/remotespark/sparkkernelbase.py
@@ -1,12 +1,11 @@
 # Copyright (c) 2015  aggftw@gmail.com
 # Distributed under the terms of the Modified BSD License.
-import os
 from ipykernel.ipkernel import IPythonKernel
 import altair.api as alt
 import pandas as pd
 
 from remotespark.livyclientlib.log import Log
-from remotespark.livyclientlib.connectionstringutil import get_connection_string
+from remotespark.livyclientlib.utils import get_connection_string, read_environment_variable
 
 
 class SparkKernelBase(IPythonKernel):
@@ -41,15 +40,11 @@ class SparkKernelBase(IPythonKernel):
         except:
             self.logger.error("Could not initialize renderer or create dummy records")
 
-    @staticmethod
-    def read_environment_variable(name):
-        return os.environ[name]
-
     def get_configuration(self):
         try:
-            username = self.read_environment_variable(self.username_env_var)
-            password = self.read_environment_variable(self.password_env_var)
-            url = self.read_environment_variable(self.url_env_var)
+            username = read_environment_variable(self.username_env_var)
+            password = read_environment_variable(self.password_env_var)
+            url = read_environment_variable(self.url_env_var)
             return username, password, url
         except KeyError:
             error = "FATAL ERROR: Please set environment variables '{}', '{}', '{} to initialize Kernel.".format(

--- a/tests/test_clientmanager.py
+++ b/tests/test_clientmanager.py
@@ -123,3 +123,18 @@ def test_clean_up():
 
     client0.close_session.assert_called_once_with()
     client1.close_session.assert_called_once_with()
+
+
+def test_clean_up_serializer():
+    client0 = MagicMock()
+    client1 = MagicMock()
+    serializer = MagicMock()
+    manager = ClientManager(serializer)
+    manager.add_client("name0", client0)
+    manager.add_client("name1", client1)
+
+    manager.clean_up_all()
+
+    client0.close_session.assert_called_once_with()
+    client1.close_session.assert_called_once_with()
+    serializer.serialize_state.assert_called_once_with({})

--- a/tests/test_clientmanagerstateserializer.py
+++ b/tests/test_clientmanagerstateserializer.py
@@ -18,6 +18,7 @@ def test_serializer_throws_none_factory():
 def test_deserialize_not_emtpy():
     client_factory = MagicMock()
     session = MagicMock()
+    session.is_final_status.return_value = False
     client_factory.create_session.return_value = session
     reader_writer = MagicMock()
     reader_writer.read_lines.return_value = """{
@@ -50,16 +51,52 @@ def test_deserialize_not_emtpy():
     (name, client) = deserialized[0]
     assert name == "py"
     client_factory.create_session.assert_any_call("python",
-                                                     "url=https://mysite.com/livy;username=user;password=pass",
-                                                     "1", True)
+                                                  "url=https://mysite.com/livy;username=user;password=pass",
+                                                  "1", True)
     client_factory.build_client.assert_any_call("python", session)
 
     (name, client) = deserialized[1]
     assert name == "sc"
     client_factory.create_session.assert_any_call("scala",
-                                                     "url=https://mysite.com/livy;username=user;password=pass",
-                                                     "2", False)
+                                                  "url=https://mysite.com/livy;username=user;password=pass",
+                                                  "2", False)
     client_factory.build_client.assert_any_call("scala", session)
+
+
+def test_deserialize_not_emtpy_but_dead():
+    client_factory = MagicMock()
+    session = MagicMock()
+    session.is_final_status.return_value = True
+    client_factory.create_session.return_value = session
+    reader_writer = MagicMock()
+    reader_writer.read_lines.return_value = """{
+  "clients": [
+    {
+      "name": "py",
+      "id": "1",
+      "sqlcontext": true,
+      "language": "python",
+      "connectionstring": "url=https://mysite.com/livy;username=user;password=pass",
+      "version": "0.0.0"
+    },
+    {
+      "name": "sc",
+      "id": "2",
+      "sqlcontext": false,
+      "language": "scala",
+      "connectionstring": "url=https://mysite.com/livy;username=user;password=pass",
+      "version": "0.0.0"
+    }
+  ]
+}
+"""
+    serializer = ClientManagerStateSerializer(client_factory, reader_writer)
+
+    deserialized = serializer.deserialize_state()
+
+    assert len(deserialized) == 0
+    client_factory.create_session.assert_no_called()
+    client_factory.build_client.assert_no_called()
 
 
 def test_deserialize_empty():

--- a/tests/test_connectionstring_utility.py
+++ b/tests/test_connectionstring_utility.py
@@ -1,6 +1,6 @@
 ﻿from nose.tools import assert_equals
 
-import remotespark.livyclientlib.connectionstringutil as csutil
+import remotespark.livyclientlib.utils as csutil
 
 connection_string = "url=dns;username=user;password=pass"
 host = "dns"

--- a/tests/test_livyclient.py
+++ b/tests/test_livyclient.py
@@ -1,4 +1,4 @@
-﻿from mock import MagicMock
+﻿from mock import MagicMock, PropertyMock
 
 from remotespark.livyclientlib.livyclient import LivyClient
 from remotespark.livyclientlib.utils import get_connection_string
@@ -59,3 +59,27 @@ def test_serialize():
     assert serialized["sqlcontext"] == sql_created
     assert serialized["version"] == "0.0.0"
     assert len(serialized.keys()) == 5
+
+
+def test_language():
+    lang = "python"
+    mock_spark_session = MagicMock()
+    language_mock = PropertyMock(return_value=lang)
+    type(mock_spark_session).language = language_mock
+    client = LivyClient(mock_spark_session)
+
+    l = client.language
+
+    assert l == lang
+
+
+def test_session_id():
+    session_id = "0"
+    mock_spark_session = MagicMock()
+    session_id_mock = PropertyMock(return_value=session_id)
+    type(mock_spark_session).id = session_id_mock
+    client = LivyClient(mock_spark_session)
+
+    i = client.session_id
+
+    assert i == session_id

--- a/tests/test_livyclient.py
+++ b/tests/test_livyclient.py
@@ -61,6 +61,15 @@ def test_serialize():
     assert len(serialized.keys()) == 5
 
 
+def test_close_session():
+    mock_spark_session = MagicMock()
+    client = LivyClient(mock_spark_session)
+
+    client.close_session()
+
+    mock_spark_session.delete.assert_called_once_with()
+
+
 def test_language():
     lang = "python"
     mock_spark_session = MagicMock()

--- a/tests/test_livyclient.py
+++ b/tests/test_livyclient.py
@@ -1,7 +1,7 @@
 ﻿from mock import MagicMock
 
 from remotespark.livyclientlib.livyclient import LivyClient
-from remotespark.livyclientlib.connectionstringutil import get_connection_string
+from remotespark.livyclientlib.utils import get_connection_string
 from remotespark.livyclientlib.livysessionstate import LivySessionState
 
 

--- a/tests/test_livyclientfactory.py
+++ b/tests/test_livyclientfactory.py
@@ -2,7 +2,7 @@ from mock import MagicMock
 from nose.tools import raises
 
 from remotespark.livyclientlib.livyclientfactory import LivyClientFactory
-from remotespark.livyclientlib.connectionstringutil import get_connection_string
+from remotespark.livyclientlib.utils import get_connection_string
 from remotespark.livyclientlib.constants import Constants
 
 

--- a/tests/test_livysession.py
+++ b/tests/test_livysession.py
@@ -4,7 +4,7 @@ from mock import MagicMock
 
 from remotespark.livyclientlib.livysession import LivySession
 from remotespark.livyclientlib.livyclienttimeouterror import LivyClientTimeoutError
-from remotespark.livyclientlib.connectionstringutil import get_connection_string
+from remotespark.livyclientlib.utils import get_connection_string
 
 
 class DummyResponse:

--- a/tests/test_livysession.py
+++ b/tests/test_livysession.py
@@ -141,6 +141,19 @@ class TestLivySession:
         assert session.id == "-1"
         assert not session.started_sql_context
 
+    def test_is_final_status(self):
+        kind = "scala"
+        http_client = MagicMock()
+
+        session = LivySession(http_client, kind, "-1", False, status_sleep_seconds=0.01, statement_sleep_seconds=0.01)
+
+        assert not session.is_final_status("idle")
+        assert not session.is_final_status("starting")
+        assert not session.is_final_status("busy")
+
+        assert session.is_final_status("dead")
+        assert session.is_final_status("error")
+
     def test_start_scala_starts_session(self):
         kind = "scala"
         http_client = MagicMock()

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -5,7 +5,7 @@ from remotespark.livyclientlib.log import Log
 
 
 def test_log_init():
-    logger = Log()
+    logger = Log("something")
 
     print(Log.mode)
     assert logger.mode == logger._mode

--- a/tests/test_reliablehttpclient.py
+++ b/tests/test_reliablehttpclient.py
@@ -6,7 +6,7 @@ from mock import patch, PropertyMock, MagicMock
 
 from remotespark.livyclientlib.reliablehttpclient import ReliableHttpClient
 from remotespark.livyclientlib.linearretrypolicy import LinearRetryPolicy
-from remotespark.livyclientlib.connectionstringutil import get_connection_string
+from remotespark.livyclientlib.utils import get_connection_string
 
 
 retry_policy = None

--- a/tests/test_remotesparkmagics.py
+++ b/tests/test_remotesparkmagics.py
@@ -38,6 +38,7 @@ def test_info_command_parses():
 
 @with_setup(_setup, _teardown)
 def test_add_endpoint_command_parses():
+    # Do not skip
     add_endpoint_mock = MagicMock()
     spark_controller.add_endpoint = add_endpoint_mock
     command = "add"
@@ -48,7 +49,20 @@ def test_add_endpoint_command_parses():
 
     magic.spark(line)
 
-    add_endpoint_mock.assert_called_once_with(name, language, connection_string)
+    add_endpoint_mock.assert_called_once_with(name, language, connection_string, False)
+
+    # Skip
+    add_endpoint_mock = MagicMock()
+    spark_controller.add_endpoint = add_endpoint_mock
+    command = "add"
+    name = "name"
+    language = "python"
+    connection_string = "url=http://location:port;username=name;password=word"
+    line = " ".join([command, name, language, connection_string, "skip"])
+
+    magic.spark(line)
+
+    add_endpoint_mock.assert_called_once_with(name, language, connection_string, True)
 
 
 @with_setup(_setup, _teardown)
@@ -62,20 +76,6 @@ def test_delete_endpoint_command_parses():
     magic.spark(line)
 
     mock_method.assert_called_once_with(name)
-
-
-@with_setup(_setup, _teardown)
-def test_mode_command_parses():
-    mock_method = MagicMock()
-    spark_controller.set_log_mode = mock_method
-    command = "mode"
-    mode = "debug"
-
-    line = " ".join([command, mode])
-
-    magic.spark(line)
-
-    mock_method.assert_called_once_with(mode)
 
 
 @with_setup(_setup, _teardown)

--- a/tests/test_sparkkernelbase.py
+++ b/tests/test_sparkkernelbase.py
@@ -3,7 +3,7 @@ from mock import MagicMock, call
 import os
 
 from remotespark.sparkkernelbase import SparkKernelBase
-from remotespark.livyclientlib.connectionstringutil import get_connection_string
+from remotespark.livyclientlib.utils import get_connection_string
 
 
 kernel = None

--- a/tests/test_sparkkernelbase.py
+++ b/tests/test_sparkkernelbase.py
@@ -12,16 +12,19 @@ pass_ev = "PASS"
 url_ev = "URL"
 
 
+class TestSparkKernel(SparkKernelBase):
+    client_name = "TestKernel"
+
+
 def _setup():
     global kernel, user_ev, pass_ev, url_ev
 
-    kernel = SparkKernelBase()
+    kernel = TestSparkKernel()
     kernel.use_altair = False
     kernel.username_env_var = user_ev
     kernel.password_env_var = pass_ev
     kernel.url_env_var = url_ev
     kernel.session_language = "python"
-    kernel.client_name = "test"
 
 
 def _teardown():
@@ -80,10 +83,11 @@ def test_initialize_magics():
 
     # Assertions
     assert kernel.already_ran_once
-    expected = [call("%spark add test python {}".format(conn_str), True, False),
-                call("%load_ext remotespark\nimport requests\nrequests.packages.urllib3.disable_warnings()",
-                     True, False)]
-    execute_cell_mock.mock_calls == expected
+    expected = [call("%spark add TestKernel python {} skip".format(conn_str), True, False),
+                call("%load_ext remotespark", True, False)]
+    assert len(execute_cell_mock.mock_calls) == 2
+    for kall in expected:
+        assert kall in execute_cell_mock.mock_calls
 
 
 @with_setup(_setup, _teardown)

--- a/tests/test_sparkkernelbase.py
+++ b/tests/test_sparkkernelbase.py
@@ -91,6 +91,33 @@ def test_initialize_magics():
 
 
 @with_setup(_setup, _teardown)
+def test_do_execute_initializes_magics_if_not_run():
+    # Set up
+    usr = "u"
+    pwd = "p"
+    url = "url"
+    conn_str = get_connection_string(url, usr, pwd)
+    config_mock = MagicMock()
+    config_mock.return_value = (usr, pwd, url)
+
+    kernel.get_configuration = config_mock
+    kernel.execute_cell_for_user = execute_cell_mock = MagicMock()
+
+    code = "code"
+
+    # Call method
+    assert not kernel.already_ran_once
+    kernel.do_execute(code, False)
+
+    # Assertions
+    assert kernel.already_ran_once
+    assert len(execute_cell_mock.mock_calls) == 3
+    assert call("%spark add TestKernel python {} skip".format(conn_str), True, False) in execute_cell_mock.mock_calls
+    assert call("%load_ext remotespark", True, False) in execute_cell_mock.mock_calls
+    assert call("%%spark\n{}".format(code), False, True, None, False) in execute_cell_mock.mock_calls
+
+
+@with_setup(_setup, _teardown)
 def test_call_spark():
     # Set up
     code = "some spark code"


### PR DESCRIPTION
Logger includes class name and can print or write to disk if env var is set.

Serializer ignores dead connections.

Session adds ability to know if session is in a final status.

Spark controller does not tinker with log mode now and add_endpoint skips endpoints that are already present if asked.

RemoteSparkMagics does not set mode to logger now and can skip adding duplicate endpoints.

sparkkernelbase tries to suppress some altair warnings as well as requests library warnings for HDI test clusters.

Improved test coverage.