### PR TITLE
Change a setting in the default logger to prevent debug logs from being propagated up to Jupyter

### DIFF
--- a/remotespark/default_config.json
+++ b/remotespark/default_config.json
@@ -33,7 +33,7 @@
       "magicsLogger": { 
         "handlers": ["magicsHandler"],
         "level": "DEBUG",
-	"propagate": 0
+        "propagate": 0
       }
     }
   },

--- a/remotespark/default_config.json
+++ b/remotespark/default_config.json
@@ -32,7 +32,8 @@
     "loggers": {
       "magicsLogger": { 
         "handlers": ["magicsHandler"],
-        "level": "DEBUG"
+        "level": "DEBUG",
+	"propagate": 0
       }
     }
   },


### PR DESCRIPTION
Without setting propagate=0, debug logs get propagated up to the main Jupyter logger and spilled all over the notebook.  This setting will prevent that behavior by default.