### PR TITLE
Three quotes for SQL queries to allow for multiline strings

### DIFF
--- a/remotespark/livyclientlib/pandaslivyclientbase.py
+++ b/remotespark/livyclientlib/pandaslivyclientbase.py
@@ -35,7 +35,7 @@ class PandasLivyClientBase(LivyClient):
 
     @staticmethod
     def make_context_columns(context_name, command):
-        return '{}.sql("{}").columns'.format(context_name, command)
+        return '{}.sql("""{}""").columns'.format(context_name, command)
 
     # Please override here down
     def get_records(self, context_name, command, max_take_rows):

--- a/remotespark/livyclientlib/pandaspysparklivyclient.py
+++ b/remotespark/livyclientlib/pandaspysparklivyclient.py
@@ -14,7 +14,7 @@ class PandasPysparkLivyClient(PandasLivyClientBase):
         super(PandasPysparkLivyClient, self).__init__(session, max_take_rows)
 
     def get_records(self, context_name, command, max_take_rows):
-        command = '{}.sql("{}").toJSON().take({})'.format(context_name, command, max_take_rows)
+        command = '{}.sql("""{}""").toJSON().take({})'.format(context_name, command, max_take_rows)
         return self.execute(command)
 
     def no_records(self, records_text):

--- a/remotespark/livyclientlib/pandasscalalivyclient.py
+++ b/remotespark/livyclientlib/pandasscalalivyclient.py
@@ -14,7 +14,7 @@ class PandasScalaLivyClient(PandasLivyClientBase):
         super(PandasScalaLivyClient, self).__init__(session, max_take_rows)
 
     def get_records(self, context_name, command, max_take_rows):
-        command = '{}.sql("{}").toJSON.take({}).foreach(println)'.format(context_name, command, max_take_rows)
+        command = '{}.sql("""{}""").toJSON.take({}).foreach(println)'.format(context_name, command, max_take_rows)
         return self.execute(command)
 
     def no_records(self, records_text):

--- a/tests/test_pandaspysparklivyclient.py
+++ b/tests/test_pandaspysparklivyclient.py
@@ -49,7 +49,7 @@ def test_execute_sql_pandas_pyspark_livy():
     command = "command"
     result = client.execute_sql(command)
 
-    execute_m.assert_called_with('sqlContext.sql("{}").toJSON().take({})'.format(command, 10))
+    execute_m.assert_called_with('sqlContext.sql("""{}""").toJSON().take({})'.format(command, 10))
 
     # Verify result is desired pandas df
     assert_frame_equal(desired_result, result)
@@ -73,7 +73,7 @@ def test_execute_sql_pandas_pyspark_livy_no_results():
     result = client.execute_sql(command)
 
     # Verify basic calls were done
-    execute_m.assert_called_with('sqlContext.sql("{}").columns'.format(command))
+    execute_m.assert_called_with('sqlContext.sql("""{}""").columns'.format(command))
 
     # Verify result is desired pandas dataframe
     assert_frame_equal(desired_result, result)
@@ -93,7 +93,7 @@ def test_execute_sql_pandas_pyspark_livy_no_results_exception_in_columns():
     result = client.execute_sql(command)
 
     # Verify basic calls were done
-    execute_m.assert_called_with('sqlContext.sql("{}").columns'.format(command))
+    execute_m.assert_called_with('sqlContext.sql("""{}""").columns'.format(command))
 
     # Verify result is exception
     assert result == some_exception
@@ -109,7 +109,7 @@ def test_execute_sql_pandas_pyspark_livy_some_exception():
     result = client.execute_sql(command)
 
     # Verify basic calls were done
-    execute_m.assert_called_with('sqlContext.sql("{}").toJSON().take({})'.format(command, 10))
+    execute_m.assert_called_with('sqlContext.sql("""{}""").toJSON().take({})'.format(command, 10))
 
     # Verify result is desired pandas dataframe
     assert some_exception == result

--- a/tests/test_pandasscalalivyclient.py
+++ b/tests/test_pandasscalalivyclient.py
@@ -49,7 +49,7 @@ def test_execute_sql_pandas_scala_livy():
     command = "command"
     result = client.execute_sql(command)
 
-    execute_m.assert_called_with('sqlContext.sql("{}").toJSON.take({}).foreach(println)'.format(command, 10))
+    execute_m.assert_called_with('sqlContext.sql("""{}""").toJSON.take({}).foreach(println)'.format(command, 10))
 
     # Verify result is desired pandas df
     assert_frame_equal(desired_result, result)
@@ -73,7 +73,7 @@ def test_execute_sql_pandas_scala_livy_no_results():
     result = client.execute_sql(command)
 
     # Verify basic calls were done
-    execute_m.assert_called_with('sqlContext.sql("{}").columns'.format(command))
+    execute_m.assert_called_with('sqlContext.sql("""{}""").columns'.format(command))
 
     # Verify result is desired pandas dataframe
     assert_frame_equal(desired_result, result)
@@ -93,7 +93,7 @@ def test_execute_sql_pandas_scala_livy_no_results_exception_in_columns():
     result = client.execute_sql(command)
 
     # Verify basic calls were done
-    execute_m.assert_called_with('sqlContext.sql("{}").columns'.format(command))
+    execute_m.assert_called_with('sqlContext.sql("""{}""").columns'.format(command))
 
     # Verify result is exception
     assert result == some_exception
@@ -109,7 +109,7 @@ def test_execute_sql_pandas_scala_livy_some_exception():
     result = client.execute_sql(command)
 
     # Verify basic calls were done
-    execute_m.assert_called_with('sqlContext.sql("{}").toJSON.take({}).foreach(println)'.format(command, 10))
+    execute_m.assert_called_with('sqlContext.sql("""{}""").toJSON.take({}).foreach(println)'.format(command, 10))
 
     # Verify result is desired pandas dataframe
     assert some_exception == result


### PR DESCRIPTION
This allows for multiline magics, which would otherwise fail