### PR TITLE
Syntax highlighting for Python kernel

### DIFF
--- a/remotespark/pysparkkernel/pysparkkernel.py
+++ b/remotespark/pysparkkernel/pysparkkernel.py
@@ -12,7 +12,9 @@ class PySparkKernel(SparkKernelBase):
         language_version = '0.1'
         language_info = {
             'name': 'pyspark',
-            'mimetype': 'text/x-python'
+            'mimetype': 'text/x-python',
+            'codemirror_mode' : { 'name' : 'python' },
+            'pygments_lexer': 'python2'
         }
 
         kernel_conf_name = Constants.lang_python

--- a/tests/test_kernels.py
+++ b/tests/test_kernels.py
@@ -1,7 +1,6 @@
 from remotespark.pysparkkernel.pysparkkernel import PySparkKernel
 from remotespark.sparkkernel.sparkkernel import SparkKernel
 from remotespark.utils.constants import Constants
-from nose.tools import assert_equal
 
 
 class TestPyparkKernel(PySparkKernel):
@@ -25,12 +24,12 @@ def test_pyspark_kernel_configs():
     assert kernel.implementation == 'PySpark'
     assert kernel.language == 'no-op'
     assert kernel.language_version == '0.1'
-    assert_equal (kernel.language_info, {
+    assert kernel.language_info == {
         'name': 'pyspark',
         'mimetype': 'text/x-python',
         'codemirror_mode': {'name': 'python'},
         'pygments_lexer': 'python2'
-    })
+    }
 
 
 def test_spark_kernel_configs():

--- a/tests/test_kernels.py
+++ b/tests/test_kernels.py
@@ -1,6 +1,7 @@
 from remotespark.pysparkkernel.pysparkkernel import PySparkKernel
 from remotespark.sparkkernel.sparkkernel import SparkKernel
 from remotespark.utils.constants import Constants
+from nose.tools import assert_equal
 
 
 class TestPyparkKernel(PySparkKernel):
@@ -24,10 +25,12 @@ def test_pyspark_kernel_configs():
     assert kernel.implementation == 'PySpark'
     assert kernel.language == 'no-op'
     assert kernel.language_version == '0.1'
-    assert kernel.language_info == {
+    assert_equal (kernel.language_info, {
         'name': 'pyspark',
-        'mimetype': 'text/x-python'
-    }
+        'mimetype': 'text/x-python',
+        'codemirror_mode': {'name': 'python'},
+        'pygments_lexer': 'python2'
+    })
 
 
 def test_spark_kernel_configs():


### PR DESCRIPTION
Add syntax highlighting for the Python kernel.  This one's very easy.  We can probably use the same general solution for Scala but I'm not sure how to do it right now.