### PR TITLE
Fail eagerly to wait for the idle status if we have reached a "final" status

### DIFF
--- a/remotespark/livyclientlib/livyclient.py
+++ b/remotespark/livyclientlib/livyclient.py
@@ -21,7 +21,7 @@ class LivyClient(object):
         return self._session.get_state().to_dict()
 
     def execute(self, commands):
-        self._session.wait_for_status("idle", self._execute_timeout_seconds)
+        self._session.wait_for_idle(self._execute_timeout_seconds)
         return self._session.execute(commands)
 
     def execute_sql(self, command):

--- a/remotespark/livyclientlib/livyunexpectederror.py
+++ b/remotespark/livyclientlib/livyunexpectederror.py
@@ -1,0 +1,3 @@
+class LivyUnexpectedError(Exception):
+    """An exception that will be shown if some unexpected error happens on the Livy side."""
+    pass

--- a/remotespark/livyclientlib/livyunexpectedstatuserror.py
+++ b/remotespark/livyclientlib/livyunexpectedstatuserror.py
@@ -1,3 +1,3 @@
-class LivyUnexpectedError(Exception):
+class LivyUnexpectedStatusError(Exception):
     """An exception that will be shown if some unexpected error happens on the Livy side."""
     pass

--- a/tests/test_livyclient.py
+++ b/tests/test_livyclient.py
@@ -20,7 +20,7 @@ def test_execute_code():
     client.execute(command)
 
     mock_spark_session.create_sql_context.assert_called_with()
-    mock_spark_session.wait_for_status.assert_called_with("idle", 3600)
+    mock_spark_session.wait_for_idle.assert_called_with(3600)
     mock_spark_session.execute.assert_called_with(command)
 
 
@@ -32,7 +32,7 @@ def test_execute_sql():
     client.execute_sql(command)
 
     mock_spark_session.create_sql_context.assert_called_with()
-    mock_spark_session.wait_for_status.assert_called_with("idle", 3600)
+    mock_spark_session.wait_for_idle.assert_called_with(3600)
     mock_spark_session.execute.assert_called_with("sqlContext.sql(\"{}\").collect()".format(command))
 
 
@@ -44,7 +44,7 @@ def test_execute_hive():
     client.execute_hive(command)
 
     mock_spark_session.create_sql_context.assert_called_with()
-    mock_spark_session.wait_for_status.assert_called_with("idle", 3600)
+    mock_spark_session.wait_for_idle.assert_called_with(3600)
     mock_spark_session.execute.assert_called_with("hiveContext.sql(\"{}\").collect()".format(command))
 
 

--- a/tests/test_livysession.py
+++ b/tests/test_livysession.py
@@ -4,7 +4,7 @@ from mock import MagicMock, call
 from nose.tools import raises, assert_equals
 
 from remotespark.livyclientlib.livyclienttimeouterror import LivyClientTimeoutError
-from remotespark.livyclientlib.livyunexpectederror import LivyUnexpectedError
+from remotespark.livyclientlib.livyunexpectedstatuserror import LivyUnexpectedStatusError
 from remotespark.livyclientlib.livysession import LivySession
 import remotespark.utils.configuration as conf
 from remotespark.utils.utils import get_connection_string, get_instance_id
@@ -224,8 +224,9 @@ class TestLivySession:
         session = LivySession(http_client, "scala", "-1", False)
         conf.load()
         session.start()
-    
-        state = session.status
+
+        session.refresh_status()
+        state = session._status
 
         assert_equals("idle", state)
         http_client.get.assert_called_with("/sessions", [200])
@@ -251,7 +252,7 @@ class TestLivySession:
         http_client.get.assert_called_with("/sessions", [200])
         assert_equals(2, http_client.get.call_count)
 
-    @raises(LivyUnexpectedError)
+    @raises(LivyUnexpectedStatusError)
     def test_wait_for_idle_throws_when_in_final_status(self):
         http_client = MagicMock()
         http_client.post.return_value = DummyResponse(201, self.session_create_json)


### PR DESCRIPTION
* Rename `wait_for_status()` to `wait_for_idle()` and adjust parameter list appropriately.  If we ever need to wait for a status besides idle (seems unlikely?), then this can be refactored back out again.

* Throw a `LivyUnexpectedError` if the Livy session goes into error or dead.