### PR TITLE
Allow to override a single configuration

### DIFF
--- a/remotespark/remotesparkmagics.py
+++ b/remotespark/remotesparkmagics.py
@@ -43,8 +43,6 @@ class RemoteSparkMagics(Magics):
         except KeyError:
             self.logger.error("Could not read env vars for serialization.")
 
-        self.properties = conf.session_configs()
-
         self.logger.debug("Initialized spark magics.")
 
     @magic_arguments()
@@ -114,7 +112,7 @@ class RemoteSparkMagics(Magics):
         elif subcommand == "config":
             # Would normally do " ".join(args.command[1:]) but parse_argstring removes quotes...
             rest_of_line = user_input[7:]
-            self.properties = json.loads(rest_of_line)
+            conf.override(conf.session_configs.__name__, json.loads(rest_of_line))
         # add
         elif subcommand == "add":
             if len(args.command) != 4 and len(args.command) != 5:
@@ -129,7 +127,7 @@ class RemoteSparkMagics(Magics):
             else:
                 skip = False
 
-            properties = copy.deepcopy(self.properties)
+            properties = copy.deepcopy(conf.session_configs())
             properties["kind"] = self._get_livy_kind(language)
 
             self.spark_controller.add_session(name, connection_string, skip, properties)
@@ -178,7 +176,7 @@ class RemoteSparkMagics(Magics):
         {}
     Session configs:
         {}
-""".format(self.spark_controller.get_client_keys(), self.properties))
+""".format(self.spark_controller.get_client_keys(), conf.session_configs()))
 
     @staticmethod
     def _get_livy_kind(language):

--- a/remotespark/utils/configuration.py
+++ b/remotespark/utils/configuration.py
@@ -36,14 +36,21 @@ def load(fsrw_class = None):
         overrides = {}
     else:
         overrides = json.loads(line)
-    override(overrides)
+    override_all(overrides)
 
 
-def override(obj):
+def override_all(obj):
     """Given a dictionary representing the overrided defaults for this
     configuration, initialize the global configuration."""
     global _overrides
     _overrides = obj
+
+
+def override(config, value):
+    """Given a string representing a configuration and a value for that configuration,
+    override the configuration. Initialize the overrided configuration beforehand."""
+    initialize()
+    _overrides[config] = value
 
 
 def _override(f):

--- a/tests/test_clientmanager.py
+++ b/tests/test_clientmanager.py
@@ -30,8 +30,8 @@ def test_deserialize_on_creation():
 
 
 def test_serialize_periodically():
-    conf.override({conf.serialize_period_seconds.__name__: 0.1,
-                   conf.serialize_periodically.__name__: True})
+    conf.override_all({conf.serialize_period_seconds.__name__: 0.1,
+                       conf.serialize_periodically.__name__: True})
     serializer = MagicMock()
     ClientManager(serializer)
 

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -27,7 +27,7 @@ def test_configuration_initialize():
 @with_setup(_setup)
 def test_configuration_initialize_lazy():
     """Tests that the initialize function has no behavior if the override dict is already initialized"""
-    conf.override({})
+    conf.override_all({})
     fsrw_class = MagicMock(side_effect=ValueError)
     conf.initialize(fsrw_class)
 
@@ -56,7 +56,7 @@ def test_configuration_load_not_lazy():
     read_lines = MagicMock(return_value=[json.dumps(config)])
     fsrw.read_lines = read_lines
     fsrw_class = MagicMock(return_value=fsrw)
-    conf.override({ conf.default_chart_type.__name__: "bar" })
+    conf.override_all({conf.default_chart_type.__name__: "bar"})
     conf.load(fsrw_class)
     assert conf._overrides is not None
     assert_equals(conf._overrides, config)
@@ -67,7 +67,7 @@ def test_configuration_load_not_lazy():
 def test_configuration_override():
     z = 1500
     config = { conf.status_sleep_seconds.__name__: z }
-    conf.override(config)
+    conf.override_all(config)
     assert_equals(conf._overrides, config)
     assert_equals(conf.status_sleep_seconds(), z)
 
@@ -76,7 +76,7 @@ def test_configuration_override():
 def test_configuration_decorator():
     def test_f():
         return 0
-    conf.override({test_f.__name__: -1})
+    conf.override_all({test_f.__name__: -1})
     test_f_decorated = conf._override(test_f)
     assert_not_equals(test_f_decorated(), test_f())
     assert_equals(test_f_decorated(), -1)

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -65,6 +65,18 @@ def test_configuration_load_not_lazy():
 
 @with_setup(_setup)
 def test_configuration_override():
+    kpc = { 'username': 'U', 'password': 'P', 'url': 'L' }
+    overrides = { conf.kernel_python_credentials.__name__: kpc }
+    conf.override_all(overrides)
+    conf.override(conf.execute_timeout_seconds.__name__, 1)
+    assert_equals(conf._overrides, { conf.kernel_python_credentials.__name__: kpc,
+                                     conf.execute_timeout_seconds.__name__: 1 })
+    assert_equals(conf.execute_timeout_seconds(), 1)
+    assert_equals(conf.kernel_python_credentials(), kpc)
+
+
+@with_setup(_setup)
+def test_configuration_override_all():
     z = 1500
     config = { conf.status_sleep_seconds.__name__: z }
     conf.override_all(config)

