### PR TITLE
Create SQL context after adding client to our client list

### DIFF
--- a/remotespark/livyclientlib/livyclient.py
+++ b/remotespark/livyclientlib/livyclient.py
@@ -10,15 +10,14 @@ class LivyClient(object):
 
     def __init__(self, session):
         self.logger = Log("LivyClient")
-
-        execute_timeout_seconds = conf.execute_timeout_seconds()
-
         self._session = session
-        self._session.create_sql_context()
-        self._execute_timeout_seconds = execute_timeout_seconds
+        self._execute_timeout_seconds = conf.execute_timeout_seconds()
 
     def __str__(self):
         return str(self._session)
+
+    def start(self):
+        self._session.create_sql_context()
 
     def serialize(self):
         return self._session.get_state().to_dict()

--- a/remotespark/livyclientlib/sparkcontroller.py
+++ b/remotespark/livyclientlib/sparkcontroller.py
@@ -72,6 +72,7 @@ class SparkController(object):
         session.start()
         livy_client = self.client_factory.build_client(session)
         self.client_manager.add_client(name, livy_client)
+        livy_client.start()
 
     def get_client_keys(self):
         return self.client_manager.get_sessions_list()

--- a/tests/test_livyclient.py
+++ b/tests/test_livyclient.py
@@ -6,16 +6,23 @@ from remotespark.utils.utils import get_connection_string
 from remotespark.utils.constants import Constants
 
 
-def test_create_sql_context_automatically():
+def test_doesnt_create_sql_context_automatically():
     mock_spark_session = MagicMock()
     LivyClient(mock_spark_session)
+    assert not mock_spark_session.create_sql_context.called
 
+
+def test_start_creates_sql_context():
+    mock_spark_session = MagicMock()
+    client = LivyClient(mock_spark_session)
+    client.start()
     mock_spark_session.create_sql_context.assert_called_with()
 
 
 def test_execute_code():
     mock_spark_session = MagicMock()
     client = LivyClient(mock_spark_session)
+    client.start()
     command = "command"
 
     client.execute(command)
@@ -28,6 +35,7 @@ def test_execute_code():
 def test_execute_sql():
     mock_spark_session = MagicMock()
     client = LivyClient(mock_spark_session)
+    client.start()
     command = "command"
 
     client.execute_sql(command)
@@ -40,6 +48,7 @@ def test_execute_sql():
 def test_execute_hive():
     mock_spark_session = MagicMock()
     client = LivyClient(mock_spark_session)
+    client.start()
     command = "command"
 
     client.execute_hive(command)
@@ -63,6 +72,7 @@ def test_serialize():
     session.get_state.return_value = LivySessionState(session_id, connection_string, kind, sql_created)
 
     client = LivyClient(session)
+    client.start()
 
     serialized = client.serialize()
 
@@ -77,6 +87,7 @@ def test_serialize():
 def test_close_session():
     mock_spark_session = MagicMock()
     client = LivyClient(mock_spark_session)
+    client.start()
 
     client.close_session()
 
@@ -89,6 +100,7 @@ def test_kind():
     language_mock = PropertyMock(return_value=kind)
     type(mock_spark_session).kind = language_mock
     client = LivyClient(mock_spark_session)
+    client.start()
 
     l = client.kind
 
@@ -101,6 +113,7 @@ def test_session_id():
     session_id_mock = PropertyMock(return_value=session_id)
     type(mock_spark_session).id = session_id_mock
     client = LivyClient(mock_spark_session)
+    client.start()
 
     i = client.session_id
 

--- a/tests/test_sparkcontroller.py
+++ b/tests/test_sparkcontroller.py
@@ -41,7 +41,7 @@ def test_add_session():
     name = "name"
     properties = {"kind": "spark"}
     connection_string = "url=http://location:port;username=name;password=word"
-    client = "client"
+    client = MagicMock()
     session = MagicMock()
     client_factory.create_session = MagicMock(return_value=session)
     client_factory.build_client = MagicMock(return_value=client)
@@ -51,6 +51,7 @@ def test_add_session():
     client_factory.create_session.assert_called_once_with(connection_string, properties, "-1", False)
     client_factory.build_client.assert_called_once_with(session)
     client_manager.add_client.assert_called_once_with(name, client)
+    client.start.assert_called_once_with()
     session.start.assert_called_once_with()
 
 


### PR DESCRIPTION
Closes #110 

Add a new "start" method to Livy clients. Add to our client manager's list before calling the start method.  This reduces the odds of leaking sessions.