### PR TITLE
Use logging standard library module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,6 @@ python:
 install:
     - pip install git+https://github.com/ellisonbg/altair
     - pip install -r requirements.txt -e .
+    - mkdir ~/.sparkmagic
     - cp remotespark/default_config.json ~/.sparkmagic/config.json
 script: nosetests

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,5 @@ python:
 install:
     - pip install git+https://github.com/ellisonbg/altair
     - pip install -r requirements.txt -e .
+    - cp remotespark/default_config.json ~/.sparkmagic/config.json
 script: nosetests

--- a/remotespark/default_config.json
+++ b/remotespark/default_config.json
@@ -15,8 +15,27 @@
   "kernel_scala_password": "",
   "kernel_scala_url": "",
 
-  "log_level": "debug",
-  "log_to_disk": true,
+  "logging_config": {
+    "version": 1,
+    "formatters": {
+      "magicsFormatter": { 
+        "format": "%(asctime)s	%(levelname)s	%(message)s",
+	"datefmt": ""
+      }
+    },
+    "handlers": {
+      "magicsHandler": { 
+        "class": "remotespark.livyclientlib.log.MagicsFileHandler",
+	"formatter": "magicsFormatter"
+      }
+    },
+    "loggers": {
+      "magicsLogger": { 
+        "handlers": ["magicsHandler"],
+	"level": "DEBUG"
+      }
+    }
+  },
 
   "execute_timeout_seconds": 3600,
   "status_sleep_seconds": 2,

--- a/remotespark/default_config.json
+++ b/remotespark/default_config.json
@@ -20,19 +20,19 @@
     "formatters": {
       "magicsFormatter": { 
         "format": "%(asctime)s	%(levelname)s	%(message)s",
-	"datefmt": ""
+        "datefmt": ""
       }
     },
     "handlers": {
       "magicsHandler": { 
-        "class": "remotespark.livyclientlib.log.MagicsFileHandler",
-	"formatter": "magicsFormatter"
+        "class": "remotespark.livyclientlib.filehandler.MagicsFileHandler",
+        "formatter": "magicsFormatter"
       }
     },
     "loggers": {
       "magicsLogger": { 
         "handlers": ["magicsHandler"],
-	"level": "DEBUG"
+        "level": "DEBUG"
       }
     }
   },

--- a/remotespark/default_config.json
+++ b/remotespark/default_config.json
@@ -19,7 +19,7 @@
     "version": 1,
     "formatters": {
       "magicsFormatter": { 
-        "format": "%(asctime)s	%(levelname)s	%(message)s",
+        "format": "%(asctime)s\t%(levelname)s\t%(message)s",
         "datefmt": ""
       }
     },

--- a/remotespark/livyclientlib/constants.py
+++ b/remotespark/livyclientlib/constants.py
@@ -30,10 +30,8 @@ class Constants:
     kernel_scala_password = "kernel_scala_password"
     kernel_scala_url = "kernel_scala_url"
 
-    log_level = "log_level"
-    log_to_disk = "log_to_disk"
-    debug_level = "debug"
-    normal_level = "normal"
+    magics_logger_name = "magicsLogger"
+    logging_config = "logging_config"
 
     execute_timeout_seconds = "execute_timeout_seconds"
     status_sleep_seconds = "status_sleep_seconds"

--- a/remotespark/livyclientlib/filehandler.py
+++ b/remotespark/livyclientlib/filehandler.py
@@ -1,0 +1,17 @@
+import logging
+from .utils import join_paths, get_magics_home_path, get_instance_id, ensure_path_exists
+
+class MagicsFileHandler(logging.FileHandler):
+    """The default logging handler used by the magics; this behavior can be overriden by modifying the config file"""
+    def __init__(self, **kwargs):
+        # Simply invokes the behavior of the superclass, but sets the filename keyword argument if it's not already set.
+        if 'filename' in kwargs:
+            super(MagicsFileHandler, self).__init__(**kwargs)
+        else:
+            magics_home_path = get_magics_home_path()
+            logs_folder_name = "logs"
+            log_file_name = "log_{}.log".format(get_instance_id())
+            directory = join_paths(magics_home_path, logs_folder_name)
+            ensure_path_exists(directory)
+            super(MagicsFileHandler, self).__init__(filename=join_paths(directory, log_file_name), **kwargs)
+

--- a/remotespark/livyclientlib/log.py
+++ b/remotespark/livyclientlib/log.py
@@ -2,63 +2,26 @@
 # Distributed under the terms of the Modified BSD License.
 
 from __future__ import print_function
-from datetime import datetime
+import logging, logging.config
 
-from .utils import join_paths, get_magics_home_path, get_instance_id, ensure_path_exists, ensure_file_exists
 from .configuration import get_configuration
 from .constants import Constants
 
-
 class Log(object):
-    """Logger."""
+    """Logger for magics. A small wrapper class around the configured logger described in the configuration file"""
+    logging.config.dictConfig(get_configuration(Constants.logging_config))
 
     def __init__(self, caller_name):
         assert caller_name is not None