--- a/tests/test_livysession.py
+++ b/tests/test_livysession.py
@@ -59,7 +59,7 @@ class TestLivySession:
 
     @raises(AssertionError)
     def test_constructor_throws_status_sleep_seconds(self):
-        conf.override({
+        conf.override_all({
             "status_sleep_seconds": 0,
             "statement_sleep_seconds": 2,
             "create_sql_context_timeout_seconds": 60
@@ -69,7 +69,7 @@ class TestLivySession:
 
     @raises(AssertionError)
     def test_constructor_throws_statement_sleep_seconds(self):
-        conf.override({
+        conf.override_all({
             "status_sleep_seconds": 3,
             "statement_sleep_seconds": 0,
             "create_sql_context_timeout_seconds": 60
@@ -79,7 +79,7 @@ class TestLivySession:
 
     @raises(AssertionError)
     def test_constructor_throws_sql_create_timeout_seconds(self):
-        conf.override({
+        conf.override_all({
             "status_sleep_seconds": 4,
             "statement_sleep_seconds": 2,
             "create_sql_context_timeout_seconds": 0
@@ -89,7 +89,7 @@ class TestLivySession:
 
     @raises(ValueError)
     def test_constructor_throws_invalid_session_sql_combo(self):
-        conf.override({
+        conf.override_all({
             "status_sleep_seconds": 2,
             "statement_sleep_seconds": 2,
             "create_sql_context_timeout_seconds": 60
@@ -98,7 +98,7 @@ class TestLivySession:
         conf.load()
 
     def test_constructor_starts_with_existing_session(self):
-        conf.override({
+        conf.override_all({
             "status_sleep_seconds": 4,
             "statement_sleep_seconds": 2,
             "create_sql_context_timeout_seconds": 60
@@ -111,7 +111,7 @@ class TestLivySession:
         assert session.started_sql_context
 
     def test_constructor_starts_with_no_session(self):
-        conf.override({
+        conf.override_all({
             "status_sleep_seconds": 4,
             "statement_sleep_seconds": 2,
             "create_sql_context_timeout_seconds": 60
@@ -123,7 +123,7 @@ class TestLivySession:
         assert not session.started_sql_context
 
     def test_is_final_status(self):
-        conf.override({
+        conf.override_all({
             "status_sleep_seconds": 0.01,
             "statement_sleep_seconds": 0.01
         })
@@ -141,7 +141,7 @@ class TestLivySession:
         http_client = MagicMock()
         http_client.post.return_value = DummyResponse(201, self.session_create_json)
 
-        conf.override({
+        conf.override_all({
             "status_sleep_seconds": 0.01,
             "statement_sleep_seconds": 0.01
         })
@@ -160,7 +160,7 @@ class TestLivySession:
         http_client = MagicMock()
         http_client.post.return_value = DummyResponse(201, self.session_create_json)
 
-        conf.override({
+        conf.override_all({
             "status_sleep_seconds": 0.01,
             "statement_sleep_seconds": 0.01
         })
@@ -179,7 +179,7 @@ class TestLivySession:
         http_client = MagicMock()
         http_client.post.return_value = DummyResponse(201, self.session_create_json)
 
-        conf.override({
+        conf.override_all({
             "status_sleep_seconds": 0.01,
             "statement_sleep_seconds": 0.01
         })
@@ -196,7 +196,7 @@ class TestLivySession:
         http_client = MagicMock()
         http_client.post.return_value = DummyResponse(201, self.session_create_json)
         http_client.get.return_value = DummyResponse(200, self.ready_sessions_json)
-        conf.override({
+        conf.override_all({
             "status_sleep_seconds": 0.01,
             "statement_sleep_seconds": 0.01
         })
@@ -217,12 +217,12 @@ class TestLivySession:
                               DummyResponse(200, self.ready_sessions_json)]
         http_client.get.side_effect = self._next_response_get
 
-        conf.override({
+        conf.override_all({
             "status_sleep_seconds": 0.01,
             "statement_sleep_seconds": 0.01
         })
         session = self._create_session(http_client=http_client)
-        conf.override({})
+        conf.override_all({})
 
         session.start()
 
@@ -240,7 +240,7 @@ class TestLivySession:
                               DummyResponse(200, self.error_sessions_json)]
         http_client.get.side_effect = self._next_response_get
 
-        conf.override({
+        conf.override_all({
             "status_sleep_seconds": 0.011,
             "statement_sleep_seconds": 6000
         })
@@ -260,7 +260,7 @@ class TestLivySession:
                               DummyResponse(200, self.ready_sessions_json)]
         http_client.get.side_effect = self._next_response_get
 
-        conf.override({
+        conf.override_all({
             "status_sleep_seconds": 0.011,
             "statement_sleep_seconds": 6000
         })
@@ -274,7 +274,7 @@ class TestLivySession:
     def test_delete_session_when_active(self):
         http_client = MagicMock()
         http_client.post.return_value = DummyResponse(201, self.session_create_json)
-        conf.override({
+        conf.override_all({
             "status_sleep_seconds": 0.01,
             "statement_sleep_seconds": 0.01
         })
@@ -290,7 +290,7 @@ class TestLivySession:
     def test_delete_session_when_not_started(self):
         http_client = MagicMock()
         http_client.post.return_value = DummyResponse(201, self.session_create_json)
-        conf.override({
+        conf.override_all({
             "status_sleep_seconds": 0.01,
             "statement_sleep_seconds": 0.01
         })
@@ -306,7 +306,7 @@ class TestLivySession:
     def test_delete_session_when_dead_throws(self):
         http_client = MagicMock()
         http_client.post.return_value = DummyResponse(201, self.session_create_json)
-        conf.override({
+        conf.override_all({
             "status_sleep_seconds": 0.01,
             "statement_sleep_seconds": 0.01
         })
@@ -325,7 +325,7 @@ class TestLivySession:
         self.get_responses = [DummyResponse(200, self.running_statement_json),
                               DummyResponse(200, self.ready_statement_json)]
         http_client.get.side_effect = self._next_response_get
-        conf.override({
+        conf.override_all({
             "status_sleep_seconds": 0.01,
             "statement_sleep_seconds": 0.01
         })
@@ -355,7 +355,7 @@ class TestLivySession:
                               DummyResponse(200, self.ready_sessions_json),
                               DummyResponse(200, self.ready_statement_json)]
         http_client.get.side_effect = self._next_response_get
-        conf.override({
+        conf.override_all({
             "status_sleep_seconds": 0.01,
             "statement_sleep_seconds": 0.01
         })
@@ -391,7 +391,7 @@ class TestLivySession:
                               DummyResponse(200, self.ready_sessions_json),
                               DummyResponse(200, self.ready_statement_json)]
         http_client.get.side_effect = self._next_response_get
-        conf.override({
+        conf.override_all({
             "status_sleep_seconds": 0.01,
             "statement_sleep_seconds": 0.01
         })
@@ -420,7 +420,7 @@ class TestLivySession:
                               DummyResponse(200, self.ready_sessions_json),
                               DummyResponse(200, self.ready_statement_json)]
         http_client.get.side_effect = self._next_response_get
-        conf.override({
+        conf.override_all({
             "status_sleep_seconds": 0.01,
             "statement_sleep_seconds": 0.01
         })
@@ -448,7 +448,7 @@ class TestLivySession:
                               DummyResponse(200, self.running_statement_json),
                               DummyResponse(200, self.ready_statement_json)]
         http_client.get.side_effect = self._next_response_get
-        conf.override({
+        conf.override_all({
             "status_sleep_seconds": 0.01,
             "statement_sleep_seconds": 0.01
         })
@@ -466,7 +466,7 @@ class TestLivySession:
         http_client = MagicMock()
         http_client.connection_string = connection_string
         kind = Constants.session_kind_spark
-        conf.override({
+        conf.override_all({
             "status_sleep_seconds": 0.01,
             "statement_sleep_seconds": 0.01
         })

--- a/tests/test_remotesparkmagics.py
+++ b/tests/test_remotesparkmagics.py
@@ -14,7 +14,7 @@ shell = None
 def _setup():
     global magic, spark_controller, shell
 
-    conf.override({})
+    conf.override_all({})
 
     shell = MagicMock()
     magic = RemoteSparkMagics(shell=None)
@@ -70,8 +70,9 @@ def test_add_sessions_command_parses():
 
 @with_setup(_setup, _teardown)
 def test_add_sessions_command_extra_properties():
+    conf.override_all({})
     magic.spark("config {\"extra\": \"yes\"}")
-    assert magic.properties == {"extra": "yes"}
+    assert conf.session_configs() == {"extra": "yes"}
 
     add_sessions_mock = MagicMock()
     spark_controller.add_session = add_sessions_mock
@@ -84,6 +85,7 @@ def test_add_sessions_command_extra_properties():
     magic.spark(line)
 
     add_sessions_mock.assert_called_once_with(name, connection_string, False, {"kind": "spark", "extra": "yes"})
+    conf.load()
 
 
 @with_setup(_setup, _teardown)

--- a/tests/test_sparkkernelbase.py
+++ b/tests/test_sparkkernelbase.py
@@ -54,7 +54,7 @@ def test_get_config():
     url = "url"
 
     config = { "kernel_python_credentials": {user_ev: usr, pass_ev: pwd, url_ev: url} }
-    conf.override(config)
+    conf.override_all(config)
 
     u, p, r = kernel._get_configuration()
 
@@ -67,7 +67,7 @@ def test_get_config():
 
 @with_setup(_setup, _teardown)
 def test_get_config_not_set():
-    conf.override({})
+    conf.override_all({})
     try:
         kernel._get_configuration()
 


### PR DESCRIPTION
This paves the way for being able to update arbitrary configuration values at runtime, including those passed in by the user.