### PR TITLE
Fix typo which causes Python kernel not to recognize empty dataframe results

### DIFF
--- a/remotespark/livyclientlib/pandaslivyclientbase.py
+++ b/remotespark/livyclientlib/pandaslivyclientbase.py
@@ -62,4 +62,4 @@ class PandasLivyClientBase(LivyClient):
 
 
     def no_records(self, records_text):
-        raise NotImplementedError()
+        return records_text == ""

--- a/remotespark/livyclientlib/pandaspysparklivyclient.py
+++ b/remotespark/livyclientlib/pandaspysparklivyclient.py
@@ -26,4 +26,4 @@ class PandasPysparkLivyClient(PandasLivyClientBase):
 
 
     def no_records(self, records_text):
-        return records_text == "[]"
+        return records_text == ""

--- a/remotespark/livyclientlib/pandaspysparklivyclient.py
+++ b/remotespark/livyclientlib/pandaspysparklivyclient.py
@@ -25,5 +25,3 @@ class PandasPysparkLivyClient(PandasLivyClientBase):
         return self.execute(command)
 
 
-    def no_records(self, records_text):
-        return records_text == ""

--- a/remotespark/livyclientlib/pandasscalalivyclient.py
+++ b/remotespark/livyclientlib/pandasscalalivyclient.py
@@ -20,5 +20,3 @@ class PandasScalaLivyClient(PandasLivyClientBase):
         return self.execute(command)
 
 
-    def no_records(self, records_text):
-        return records_text == ""

--- a/tests/test_pandaspysparklivyclient.py
+++ b/tests/test_pandaspysparklivyclient.py
@@ -63,7 +63,7 @@ def test_execute_sql_pandas_pyspark_livy_no_results():
 
     # Set up spark session to return empty JSON and then columns
     command = "command"
-    result_json = "[]"
+    result_json = ""
     result_columns = "buildingID\ndate\ntemp_diff"
     execute_responses = [(True, result_json), (True, result_columns)]
     execute_m.side_effect = _next_response_execute
@@ -102,7 +102,7 @@ def test_execute_sql_pandas_pyspark_livy_no_results_exception_in_columns():
 
     # Set up spark session to return empty JSON and then columns
     command = "command"
-    result_json = "[]"
+    result_json = ""
     some_exception = "some exception"
     execute_responses = [(True, result_json), (False, some_exception)]
     execute_m.side_effect = _next_response_execute


### PR DESCRIPTION
Now the Python kernel should be able to properly handle empty dataframes, which it wasn't able to do before thanks to a typo.