### PR TITLE
Scala syntax highlighting

### DIFF
--- a/remotespark/sparkkernel/sparkkernel.py
+++ b/remotespark/sparkkernel/sparkkernel.py
@@ -12,7 +12,8 @@ class SparkKernel(SparkKernelBase):
         language_version = '0.1'
         language_info = {
             'name': 'scala',
-            'mimetype': 'text/x-scala'
+            'mimetype': 'text/x-scala',
+            'pygments_lexer': 'scala'
         }
 
         kernel_conf_name = Constants.lang_scala

--- a/remotespark/sparkkernel/sparkkernel.py
+++ b/remotespark/sparkkernel/sparkkernel.py
@@ -11,8 +11,8 @@ class SparkKernel(SparkKernelBase):
         language = 'no-op'
         language_version = '0.1'
         language_info = {
-            'name': 'spark',
-            'mimetype': 'text/x-python'
+            'name': 'scala',
+            'mimetype': 'text/x-scala'
         }
 
         kernel_conf_name = Constants.lang_scala

--- a/tests/test_kernels.py
+++ b/tests/test_kernels.py
@@ -44,5 +44,6 @@ def test_spark_kernel_configs():
     assert kernel.language_version == '0.1'
     assert kernel.language_info == {
         'name': 'scala',
-        'mimetype': 'text/x-scala'
+        'mimetype': 'text/x-scala',
+        'pygments_lexer': 'scala'
     }

--- a/tests/test_kernels.py
+++ b/tests/test_kernels.py
@@ -43,6 +43,6 @@ def test_spark_kernel_configs():
     assert kernel.language == 'no-op'
     assert kernel.language_version == '0.1'
     assert kernel.language_info == {
-        'name': 'spark',
-        'mimetype': 'text/x-python'
+        'name': 'scala',
+        'mimetype': 'text/x-scala'
     }


### PR DESCRIPTION
Enable syntax highlighting for Scala. Making this work required that I change the `name` field of the `language_info` for the Spark kernel. I don't believe this has any other repercussions, but I'll wait for Alejandro's +1 before merging this in.