-
         self._caller_name = caller_name
-
-        self._level = Constants.normal_level
-        self._path_to_serialize = None
-
-        self._read_config()
-
-    @property
-    def level(self):
-        """One of: 'debug', 'normal'"""
-        return self._level
-
-    def _read_config(self):
-        # Create path name
-        magics_home_path = get_magics_home_path()
-        logs_folder_name = "logs"
-        log_file_name = "log_{}.log".format(get_instance_id())
-        self._path_to_serialize = join_paths(magics_home_path, logs_folder_name)
-        ensure_path_exists(self._path_to_serialize)
-        self._path_to_serialize = join_paths(self._path_to_serialize, log_file_name)
-        ensure_file_exists(self._path_to_serialize)
-
-        # Read log level
-        level = get_configuration(Constants.log_level, Constants.debug_level)
-
-        self._level = level
-
+        self.logger = logging.getLogger(Constants.magics_logger_name)
+    
     def debug(self, message):
-        """Prints if in debug mode."""
-        self._handle_message("DEBUG", message, [Constants.debug_level])
+        self.logger.debug(self._transform_log_message(message))
 
     def error(self, message):
-        """Always shows."""
-        self._handle_message("ERROR", message, [Constants.normal_level, Constants.debug_level])
+        self.logger.error(self._transform_log_message(message))
 
-    def _handle_message(self, level, message, accepted_modes):
-        if self.level in accepted_modes:
-            message = "{}\t{}\t{}\t{}\n".format(str(datetime.utcnow()), level, self._caller_name, message)
+    def _transform_log_message(self, message):
+        return '{}\t{}'.format(self._caller_name, message)
 
-            if get_configuration(Constants.log_to_disk, True):
-                self._write_to_disk(message)
-            else:
-                print(message)
-
-    def _write_to_disk(self, message):
-        with open(self._path_to_serialize, "a+") as f:
-            f.write(message)

--- a/remotespark/livyclientlib/log.py
+++ b/remotespark/livyclientlib/log.py
@@ -14,7 +14,7 @@ class Log(object):
     def __init__(self, caller_name):
         assert caller_name is not None
         self._caller_name = caller_name
-        self.logger = logging.getLogger(Constants.magics_logger_name)
+        self._getLogger()
     
     def debug(self, message):
         self.logger.debug(self._transform_log_message(message))
@@ -22,6 +22,9 @@ class Log(object):
     def error(self, message):
         self.logger.error(self._transform_log_message(message))
 
+    def _getLogger(self):
+        self.logger = logging.getLogger(Constants.magics_logger_name)
+
     def _transform_log_message(self, message):
         return '{}\t{}'.format(self._caller_name, message)
-
+    

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,10 +1,8 @@
 from remotespark.livyclientlib.log import Log
 from remotespark.livyclientlib.constants import Constants
-
+import logging
 
 def test_log_init():
     logger = Log("something")
+    assert isinstance(logger.logger, logging.Logger)
 
-    print(Log.level)
-    assert logger.level == logger._level
-    assert logger.level == Constants.debug_level

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -3,6 +3,32 @@ from remotespark.livyclientlib.constants import Constants
 import logging
 
 def test_log_init():
-    logger = Log("something")
+    logger = Log('something')
     assert isinstance(logger.logger, logging.Logger)
 
+# A MockLogger class with debug and error methods that store the most recent level + message in an
+# instance variable.
+class MockLogger(object):
+    def __init__(self):
+        self.level = self.message = None
+
+    def debug(self, message):
+        self.level, self.message = 'DEBUG', message
+    
+    def error(self, message):
+        self.level, self.message = 'ERROR', message
+
+class MockLog(Log):
+    def _getLogger(self):
+       self.logger = MockLogger() 
+
+def test_log_returnvalue():
+    logger = MockLog('test2')
+    assert isinstance(logger.logger, MockLogger)
+    mock = logger.logger
+    logger.debug('word1')
+    assert mock.level == 'DEBUG'
+    assert mock.message == 'test2\tword1'
+    logger.error('word2')
+    assert mock.level == 'ERROR'
+    assert mock.message == 'test2\tword2'


### PR DESCRIPTION
This pull request enables support for Python's standard library `logging` module for magics. This greatly increases the configurability of the logging system without adding much additional complexity.  The following files have been changed:

* `log.py` has been completely rewritten to be a light wrapper around the standard library logging module

* A new `FileHandler` class has been added to serve as a "default" log handler

* Configuration files will need a different schema and I've edited `default_config.json` to reflect that. I have removed the `"log_level"` and `"log_to_disk"` settings, which are now both entirely subsumed by the new `"logging_config"` setting. The `logging_config` setting is a JSON object which can be passed to the `logging.config.dictConfig()` function as described [here](https://docs.python.org/2/library/logging.config.html).  This allows users to easily drop-in their own logging behavior.

* Finally, there are some small changes to `constants.py` and `test_logger.py` to accomodate this change.