### PR TITLE
Improve parsing and error reporting for dataframes in Pandas clients

### DIFF
--- a/remotespark/livyclientlib/dataframeparseexception.py
+++ b/remotespark/livyclientlib/dataframeparseexception.py
@@ -2,5 +2,5 @@
 (i.e. when the query resulted in an error"""
 
 class DataFrameParseException(Exception):
-    def __init__(self, out):
+    def __init__(self, out=None):
         self.out = out

--- a/remotespark/livyclientlib/pandaslivyclientbase.py
+++ b/remotespark/livyclientlib/pandaslivyclientbase.py
@@ -21,17 +21,13 @@ class PandasLivyClientBase(LivyClient):
                                                    str(self.max_take_rows))
         if not success:
             raise DataFrameParseException(records_text)
-        try:
-            if self.no_records(records_text):
-                # If there are no records, show some columns at least.
-                records_text = self.get_columns(context_name, command)
-                return self.get_columns_dataframe(records_text)
-            else:
-                return self.get_data_dataframe(records_text)
-        except (ValueError, SyntaxError) as e:
-            self.logger.error("Could not convert sql results to pandas DF.")
-            raise DataFrameParseException(records_text)
-            
+        if self.no_records(records_text):
+            # If there are no records, show some columns at least.
+            records_text = self.get_columns(context_name, command)
+            return self.get_columns_dataframe(records_text)
+        else:
+            return self.get_data_dataframe(records_text)
+
     def get_columns(self, context_name, command):
         (success, out) = self.execute(self.make_context_columns(context_name,
                                                                 command))

--- a/remotespark/livyclientlib/pandaspysparklivyclient.py
+++ b/remotespark/livyclientlib/pandaspysparklivyclient.py
@@ -5,53 +5,25 @@ import pandas as pd
 import json
 import re
 
+from remotespark.utils.constants import Constants
 from .pandaslivyclientbase import PandasLivyClientBase
 from .dataframeparseexception import DataFrameParseException
 
 class PandasPysparkLivyClient(PandasLivyClientBase):
     """Spark client for Livy session in PySpark"""
-    GET_DATA_RE = re.compile("^\[\s*(((''|'.*?[^\\\\]'),\s*)*\s*(''|'(.*?[^\\\\])'))?\s*\]$")
-    PARSE_FIELDS_RE = re.compile("''|'(.*?[^\\\\])'")
 
-    def __init__(self, session, max_take_rows):
-        super(PandasPysparkLivyClient, self).__init__(session, max_take_rows)
+    def make_context_columns(self, context_name, command):
+        return 'for {} in {}.sql("""{}""").columns: print({})'.format(Constants.long_random_variable_name,
+                                                                      context_name, command,
+                                                                      Constants.long_random_variable_name)
+
 
     def get_records(self, context_name, command, max_take_rows):
-        command = '{}.sql("""{}""").toJSON().take({})'.format(context_name, command, max_take_rows)
+        command = 'for {} in {}.sql("""{}""").toJSON().take({}): print({})'.format(Constants.long_random_variable_name,
+                                                                                   context_name, command, max_take_rows,
+                                                                                   Constants.long_random_variable_name)
         return self.execute(command)
+
 
     def no_records(self, records_text):
         return records_text == "[]"
-
-    def get_columns_dataframe(self, columns_text):
-        return pd.DataFrame.from_records([], columns=self._extract_strings_from_array(columns_text))
-
-
-    def get_data_dataframe(self, records_text):
-        strings = self._extract_strings_from_array(records_text)
-        try:
-            return pd.DataFrame([json.loads(s) for s in strings])
-        except ValueError:
-            raise DataFrameParseException("Cannot parse object as JSON: '{}'".format(strings))
-
-
-    def _extract_strings_from_array(self, s):
-        """This method consumes a string of the form
-           ['abc...', 'def...', 'xyz...', ...]
-           and returns all of the strings embedded inside the array as a list of
-           strings. That is, given a string that represents a list of single-quoted
-           strings, parse the array and return the list of strings. This method can
-           only handle single-quoted strings (not double-quoted) and it must handle
-           any list of any length, including 0. Furthermore it must support escaping
-           single-quotes using a backslash. Ignores newlines and leading and
-           trailing whitespace."""
-        match = re.match(self.GET_DATA_RE, s.strip().replace('\n', ''))
-        if match is not None:
-            inside_brackets = match.group(1)
-            if inside_brackets is None:
-                return []
-            else:
-                columns = list(re.findall(self.PARSE_FIELDS_RE, inside_brackets))
-                return [string.replace("\\'", "'") for string in columns]
-        else:
-            raise DataFrameParseException("Cannot parse dataframe data in text '{}'".format(s))

--- a/remotespark/livyclientlib/pandaspysparklivyclient.py
+++ b/remotespark/livyclientlib/pandaspysparklivyclient.py
@@ -24,18 +24,18 @@ class PandasPysparkLivyClient(PandasLivyClientBase):
         return records_text == "[]"
 
     def get_columns_dataframe(self, columns_text):
-        return pd.DataFrame.from_records([], columns=self.extract_strings_from_array(columns_text))
+        return pd.DataFrame.from_records([], columns=self._extract_strings_from_array(columns_text))
 
 
     def get_data_dataframe(self, records_text):
-        strings = self.extract_strings_from_array(records_text)
+        strings = self._extract_strings_from_array(records_text)
         try:
             return pd.DataFrame([json.loads(s) for s in strings])
         except ValueError:
             raise DataFrameParseException("Cannot parse object as JSON: '{}'".format(strings))
 
 
-    def extract_strings_from_array(self, s):
+    def _extract_strings_from_array(self, s):
         match = re.match(self.GET_DATA_RE, s.strip().replace('\n', ''))
         if match is not None:
             inside_brackets = match.group(1)

--- a/remotespark/livyclientlib/pandaspysparklivyclient.py
+++ b/remotespark/livyclientlib/pandaspysparklivyclient.py
@@ -3,11 +3,15 @@
 
 import pandas as pd
 import json
+import re
 
 from .pandaslivyclientbase import PandasLivyClientBase
+from .dataframeparseexception import DataFrameParseException
 
 class PandasPysparkLivyClient(PandasLivyClientBase):
     """Spark client for Livy session in PySpark"""
+    GET_DATA_RE = re.compile("^\[\s*(('.*[^\\\\]',\s*)\s*('.*[^\\\\]')?)\s*\]$")
+    PARSE_FIELDS_RE = re.compile("'(.*?[^\\\\])'")
 
     def __init__(self, session, max_take_rows):
         super(PandasPysparkLivyClient, self).__init__(session, max_take_rows)
@@ -20,11 +24,22 @@ class PandasPysparkLivyClient(PandasLivyClientBase):
         return records_text == "[]"
 
     def get_columns_dataframe(self, columns_text):
-        records = list()
-        columns = eval(columns_text)
-        return pd.DataFrame.from_records(records, columns=columns)
+        return pd.DataFrame.from_records([], columns=self.extract_strings_from_array(columns_text))
+
 
     def get_data_dataframe(self, records_text):
-        json_data = eval(records_text)
-        json_array = "[{}]".format(",".join(json_data))
-        return pd.DataFrame(json.loads(json_array))
+        strings = self.extract_strings_from_array(records_text)
+        try:
+            return pd.DataFrame([json.loads(s) for s in strings])
+        except ValueError:
+            raise DataFrameParseException("Cannot parse object as JSON: '{}'".format(strings))
+
+
+    def extract_strings_from_array(self, s):
+        match = re.match(self.GET_DATA_RE, s.strip().replace('\n', ''))
+        if match is not None:
+            inside_brackets = match.group(1)
+            columns = list(re.findall(self.PARSE_FIELDS_RE, inside_brackets))
+            return [string.replace("\\'", "'") for string in columns]
+        else:
+            raise DataFrameParseException("Cannot parse dataframe data in text '{}'".format(s))

--- a/remotespark/livyclientlib/pandasscalalivyclient.py
+++ b/remotespark/livyclientlib/pandasscalalivyclient.py
@@ -10,41 +10,15 @@ from .pandaslivyclientbase import PandasLivyClientBase
 
 class PandasScalaLivyClient(PandasLivyClientBase):
     """Spark client for Livy session in Scala"""
-    GET_DATA_RE = re.compile('Array\[String\] = Array\((.*)\)')
 
-    def __init__(self, session, max_take_rows):
-        super(PandasScalaLivyClient, self).__init__(session, max_take_rows)
+    def make_context_columns(self, context_name, command):
+        return '{}.sql("""{}""").columns.foreach(println)'.format(context_name, command)
+
 
     def get_records(self, context_name, command, max_take_rows):
         command = '{}.sql("""{}""").toJSON.take({}).foreach(println)'.format(context_name, command, max_take_rows)
         return self.execute(command)
 
+
     def no_records(self, records_text):
         return records_text == ""
-
-    def get_columns_dataframe(self, columns_text):
-        # Columns will look something like this: 'res1: Array[String] = Array(tableName, isTemporary)'
-        # We need to transform them into a list of strings: ["tableName", "isTemporary"]
-        m = re.search(self.GET_DATA_RE, columns_text)
-
-        # If we failed to find the columns
-        if m is None:
-            raise DataFrameParseException("Could not find columns in '{}'.".format(columns_text))
-
-        captured_group = m.group(1)
-
-        # If there are no columns
-        if captured_group.strip() == "":
-            raise DataFrameParseException("No data available in '{}'".format(columns_text))
-
-        # Convert the columns into an array of text
-        columns = [s.strip() for s in captured_group.split(",")]
-
-        return pd.DataFrame.from_records([], columns=columns)
-
-    def get_data_dataframe(self, records_text):
-        json_array = records_text.split("\n")
-        try:
-            return pd.DataFrame([json.loads(s) for s in json_array])
-        except ValueError:
-            raise DataFrameParseException("Could not parse the object as JSON: '{}'".format(records_text))

--- a/remotespark/utils/constants.py
+++ b/remotespark/utils/constants.py
@@ -17,6 +17,8 @@ class Constants:
     lang_python = "python"
     lang_supported = [lang_scala, lang_python]
 
+    long_random_variable_name = "_yQeKOYBsFgLWWGWZJu3y"
+
     magics_logger_name = "magicsLogger"
 
     idle_session_status = "idle"

--- a/tests/test_pandaslivyclientbase.py
+++ b/tests/test_pandaslivyclientbase.py
@@ -60,7 +60,7 @@ def test_execute_sql_some_exception():
     client.get_records = MagicMock(return_value=records)
     client.no_records = MagicMock(return_value=no_records)
     client.get_columns_dataframe = MagicMock(return_value=result_columns)
-    client.get_data_dataframe = MagicMock(side_effect=ValueError)
+    client.get_data_dataframe = MagicMock(side_effect=DataFrameParseException)
 
     try:
         result = client.execute_sql(records)
@@ -107,7 +107,7 @@ def test_execute_hive_some_exception():
     client.get_records = MagicMock(return_value=records)
     client.no_records = MagicMock(return_value=no_records)
     client.get_columns_dataframe = MagicMock(return_value=result_columns)
-    client.get_data_dataframe = MagicMock(side_effect=ValueError)
+    client.get_data_dataframe = MagicMock(side_effect=DataFrameParseException)
 
     try:
         result = client.execute_hive(records)

--- a/tests/test_pandaslivyclientbase.py
+++ b/tests/test_pandaslivyclientbase.py
@@ -47,6 +47,7 @@ def test_execute_sql_no_results():
     client.no_records = MagicMock(return_value=no_records)
     client.get_columns_dataframe = MagicMock(return_value=result_columns)
     client.get_data_dataframe = MagicMock(return_value=result_data)
+    client.make_context_columns = MagicMock()
 
     result = client.execute_sql(records)
     assert_frame_equal(result, result_columns)
@@ -94,6 +95,7 @@ def test_execute_hive_no_results():
     client.no_records = MagicMock(return_value=no_records)
     client.get_columns_dataframe = MagicMock(return_value=result_columns)
     client.get_data_dataframe = MagicMock(return_value=result_data)
+    client.make_context_columns = MagicMock()
 
     result = client.execute_hive(records)
     assert_frame_equal(result, result_columns)

--- a/tests/test_pandaspysparklivyclient.py
+++ b/tests/test_pandaspysparklivyclient.py
@@ -130,7 +130,7 @@ def test_execute_sql_pandas_pyspark_extract_strings():
                    (" ['aa\\'a',\n'q\\'']", ["aa'a", "q'"]),
                    ("['']", ['']),
                    ("['', '', 'abc', 'df\\'dd']", ['', '', 'abc', "df'dd"]),
-                   ("['a', 'bbbb', '\\'\\'\\'']", ['a', 'bbbb', "'''"])]:
+                   ("['a', 'bbbb', '\\'\\'\\'', '']", ['a', 'bbbb', "'''", ''])]:
         assert_equal(client._extract_strings_from_array(s), a)
 
 

--- a/tests/test_pandaspysparklivyclient.py
+++ b/tests/test_pandaspysparklivyclient.py
@@ -76,6 +76,20 @@ def test_execute_sql_pandas_pyspark_livy_no_results():
     assert_frame_equal(desired_df, df)
 
 @with_setup(_setup, _teardown)
+def test_execute_sql_pandas_pyspark_livy_bad_return():
+    global execute_responses
+
+    command = "command"
+    result_json = (True, "something bad happened")
+    execute_m.return_value = result_json
+
+    try:
+        client.execute_sql(command)
+        assert False
+    except DataFrameParseException:
+        pass
+
+@with_setup(_setup, _teardown)
 def test_execute_sql_pandas_pyspark_livy_no_results_exception_in_columns():
     global execute_responses
 

--- a/tests/test_pandaspysparklivyclient.py
+++ b/tests/test_pandaspysparklivyclient.py
@@ -130,7 +130,8 @@ def test_execute_sql_pandas_pyspark_extract_strings():
                    (" ['aa\\'a',\n'q\\'']", ["aa'a", "q'"]),
                    ("['']", ['']),
                    ("['', '', 'abc', 'df\\'dd']", ['', '', 'abc', "df'dd"]),
-                   ("['a', 'bbbb', '\\'\\'\\'', '']", ['a', 'bbbb', "'''", ''])]:
+                   ("['a', 'bbbb', '\\'\\'\\'', '']", ['a', 'bbbb', "'''", '']),
+                   ("['adfadf', 'asdf', 'asdf']", ['adfadf', 'asdf', 'asdf'])]:
         assert_equal(client._extract_strings_from_array(s), a)
 
 

--- a/tests/test_pandaspysparklivyclient.py
+++ b/tests/test_pandaspysparklivyclient.py
@@ -3,6 +3,7 @@ from nose.tools import with_setup, assert_equal
 from pandas.util.testing import assert_frame_equal
 import pandas as pd
 
+from remotespark.utils.constants import Constants
 from remotespark.livyclientlib.pandaspysparklivyclient import PandasPysparkLivyClient
 from remotespark.livyclientlib.dataframeparseexception import DataFrameParseException
 
@@ -38,8 +39,8 @@ def _teardown():
 def test_execute_sql_pandas_pyspark_livy():
     # result from livy
     result_json = (True,
-                   """['{\"buildingID\":0,\"date\":\"6/1/13\",\"temp_diff\":12}',
-                   '{\"buildingID\":1,\"date\":\"6/1/13\",\"temp_diff\":0}']""")
+                   """{"buildingID":0,"date":"6/1/13","temp_diff":12}
+{"buildingID":1,"date":"6/1/13","temp_diff":0}""")
     execute_m.return_value = result_json
 
     # desired pandas df
@@ -50,7 +51,9 @@ def test_execute_sql_pandas_pyspark_livy():
     command = "command"
     df = client.execute_sql(command)
 
-    execute_m.assert_called_with('sqlContext.sql("""{}""").toJSON().take({})'.format(command, 10))
+    execute_m.assert_called_with('for {} in sqlContext.sql("""{}""").toJSON().take({}): print({})'\
+                                 .format(Constants.long_random_variable_name, command, 10,
+                                         Constants.long_random_variable_name))
     assert_frame_equal(desired_df, df)
 
 
@@ -61,19 +64,22 @@ def test_execute_sql_pandas_pyspark_livy_no_results():
     # Set up spark session to return empty JSON and then columns
     command = "command"
     result_json = "[]"
-    result_columns = "['buildingID', 'date', 'temp_diff']"
+    result_columns = "buildingID\ndate\ntemp_diff"
     execute_responses = [(True, result_json), (True, result_columns)]
     execute_m.side_effect = _next_response_execute
 
     # pandas to return
-    columns = eval(result_columns)
-    desired_df = pd.DataFrame.from_records(list(), columns=columns)
+    columns = ['buildingID', 'date', 'temp_diff']
+    desired_df = pd.DataFrame.from_records([], columns=columns)
 
     df = client.execute_sql(command)
 
     # Verify basic calls were done
-    execute_m.assert_called_with('sqlContext.sql("""{}""").columns'.format(command))
+    execute_m.assert_called_with('for {} in sqlContext.sql("""{}""").columns: print({})'\
+                                 .format(Constants.long_random_variable_name, command,
+                                         Constants.long_random_variable_name))
     assert_frame_equal(desired_df, df)
+
 
 @with_setup(_setup, _teardown)
 def test_execute_sql_pandas_pyspark_livy_bad_return():
@@ -88,6 +94,7 @@ def test_execute_sql_pandas_pyspark_livy_bad_return():
         assert False
     except DataFrameParseException:
         pass
+
 
 @with_setup(_setup, _teardown)
 def test_execute_sql_pandas_pyspark_livy_no_results_exception_in_columns():
@@ -104,7 +111,9 @@ def test_execute_sql_pandas_pyspark_livy_no_results_exception_in_columns():
         client.execute_sql(command)
         assert False
     except DataFrameParseException as e:
-        execute_m.assert_called_with('sqlContext.sql("""{}""").columns'.format(command))
+        execute_m.assert_called_with('for {} in sqlContext.sql("""{}""").columns: print({})'\
+                                     .format(Constants.long_random_variable_name, command,
+                                             Constants.long_random_variable_name))
         assert e.out == some_exception
 
 
@@ -119,19 +128,11 @@ def test_execute_sql_pandas_pyspark_livy_some_exception():
         client.execute_sql(command)
         assert False
     except DataFrameParseException as e:
-        execute_m.assert_called_with('sqlContext.sql("""{}""").toJSON().take({})'.format(command, 10))
+        execute_m.assert_called_with('for {} in sqlContext.sql("""{}""").toJSON().take({}): print({})'\
+                                     .format(Constants.long_random_variable_name, command, 10,
+                                             Constants.long_random_variable_name))
         assert e.out == some_exception
 
-@with_setup(_setup, _teardown)
-def test_execute_sql_pandas_pyspark_extract_strings():
-    for (s, a) in [("[]", []),
-                   ("  ['afz']  ", ["afz"]),
-                   ("['zzz', 'aaa', 'fff']", ['zzz', 'aaa', 'fff']),
-                   (" ['aa\\'a',\n'q\\'']", ["aa'a", "q'"]),
-                   ("['']", ['']),
-                   ("['', '', 'abc', 'df\\'dd']", ['', '', 'abc', "df'dd"]),
-                   ("['a', 'bbbb', '\\'\\'\\'', '']", ['a', 'bbbb', "'''", '']),
-                   ("['adfadf', 'asdf', 'asdf']", ['adfadf', 'asdf', 'asdf'])]:
-        assert_equal(client._extract_strings_from_array(s), a)
+
 
 

--- a/tests/test_pandasscalalivyclient.py
+++ b/tests/test_pandasscalalivyclient.py
@@ -37,8 +37,8 @@ def _teardown():
 @with_setup(_setup, _teardown)
 def test_execute_sql_pandas_scala_livy():
     # result from livy
-    result_json = "{\"buildingID\":0,\"date\":\"6/1/13\",\"temp_diff\":12}\n" \
-                      "{\"buildingID\":1,\"date\":\"6/1/13\",\"temp_diff\":0}"
+    result_json = """{"buildingID":0,"date":"6/1/13","temp_diff":12}
+{"buildingID":1,"date":"6/1/13","temp_diff":0}"""
     execute_m.return_value = (True, result_json)
 
     # desired pandas df
@@ -60,7 +60,7 @@ def test_execute_sql_pandas_scala_livy_no_results():
     # Set up spark session to return empty JSON and then columns
     command = "command"
     result_json = ""
-    result_columns = "res1: Array[String] = Array(buildingID, date, temp_diff)"
+    result_columns = "buildingID\ndate\ntemp_diff"
     execute_responses = [(True, result_json), (True, result_columns)]
     execute_m.side_effect = _next_response_execute
 
@@ -71,7 +71,7 @@ def test_execute_sql_pandas_scala_livy_no_results():
     df = client.execute_sql(command)
 
     # Verify basic calls were done
-    execute_m.assert_called_with('sqlContext.sql("""{}""").columns'.format(command))
+    execute_m.assert_called_with('sqlContext.sql("""{}""").columns.foreach(println)'.format(command))
     assert_frame_equal(desired_df, df)
 
 @with_setup(_setup, _teardown)
@@ -103,7 +103,7 @@ def test_execute_sql_pandas_scala_livy_no_results_exception_in_columns():
         result = client.execute_sql(command)
         assert False
     except DataFrameParseException as e:
-        execute_m.assert_called_with('sqlContext.sql("""{}""").columns'.format(command))
+        execute_m.assert_called_with('sqlContext.sql("""{}""").columns.foreach(println)'.format(command))
         assert e.out == some_exception
 
 

--- a/tests/test_pandasscalalivyclient.py
+++ b/tests/test_pandasscalalivyclient.py
@@ -74,6 +74,19 @@ def test_execute_sql_pandas_scala_livy_no_results():
     execute_m.assert_called_with('sqlContext.sql("""{}""").columns'.format(command))
     assert_frame_equal(desired_df, df)
 
+@with_setup(_setup, _teardown)
+def test_execute_sql_pandas_pyspark_livy_bad_return():
+    global execute_responses
+
+    command = "command"
+    result_json = (True, "something bad happened")
+    execute_m.return_value = result_json
+
+    try:
+        client.execute_sql(command)
+        assert False
+    except DataFrameParseException:
+        pass
 
 @with_setup(_setup, _teardown)
 def test_execute_sql_pandas_scala_livy_no_results_exception_in_columns():


### PR DESCRIPTION
* Avoid calling `eval` to parse Livy output

* Improve error reporting for parse failures, calling `DataFrameParseException` if something goes wrong