### PR TITLE
Change module names so the kernels work without having to manually move around the kernel Python files

### DIFF
--- a/remotespark/pysparkkernel/kernel.json
+++ b/remotespark/pysparkkernel/kernel.json
@@ -1,3 +1,3 @@
-{"argv":["python","-m","pysparkkernel", "-f", "{connection_file}"],
+{"argv":["python","-m","remotespark.pysparkkernel.pysparkkernel", "-f", "{connection_file}"],
  "display_name":"PySpark"
 }

--- a/remotespark/sparkkernel/kernel.json
+++ b/remotespark/sparkkernel/kernel.json
@@ -1,3 +1,3 @@
-{"argv":["python","-m","sparkkernel", "-f", "{connection_file}"],
+{"argv":["python","-m","remotespark.sparkkernel.sparkkernel", "-f", "{connection_file}"],
  "display_name":"Spark"
 }


### PR DESCRIPTION
If we reference the full qualified module name then we don't have to manually copy the module somewhere else in order to get the kernels to work. This one is a no-brainer.