### PR TITLE
Refactor SparkKernelBase

### DIFF
--- a/remotespark/pysparkkernel/pysparkkernel.py
+++ b/remotespark/pysparkkernel/pysparkkernel.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2015  aggftw@gmail.com
 # Distributed under the terms of the Modified BSD License.
-from remotespark.sparkkernelbase import SparkKernelBase
 from remotespark.utils.constants import Constants
+from remotespark.wrapperkernel.sparkkernelbase import SparkKernelBase
 
 
 class PySparkKernel(SparkKernelBase):

--- a/remotespark/sparkkernel/sparkkernel.py
+++ b/remotespark/sparkkernel/sparkkernel.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2015  aggftw@gmail.com
 # Distributed under the terms of the Modified BSD License.
-from remotespark.sparkkernelbase import SparkKernelBase
 from remotespark.utils.constants import Constants
+from remotespark.wrapperkernel.sparkkernelbase import SparkKernelBase
 
 
 class SparkKernel(SparkKernelBase):

--- a/remotespark/sparkkernelbase.py
+++ b/remotespark/sparkkernelbase.py
@@ -19,7 +19,6 @@ class SparkKernelBase(IPythonKernel):
     clean_up_command = "cleanup"
     logs_command = "logs"
 
-    output_flag = "o"
     force_flag = "f"
 
     def __init__(self, implementation, implementation_version, language, language_version, language_info,
@@ -69,26 +68,7 @@ class SparkKernelBase(IPythonKernel):
             code_to_run = "%%spark\n{}".format(code_to_run)
             return self._run_starting_session(code_to_run, silent, store_history, user_expressions, allow_stdin)
         elif subcommand == self.sql_command:
-            if self.output_flag not in flags:
-                output_var = ""
-            else:
-                ouput_error = "If -o flag is present, please place the query on the second line. Variable name " \
-                              "should come after the -o flag and be a valid python variable name."
-
-                # First line of code_to_run should be variable name
-                split_code = code_to_run.split("\n", 1)
-
-                if len(split_code) != 2:
-                    raise SyntaxError(ouput_error)
-
-                var_name = split_code[0].strip()
-
-                if var_name.find(" ") != -1:
-                    raise SyntaxError(ouput_error)
-
-                code_to_run = split_code[1]
-                output_var = " -o {}".format(var_name)
-            code_to_run = "%%spark -c sql{}\n{}".format(output_var, code_to_run)
+            code_to_run = "%%spark -c sql\n{}".format(code_to_run)
             return self._run_starting_session(code_to_run, silent, store_history, user_expressions, allow_stdin)
         elif subcommand == self.hive_command:
             code_to_run = "%%spark -c hive\n{}".format(code_to_run)

--- a/remotespark/utils/constants.py
+++ b/remotespark/utils/constants.py
@@ -2,7 +2,7 @@
 # Distributed under the terms of the Modified BSD License.
 
 
-class Constants:
+class Constants(object):
     config_json = "config.json"
 
     session_kind_spark = "spark"
@@ -34,3 +34,6 @@ class Constants:
                                busy_session_status, error_session_status, dead_session_status]
     final_status = [dead_session_status, error_session_status]
 
+    delete_session_action = "delete"
+    start_session_action = "start"
+    do_nothing_action = "nothing"

--- a/remotespark/wrapperkernel/codetransformers.py
+++ b/remotespark/wrapperkernel/codetransformers.py
@@ -59,10 +59,15 @@ class SparkTransformer(UserCodeTransformerBase):
         return code_to_run, error_to_show, begin_action, end_action, deletes_session
 
 
-class SqlTransformer(UserCodeTransformerBase):
+class ContextOutputVariableTransformer(UserCodeTransformerBase):
+    def __init__(self, subcommand):
+        super(ContextOutputVariableTransformer, self).__init__(subcommand)
+
+        self.context_name = None
+
     def get_code_to_execute(self, session_started, connection_string, force, output_var, command):
         error_to_show = None
-        code_to_run = "%%spark -c sql\n{}".format(command)
+        code_to_run = "%%spark -c {}\n{}".format(self.context_name, command)
         begin_action = Constants.start_session_action
         end_action = Constants.do_nothing_action
         deletes_session = False
@@ -70,15 +75,18 @@ class SqlTransformer(UserCodeTransformerBase):
         return code_to_run, error_to_show, begin_action, end_action, deletes_session
 
 
-class HiveTransformer(UserCodeTransformerBase):
-    def get_code_to_execute(self, session_started, connection_string, force, output_var, command):
-        error_to_show = None
-        code_to_run = "%%spark -c hive\n{}".format(command)
-        begin_action = Constants.start_session_action
-        end_action = Constants.do_nothing_action
-        deletes_session = False
+class SqlTransformer(ContextOutputVariableTransformer):
+    def __init__(self, subcommand):
+        super(SqlTransformer, self).__init__(subcommand)
 
-        return code_to_run, error_to_show, begin_action, end_action, deletes_session
+        self.context_name = Constants.context_name_sql
+
+
+class HiveTransformer(ContextOutputVariableTransformer):
+    def __init__(self, subcommand):
+        super(HiveTransformer, self).__init__(subcommand)
+
+        self.context_name = Constants.context_name_hive
 
 
 class InfoTransformer(UserCodeTransformerBase):

--- a/remotespark/wrapperkernel/codetransformers.py
+++ b/remotespark/wrapperkernel/codetransformers.py
@@ -1,0 +1,148 @@
+# Copyright (c) 2015  aggftw@gmail.com
+# Distributed under the terms of the Modified BSD License.
+
+from remotespark.utils.constants import Constants
+from remotespark.wrapperkernel.usercommandparser import UserCommandParser
+
+
+class UserCodeTransformerBase(object):
+    def __init__(self, subcommand):
+        self.name = subcommand
+
+    def get_code_to_execute(self, session_started, connection_string, flags, command):
+        raise NotImplementedError()
+
+
+class NotSupportedTransformer(UserCodeTransformerBase):
+    def get_code_to_execute(self, session_started, connection_string, flags, command):
+        error_to_show = "Magic '{}' not supported.".format(self.name)
+        code_to_run = ""
+        begin_action = Constants.do_nothing_action
+        end_action = Constants.do_nothing_action
+        deletes_session = False
+
+        return code_to_run, error_to_show, begin_action, end_action, deletes_session
+
+
+class ConfigTransformer(UserCodeTransformerBase):
+    def get_code_to_execute(self, session_started, connection_string, flags, command):
+        error_to_show = None
+        begin_action = Constants.do_nothing_action
+        end_action = Constants.do_nothing_action
+        deletes_session = False
+
+        if session_started:
+            if UserCommandParser.force_flag not in flags:
+                error_to_show = "A session has already been started. In order to modify the Spark configura" \
+                                "tion, please provide the '-f' flag at the beginning of the config magic:\n" \
+                                "\te.g. `%config -f {}`\n\nNote that this will kill the current session and" \
+                                " will create a new one with the configuration provided. All previously run " \
+                                "commands in the session will be lost."
+                code_to_run = ""
+            else:
+                begin_action = Constants.delete_session_action
+                end_action = Constants.start_session_action
+                code_to_run = "%spark config {}".format(command)
+        else:
+            code_to_run = "%spark config {}".format(command)
+
+        return code_to_run, error_to_show, begin_action, end_action, deletes_session
+
+
+class SparkTransformer(UserCodeTransformerBase):
+    def get_code_to_execute(self, session_started, connection_string, flags, command):
+        error_to_show = None
+        code_to_run = "%%spark\n{}".format(command)
+        begin_action = Constants.start_session_action
+        end_action = Constants.do_nothing_action
+        deletes_session = False
+
+        return code_to_run, error_to_show, begin_action, end_action, deletes_session
+
+
+class SqlTransformer(UserCodeTransformerBase):
+    def get_code_to_execute(self, session_started, connection_string, flags, command):
+        error_to_show = None
+        code_to_run = "%%spark -c sql\n{}".format(command)
+        begin_action = Constants.start_session_action
+        end_action = Constants.do_nothing_action
+        deletes_session = False
+
+        return code_to_run, error_to_show, begin_action, end_action, deletes_session
+
+
+class HiveTransformer(UserCodeTransformerBase):
+    def get_code_to_execute(self, session_started, connection_string, flags, command):
+        error_to_show = None
+        code_to_run = "%%spark -c hive\n{}".format(command)
+        begin_action = Constants.start_session_action
+        end_action = Constants.do_nothing_action
+        deletes_session = False
+
+        return code_to_run, error_to_show, begin_action, end_action, deletes_session
+
+
+class InfoTransformer(UserCodeTransformerBase):
+    def get_code_to_execute(self, session_started, connection_string, flags, command):
+        error_to_show = None
+        code_to_run = "%spark info {}".format(connection_string)
+        begin_action = Constants.do_nothing_action
+        end_action = Constants.do_nothing_action
+        deletes_session = False
+
+        return code_to_run, error_to_show, begin_action, end_action, deletes_session
+
+
+class DeleteSessionTransformer(UserCodeTransformerBase):
+    def get_code_to_execute(self, session_started, connection_string, flags, command):
+        error_to_show = None
+        begin_action = Constants.do_nothing_action
+        end_action = Constants.do_nothing_action
+        deletes_session = False
+
+        if UserCommandParser.force_flag not in flags:
+            error_to_show = "The session you are trying to delete could be this kernel's session. In order " \
+                            "to delete this session, please provide the '-f' flag at the beginning of the " \
+                            "delete magic:\n\te.g. `%delete -f id`\n\nAll previously run commands in the " \
+                            "session will be lost."
+            code_to_run = ""
+        else:
+            deletes_session = True
+            code_to_run = "%spark delete {} {}".format(connection_string, command)
+
+        return code_to_run, error_to_show, begin_action, end_action, deletes_session
+
+
+class CleanUpTransformer(UserCodeTransformerBase):
+    def get_code_to_execute(self, session_started, connection_string, flags, command):
+        error_to_show = None
+        begin_action = Constants.do_nothing_action
+        end_action = Constants.do_nothing_action
+        deletes_session = False
+
+        if UserCommandParser.force_flag not in flags:
+            error_to_show = "The sessions you are trying to delete could be this kernel's session or other " \
+                            "people's sessions. In order to delete them, please provide the '-f' flag at the " \
+                            "beginning of the cleanup magic:\n\te.g. `%cleanup -f`\n\nAll previously run " \
+                            "commands in the sessions will be lost."
+            code_to_run = ""
+        else:
+            deletes_session = True
+            code_to_run = "%spark cleanup {}".format(connection_string)
+
+        return code_to_run, error_to_show, begin_action, end_action, deletes_session
+
+
+class LogsTransformer(UserCodeTransformerBase):
+    def get_code_to_execute(self, session_started, connection_string, flags, command):
+        error_to_show = None
+        begin_action = Constants.do_nothing_action
+        end_action = Constants.do_nothing_action
+        deletes_session = False
+
+        if session_started:
+            code_to_run = "%spark logs"
+        else:
+            code_to_run = "print('No logs yet.')"
+
+        return code_to_run, error_to_show, begin_action, end_action, deletes_session

--- a/remotespark/wrapperkernel/codetransformers.py
+++ b/remotespark/wrapperkernel/codetransformers.py
@@ -2,19 +2,18 @@
 # Distributed under the terms of the Modified BSD License.
 
 from remotespark.utils.constants import Constants
-from remotespark.wrapperkernel.usercommandparser import UserCommandParser
 
 
 class UserCodeTransformerBase(object):
     def __init__(self, subcommand):
         self.name = subcommand
 
-    def get_code_to_execute(self, session_started, connection_string, flags, command):
+    def get_code_to_execute(self, session_started, connection_string, force, output_var, command):
         raise NotImplementedError()
 
 
 class NotSupportedTransformer(UserCodeTransformerBase):
-    def get_code_to_execute(self, session_started, connection_string, flags, command):
+    def get_code_to_execute(self, session_started, connection_string, force, output_var, command):
         error_to_show = "Magic '{}' not supported.".format(self.name)
         code_to_run = ""
         begin_action = Constants.do_nothing_action
@@ -25,14 +24,14 @@ class NotSupportedTransformer(UserCodeTransformerBase):
 
 
 class ConfigTransformer(UserCodeTransformerBase):
-    def get_code_to_execute(self, session_started, connection_string, flags, command):
+    def get_code_to_execute(self, session_started, connection_string, force, output_var, command):
         error_to_show = None
         begin_action = Constants.do_nothing_action
         end_action = Constants.do_nothing_action
         deletes_session = False
 
         if session_started:
-            if UserCommandParser.force_flag not in flags:
+            if not force:
                 error_to_show = "A session has already been started. In order to modify the Spark configura" \
                                 "tion, please provide the '-f' flag at the beginning of the config magic:\n" \
                                 "\te.g. `%config -f {}`\n\nNote that this will kill the current session and" \
@@ -50,7 +49,7 @@ class ConfigTransformer(UserCodeTransformerBase):
 
 
 class SparkTransformer(UserCodeTransformerBase):
-    def get_code_to_execute(self, session_started, connection_string, flags, command):
+    def get_code_to_execute(self, session_started, connection_string, force, output_var, command):
         error_to_show = None
         code_to_run = "%%spark\n{}".format(command)
         begin_action = Constants.start_session_action
@@ -61,7 +60,7 @@ class SparkTransformer(UserCodeTransformerBase):
 
 
 class SqlTransformer(UserCodeTransformerBase):
-    def get_code_to_execute(self, session_started, connection_string, flags, command):
+    def get_code_to_execute(self, session_started, connection_string, force, output_var, command):
         error_to_show = None
         code_to_run = "%%spark -c sql\n{}".format(command)
         begin_action = Constants.start_session_action
@@ -72,7 +71,7 @@ class SqlTransformer(UserCodeTransformerBase):
 
 
 class HiveTransformer(UserCodeTransformerBase):
-    def get_code_to_execute(self, session_started, connection_string, flags, command):
+    def get_code_to_execute(self, session_started, connection_string, force, output_var, command):
         error_to_show = None
         code_to_run = "%%spark -c hive\n{}".format(command)
         begin_action = Constants.start_session_action
@@ -83,7 +82,7 @@ class HiveTransformer(UserCodeTransformerBase):
 
 
 class InfoTransformer(UserCodeTransformerBase):
-    def get_code_to_execute(self, session_started, connection_string, flags, command):
+    def get_code_to_execute(self, session_started, connection_string, force, output_var, command):
         error_to_show = None
         code_to_run = "%spark info {}".format(connection_string)
         begin_action = Constants.do_nothing_action
@@ -94,13 +93,13 @@ class InfoTransformer(UserCodeTransformerBase):
 
 
 class DeleteSessionTransformer(UserCodeTransformerBase):
-    def get_code_to_execute(self, session_started, connection_string, flags, command):
+    def get_code_to_execute(self, session_started, connection_string, force, output_var, command):
         error_to_show = None
         begin_action = Constants.do_nothing_action
         end_action = Constants.do_nothing_action
         deletes_session = False
 
-        if UserCommandParser.force_flag not in flags:
+        if not force:
             error_to_show = "The session you are trying to delete could be this kernel's session. In order " \
                             "to delete this session, please provide the '-f' flag at the beginning of the " \
                             "delete magic:\n\te.g. `%delete -f id`\n\nAll previously run commands in the " \
@@ -114,13 +113,13 @@ class DeleteSessionTransformer(UserCodeTransformerBase):
 
 
 class CleanUpTransformer(UserCodeTransformerBase):
-    def get_code_to_execute(self, session_started, connection_string, flags, command):
+    def get_code_to_execute(self, session_started, connection_string, force, output_var, command):
         error_to_show = None
         begin_action = Constants.do_nothing_action
         end_action = Constants.do_nothing_action
         deletes_session = False
 
-        if UserCommandParser.force_flag not in flags:
+        if not force:
             error_to_show = "The sessions you are trying to delete could be this kernel's session or other " \
                             "people's sessions. In order to delete them, please provide the '-f' flag at the " \
                             "beginning of the cleanup magic:\n\te.g. `%cleanup -f`\n\nAll previously run " \
@@ -134,7 +133,7 @@ class CleanUpTransformer(UserCodeTransformerBase):
 
 
 class LogsTransformer(UserCodeTransformerBase):
-    def get_code_to_execute(self, session_started, connection_string, flags, command):
+    def get_code_to_execute(self, session_started, connection_string, force, output_var, command):
         error_to_show = None
         begin_action = Constants.do_nothing_action
         end_action = Constants.do_nothing_action

--- a/remotespark/wrapperkernel/codetransformers.py
+++ b/remotespark/wrapperkernel/codetransformers.py
@@ -67,10 +67,14 @@ class ContextOutputVariableTransformer(UserCodeTransformerBase):
 
     def get_code_to_execute(self, session_started, connection_string, force, output_var, command):
         error_to_show = None
-        code_to_run = "%%spark -c {}\n{}".format(self.context_name, command)
         begin_action = Constants.start_session_action
         end_action = Constants.do_nothing_action
         deletes_session = False
+
+        if output_var is None:
+            code_to_run = "%%spark -c {}\n{}".format(self.context_name, command)
+        else:
+            code_to_run = "%%spark -c {} -o {}\n{}".format(self.context_name, output_var, command)
 
         return code_to_run, error_to_show, begin_action, end_action, deletes_session
 

--- a/remotespark/wrapperkernel/sparkkernelbase.py
+++ b/remotespark/wrapperkernel/sparkkernelbase.py
@@ -67,7 +67,7 @@ class SparkKernelBase(IPythonKernel):
                 transformer.get_code_to_execute(self._session_started, self.connection_string,
                                                 force, output_var, command)
         except SyntaxError as se:
-            self._show_user_error(se)
+            self._show_user_error("{}".format(se))
         else:
             # Execute instructions
             if error_to_show is not None:

--- a/remotespark/wrapperkernel/sparkkernelbase.py
+++ b/remotespark/wrapperkernel/sparkkernelbase.py
@@ -7,20 +7,11 @@ from remotespark.utils.ipythondisplay import IpythonDisplay
 import remotespark.utils.configuration as conf
 from remotespark.utils.log import Log
 from remotespark.utils.utils import get_connection_string
+from .usercommandparser import UserCommandParser
+from .codetransformers import *
 
 
 class SparkKernelBase(IPythonKernel):
-    run_command = "run"
-    config_command = "config"
-    sql_command = "sql"
-    hive_command = "hive"
-    info_command = "info"
-    delete_command = "delete"
-    clean_up_command = "cleanup"
-    logs_command = "logs"
-
-    force_flag = "f"
-
     def __init__(self, implementation, implementation_version, language, language_version, language_info,
                  kernel_conf_name, session_language, client_name, **kwargs):
         # Required by Jupyter - Override
@@ -62,78 +53,72 @@ class SparkKernelBase(IPythonKernel):
         if self._fatal_error is not None:
             self._repeat_fatal_error()
 
-        subcommand, flags, code_to_run = self._parse_user_command(code)
+        # Parse command
+        subcommand, flags, command = UserCommandParser.parse_user_command(code)
 
-        if subcommand == self.run_command:
-            code_to_run = "%%spark\n{}".format(code_to_run)
-            return self._run_starting_session(code_to_run, silent, store_history, user_expressions, allow_stdin)
-        elif subcommand == self.sql_command:
-            code_to_run = "%%spark -c sql\n{}".format(code_to_run)
-            return self._run_starting_session(code_to_run, silent, store_history, user_expressions, allow_stdin)
-        elif subcommand == self.hive_command:
-            code_to_run = "%%spark -c hive\n{}".format(code_to_run)
-            return self._run_starting_session(code_to_run, silent, store_history, user_expressions, allow_stdin)
-        elif subcommand == self.config_command:
-            restart_session = False
+        # Get transformer
+        transformer = self._get_code_transformer(subcommand)
 
-            if self._session_started:
-                if self.force_flag not in flags:
-                    self._show_user_error("A session has already been started. In order to modify the Spark configura"
-                                          "tion, please provide the '-f' flag at the beginning of the config magic:\n"
-                                          "\te.g. `%config -f {}`\n\nNote that this will kill the current session and"
-                                          " will create a new one with the configuration provided. All previously run "
-                                          "commands in the session will be lost.")
-                    code_to_run = ""
-                else:
-                    restart_session = True
-                    code_to_run = "%spark config {}".format(code_to_run)
-            else:
-                code_to_run = "%spark config {}".format(code_to_run)
+        # Get instructions
+        code_to_run, error_to_show, begin_action, end_action, deletes_session = \
+            transformer.get_code_to_execute(self._session_started, self.connection_string, flags, command)
 
-            return self._run_restarting_session(code_to_run, silent, store_history, user_expressions, allow_stdin,
-                                                restart_session)
-        elif subcommand == self.info_command:
-            code_to_run = "%spark info {}".format(self.connection_string)
-            return self._run_without_session(code_to_run, silent, store_history, user_expressions, allow_stdin)
-        elif subcommand == self.delete_command:
-            if self.force_flag not in flags:
-                self._show_user_error("The session you are trying to delete could be this kernel's session. In order "
-                                      "to delete this session, please provide the '-f' flag at the beginning of the "
-                                      "delete magic:\n\te.g. `%delete -f id`\n\nAll previously run commands in the "
-                                      "session will be lost.")
-                code_to_run = ""
-            else:
-                self._session_started = False
-                code_to_run = "%spark delete {} {}".format(self.connection_string, code_to_run)
-
-            return self._run_without_session(code_to_run, silent, store_history, user_expressions, allow_stdin)
-        elif subcommand == self.clean_up_command:
-            if self.force_flag not in flags:
-                self._show_user_error("The sessions you are trying to delete could be this kernel's session or other "
-                                      "people's sessions. In order to delete them, please provide the '-f' flag at the "
-                                      "beginning of the cleanup magic:\n\te.g. `%cleanup -f`\n\nAll previously run "
-                                      "commands in the sessions will be lost.")
-                code_to_run = ""
-            else:
-                self._session_started = False
-                code_to_run = "%spark cleanup {}".format(self.connection_string)
-
-            return self._run_without_session(code_to_run, silent, store_history, user_expressions, allow_stdin)
-        elif subcommand == self.logs_command:
-            if self._session_started:
-                code_to_run = "%spark logs"
-            else:
-                code_to_run = "print('No logs yet.')"
+        # Execute instructions
+        if error_to_show is not None:
+            self._show_user_error(error_to_show)
             return self._execute_cell(code_to_run, silent, store_history, user_expressions, allow_stdin)
+
+        if begin_action == Constants.delete_session_action:
+            self._delete_session()
+        elif begin_action == Constants.start_session_action:
+            self._start_session()
+        elif begin_action == Constants.do_nothing_action:
+            pass
         else:
-            self._show_user_error("Magic '{}' not supported.".format(subcommand))
-            return self._run_without_session("", silent, store_history, user_expressions, allow_stdin)
+            raise ValueError("Begin action {} not supported.".format(begin_action))
+
+        res = self._execute_cell(code_to_run, silent, store_history, user_expressions, allow_stdin)
+
+        if end_action == Constants.delete_session_action:
+            self._delete_session()
+        elif end_action == Constants.start_session_action:
+            self._start_session()
+        elif end_action == Constants.do_nothing_action:
+            pass
+        else:
+            raise ValueError("End action {} not supported.".format(end_action))
+
+        if deletes_session:
+            self._session_started = False
+
+        return res
 
     def do_shutdown(self, restart):
         # Cleanup
         self._delete_session()
 
         return self._do_shutdown_ipykernel(restart)
+
+    @staticmethod
+    def _get_code_transformer(subcommand):
+        if subcommand == UserCommandParser.run_command:
+            return SparkTransformer(subcommand)
+        elif subcommand == UserCommandParser.sql_command:
+            return SqlTransformer(subcommand)
+        elif subcommand == UserCommandParser.hive_command:
+            return HiveTransformer(subcommand)
+        elif subcommand == UserCommandParser.config_command:
+            return ConfigTransformer(subcommand)
+        elif subcommand == UserCommandParser.info_command:
+            return InfoTransformer(subcommand)
+        elif subcommand == UserCommandParser.delete_command:
+            return DeleteSessionTransformer(subcommand)
+        elif subcommand == UserCommandParser.clean_up_command:
+            return CleanUpTransformer(subcommand)
+        elif subcommand == UserCommandParser.logs_command:
+            return LogsTransformer(subcommand)
+        else:
+            return NotSupportedTransformer(subcommand)
 
     def _load_magics_extension(self):
         register_magics_code = "%load_ext remotespark"
@@ -165,74 +150,22 @@ ip.display_formatter.ipython_display_formatter.for_type_by_name('pandas.core.fra
             self._execute_cell_for_user(code, True, False)
             self._session_started = False
 
-    def _run_without_session(self, code, silent, store_history, user_expressions, allow_stdin):
-        return self._execute_cell(code, silent, store_history, user_expressions, allow_stdin)
-
-    def _run_starting_session(self, code, silent, store_history, user_expressions, allow_stdin):
-        self._start_session()
-        return self._execute_cell(code, silent, store_history, user_expressions, allow_stdin)
-
-    def _run_restarting_session(self, code, silent, store_history, user_expressions, allow_stdin, restart):
-        if restart:
-            self._delete_session()
-
-        res = self._execute_cell(code, silent, store_history, user_expressions, allow_stdin)
-
-        if restart:
-            self._start_session()
-
-        return res
-
     def _get_configuration(self):
         """Returns (username, password, url). If there is an error (missing configuration),
            returns False."""
         try:
             credentials = getattr(conf, 'kernel_' + self.kernel_conf_name + '_credentials')()
             ret = (credentials['username'], credentials['password'], credentials['url'])
+
             # The URL has to be set in the configuration.
             assert(ret[2])
+
             return ret
         except (KeyError, AssertionError):
             message = "Please set configuration for 'kernel_{}_credentials' to initialize Kernel".format(
                 self.kernel_conf_name)
             self._queue_fatal_error(message)
             return False
-
-    def _parse_user_command(self, code):
-        # Normalize 2 signs to 1
-        if code.startswith("%%"):
-            code = code[1:]
-
-        # When no magic, return run command
-        if not code.startswith("%"):
-            code = "%{} {}".format(self.run_command, code)
-
-        # Remove percentage sign
-        code = code[1:]
-
-        split_code = code.split(None, 1)
-        subcommand = split_code[0].lower()
-        flags = []
-        if len(split_code) > 1:
-            rest = split_code[1]
-        else:
-            rest = ""
-
-        # Get all flags
-        flag_split = rest.split(None, 1)
-        while len(flag_split) >= 1 and flag_split[0].startswith("-"):
-            if len(flag_split) >= 2:
-                flags.append(flag_split[0][1:].lower())
-                rest = flag_split[1]
-                flag_split = rest.split(None, 1)
-            if len(flag_split) == 1:
-                flags.append(flag_split[0][1:].lower())
-                flag_split = [""]
-
-        # flags to lower
-        flags = [i.lower() for i in flags]
-
-        return subcommand, flags, rest
 
     def _execute_cell(self, code, silent, store_history=True, user_expressions=None, allow_stdin=False,
                       shutdown_if_error=False, log_if_error=None):

--- a/remotespark/wrapperkernel/sparkkernelbase.py
+++ b/remotespark/wrapperkernel/sparkkernelbase.py
@@ -33,6 +33,8 @@ class SparkKernelBase(IPythonKernel):
         self._fatal_error = None
         self._ipython_display = IpythonDisplay()
 
+        self.user_command_parser = UserCommandParser()
+
         # Disable warnings for test env in HDI
         requests.packages.urllib3.disable_warnings()
 
@@ -54,14 +56,14 @@ class SparkKernelBase(IPythonKernel):
             self._repeat_fatal_error()
 
         # Parse command
-        subcommand, flags, command = UserCommandParser.parse_user_command(code)
+        subcommand, force, output_var, command = self.user_command_parser.parse_user_command(code)
 
         # Get transformer
         transformer = self._get_code_transformer(subcommand)
 
         # Get instructions
         code_to_run, error_to_show, begin_action, end_action, deletes_session = \
-            transformer.get_code_to_execute(self._session_started, self.connection_string, flags, command)
+            transformer.get_code_to_execute(self._session_started, self.connection_string, force, output_var, command)
 
         # Execute instructions
         if error_to_show is not None:

--- a/remotespark/wrapperkernel/usercommandparser.py
+++ b/remotespark/wrapperkernel/usercommandparser.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2015  aggftw@gmail.com
 # Distributed under the terms of the Modified BSD License.
+import argparse
 
 
 class UserCommandParser(object):
@@ -12,41 +13,63 @@ class UserCommandParser(object):
     clean_up_command = "cleanup"
     logs_command = "logs"
 
-    force_flag = "f"
+    def __init__(self):
+        """Code can have a magic or no magic specified (specified with %word sign). If no magic is specified, %run will
+        be added.
 
-    @staticmethod
-    def parse_user_command(code):
+        First line of code needs to have all possible arguments. All arguments need to be at the end of the line.
+        i.e.
+            valid:      %delete 9 -f
+            invalid:    %delete -f 9
+        We could have a choice between option above or having to specify value for -f, like:
+            valid:      %delete -f True 9
+            invalid:    %delete -f 9
+        I went with the first option above since it's less verbose.
+
+        Anything in the first line that ends up in ns.command below will be merged with the subsequent lines.
+        """
+        parser = argparse.ArgumentParser(prog="SparkCommandParser")
+        parser.add_argument("subcommand", type=str, nargs=1)
+        parser.add_argument("-o", "--output", type=str, default=None)
+        parser.add_argument("-f", "--force", default=False, nargs="?", const=True, type=bool)
+        parser.add_argument("command", type=str, default=[], nargs="*")
+
+        self.parser = parser
+
+    def parse_user_command(self, code):
+        # Get lines
+        lines = code.split("\n")
+        first_line = lines[0]
+        other_lines = "\n".join(lines[1:])
+
         # Normalize 2 signs to 1
-        if code.startswith("%%"):
-            code = code[1:]
+        if first_line.startswith("%%"):
+            first_line = first_line[1:]
 
-        # When no magic, return run command
-        if not code.startswith("%"):
-            code = "%{} {}".format(UserCommandParser.run_command, code)
+        # When no magic, add run command
+        if not first_line.startswith("%"):
+            first_line = "%{} {}".format(UserCommandParser.run_command, code)
 
         # Remove percentage sign
-        code = code[1:]
+        first_line = first_line[1:]
 
-        split_code = code.split(None, 1)
-        subcommand = split_code[0].lower()
-        flags = []
-        if len(split_code) > 1:
-            rest = split_code[1]
+        try:
+            ns = self.parser.parse_args(first_line.split())
+        except SystemExit:
+            usage = self.parser.format_usage()
+            raise SyntaxError("Could not parse cell code to send to Spark. Please specify all flags at the end.\n{}"
+                              .format(usage))
         else:
-            rest = ""
+            command = other_lines
 
-        # Get all flags
-        flag_split = rest.split(None, 1)
-        while len(flag_split) >= 1 and flag_split[0].startswith("-"):
-            if len(flag_split) >= 2:
-                flags.append(flag_split[0][1:].lower())
-                rest = flag_split[1]
-                flag_split = rest.split(None, 1)
-            if len(flag_split) == 1:
-                flags.append(flag_split[0][1:].lower())
-                flag_split = [""]
+            if len(ns.command) > 0:
+                first_line_command = " ".join(ns.command)
 
-        # flags to lower
-        flags = [i.lower() for i in flags]
+                if command != "":
+                    command = "{}\n{}".format(first_line_command, command)
+                else:
+                    command = first_line_command
+            else:
+                command = "\n".join(lines[1:])
 
-        return subcommand, flags, rest
+            return ns.subcommand[0].lower(), ns.force, ns.output, command

--- a/remotespark/wrapperkernel/usercommandparser.py
+++ b/remotespark/wrapperkernel/usercommandparser.py
@@ -1,0 +1,52 @@
+# Copyright (c) 2015  aggftw@gmail.com
+# Distributed under the terms of the Modified BSD License.
+
+
+class UserCommandParser(object):
+    run_command = "run"
+    config_command = "config"
+    sql_command = "sql"
+    hive_command = "hive"
+    info_command = "info"
+    delete_command = "delete"
+    clean_up_command = "cleanup"
+    logs_command = "logs"
+
+    force_flag = "f"
+
+    @staticmethod
+    def parse_user_command(code):
+        # Normalize 2 signs to 1
+        if code.startswith("%%"):
+            code = code[1:]
+
+        # When no magic, return run command
+        if not code.startswith("%"):
+            code = "%{} {}".format(UserCommandParser.run_command, code)
+
+        # Remove percentage sign
+        code = code[1:]
+
+        split_code = code.split(None, 1)
+        subcommand = split_code[0].lower()
+        flags = []
+        if len(split_code) > 1:
+            rest = split_code[1]
+        else:
+            rest = ""
+
+        # Get all flags
+        flag_split = rest.split(None, 1)
+        while len(flag_split) >= 1 and flag_split[0].startswith("-"):
+            if len(flag_split) >= 2:
+                flags.append(flag_split[0][1:].lower())
+                rest = flag_split[1]
+                flag_split = rest.split(None, 1)
+            if len(flag_split) == 1:
+                flags.append(flag_split[0][1:].lower())
+                flag_split = [""]
+
+        # flags to lower
+        flags = [i.lower() for i in flags]
+
+        return subcommand, flags, rest

--- a/remotespark/wrapperkernel/usercommandparser.py
+++ b/remotespark/wrapperkernel/usercommandparser.py
@@ -24,7 +24,8 @@ class UserCommandParser(object):
         We could have a choice between option above or having to specify value for -f, like:
             valid:      %delete -f True 9
             invalid:    %delete -f 9
-        I went with the first option above since it's less verbose.
+        I went with the first option above since it's less verbose. For second option:
+            parser.add_argument("-f", "--force", default=False, type=bool)
 
         Anything in the first line that ends up in ns.command below will be merged with the subsequent lines.
         """

--- a/tests/test_codetransformers.py
+++ b/tests/test_codetransformers.py
@@ -1,0 +1,216 @@
+from mock import MagicMock, call
+from nose.tools import with_setup, raises, assert_equals
+
+from remotespark.wrapperkernel.codetransformers import *
+from remotespark.utils.constants import Constants
+
+
+code = None
+conn = None
+
+
+def _setup():
+    global code, conn
+
+    code = "code"
+    conn = "conn"
+
+
+def _teardown():
+    pass
+
+
+@with_setup(_setup, _teardown)
+def test_not_supported_transformer():
+    transformer = NotSupportedTransformer("command")
+
+    code_to_run, error_to_show, begin_action, end_action, deletes_session = \
+        transformer.get_code_to_execute(True, conn, False, None, code)
+
+    assert_equals("", code_to_run)
+    assert_equals("Magic 'command' not supported.", error_to_show)
+    assert_equals(begin_action, Constants.do_nothing_action)
+    assert_equals(end_action, Constants.do_nothing_action)
+    assert_equals(deletes_session, False)
+
+
+@with_setup(_setup, _teardown)
+def test_config_transformer_no_session():
+    transformer = ConfigTransformer("command")
+
+    code_to_run, error_to_show, begin_action, end_action, deletes_session = \
+        transformer.get_code_to_execute(False, conn, False, None, code)
+
+    assert_equals("%spark config {}".format(code), code_to_run)
+    assert error_to_show is None
+    assert_equals(begin_action, Constants.do_nothing_action)
+    assert_equals(end_action, Constants.do_nothing_action)
+    assert_equals(deletes_session, False)
+
+
+@with_setup(_setup, _teardown)
+def test_config_transformer_session_no_flag():
+    transformer = ConfigTransformer("command")
+
+    code_to_run, error_to_show, begin_action, end_action, deletes_session = \
+        transformer.get_code_to_execute(True, conn, False, None, code)
+
+    assert_equals("", code_to_run)
+    assert error_to_show is not None
+    assert_equals(begin_action, Constants.do_nothing_action)
+    assert_equals(end_action, Constants.do_nothing_action)
+    assert_equals(deletes_session, False)
+
+
+@with_setup(_setup, _teardown)
+def test_config_transformer_session_flag():
+    transformer = ConfigTransformer("command")
+
+    code_to_run, error_to_show, begin_action, end_action, deletes_session = \
+        transformer.get_code_to_execute(True, conn, True, None, code)
+
+    assert_equals("%spark config {}".format(code), code_to_run)
+    assert error_to_show is None
+    assert_equals(begin_action, Constants.delete_session_action)
+    assert_equals(end_action, Constants.start_session_action)
+    assert_equals(deletes_session, False)
+
+
+@with_setup(_setup, _teardown)
+def test_spark_transformer():
+    transformer = SparkTransformer("command")
+
+    code_to_run, error_to_show, begin_action, end_action, deletes_session = \
+        transformer.get_code_to_execute(True, conn, False, None, code)
+
+    assert_equals("%%spark\n{}".format(code), code_to_run)
+    assert error_to_show is None
+    assert_equals(begin_action, Constants.start_session_action)
+    assert_equals(end_action, Constants.do_nothing_action)
+    assert_equals(deletes_session, False)
+
+
+@with_setup(_setup, _teardown)
+def test_sql_transformer():
+    transformer = SqlTransformer("command")
+
+    code_to_run, error_to_show, begin_action, end_action, deletes_session = \
+        transformer.get_code_to_execute(True, conn, False, None, code)
+
+    assert_equals("%%spark -c sql\n{}".format(code), code_to_run)
+    assert error_to_show is None
+    assert_equals(begin_action, Constants.start_session_action)
+    assert_equals(end_action, Constants.do_nothing_action)
+    assert_equals(deletes_session, False)
+
+
+@with_setup(_setup, _teardown)
+def test_hive_transformer():
+    transformer = HiveTransformer("command")
+
+    code_to_run, error_to_show, begin_action, end_action, deletes_session = \
+        transformer.get_code_to_execute(True, conn, False, None, code)
+
+    assert_equals("%%spark -c hive\n{}".format(code), code_to_run)
+    assert error_to_show is None
+    assert_equals(begin_action, Constants.start_session_action)
+    assert_equals(end_action, Constants.do_nothing_action)
+    assert_equals(deletes_session, False)
+
+
+@with_setup(_setup, _teardown)
+def test_info_transformer():
+    transformer = InfoTransformer("command")
+
+    code_to_run, error_to_show, begin_action, end_action, deletes_session = \
+        transformer.get_code_to_execute(True, conn, False, None, code)
+
+    assert_equals("%spark info {}".format(conn), code_to_run)
+    assert error_to_show is None
+    assert_equals(begin_action, Constants.do_nothing_action)
+    assert_equals(end_action, Constants.do_nothing_action)
+    assert_equals(deletes_session, False)
+
+
+@with_setup(_setup, _teardown)
+def test_delete_transformer_no_force():
+    transformer = DeleteSessionTransformer("command")
+
+    code_to_run, error_to_show, begin_action, end_action, deletes_session = \
+        transformer.get_code_to_execute(True, conn, False, None, code)
+
+    assert_equals("", code_to_run)
+    assert error_to_show is not None
+    assert_equals(begin_action, Constants.do_nothing_action)
+    assert_equals(end_action, Constants.do_nothing_action)
+    assert_equals(deletes_session, False)
+
+
+@with_setup(_setup, _teardown)
+def test_delete_transformer_force():
+    transformer = DeleteSessionTransformer("command")
+
+    code_to_run, error_to_show, begin_action, end_action, deletes_session = \
+        transformer.get_code_to_execute(True, conn, True, None, code)
+
+    assert_equals("%spark delete {} {}".format(conn, code), code_to_run)
+    assert error_to_show is None
+    assert_equals(begin_action, Constants.do_nothing_action)
+    assert_equals(end_action, Constants.do_nothing_action)
+    assert_equals(deletes_session, True)
+
+
+@with_setup(_setup, _teardown)
+def test_cleanup_transformer_no_force():
+    transformer = CleanUpTransformer("command")
+
+    code_to_run, error_to_show, begin_action, end_action, deletes_session = \
+        transformer.get_code_to_execute(True, conn, False, None, code)
+
+    assert_equals("", code_to_run)
+    assert error_to_show is not None
+    assert_equals(begin_action, Constants.do_nothing_action)
+    assert_equals(end_action, Constants.do_nothing_action)
+    assert_equals(deletes_session, False)
+
+
+@with_setup(_setup, _teardown)
+def test_cleanup_transformer_force():
+    transformer = CleanUpTransformer("command")
+
+    code_to_run, error_to_show, begin_action, end_action, deletes_session = \
+        transformer.get_code_to_execute(True, conn, True, None, code)
+
+    assert_equals("%spark cleanup {}".format(conn), code_to_run)
+    assert error_to_show is None
+    assert_equals(begin_action, Constants.do_nothing_action)
+    assert_equals(end_action, Constants.do_nothing_action)
+    assert_equals(deletes_session, True)
+
+
+@with_setup(_setup, _teardown)
+def test_logs_transformer_session():
+    transformer = LogsTransformer("command")
+
+    code_to_run, error_to_show, begin_action, end_action, deletes_session = \
+        transformer.get_code_to_execute(True, conn, False, None, code)
+
+    assert_equals("%spark logs", code_to_run)
+    assert error_to_show is None
+    assert_equals(begin_action, Constants.do_nothing_action)
+    assert_equals(end_action, Constants.do_nothing_action)
+    assert_equals(deletes_session, False)
+
+
+@with_setup(_setup, _teardown)
+def test_logs_transformer_no_session():
+    transformer = LogsTransformer("command")
+
+    code_to_run, error_to_show, begin_action, end_action, deletes_session = \
+        transformer.get_code_to_execute(False, conn, False, None, code)
+
+    assert_equals("print('No logs yet.')", code_to_run)
+    assert error_to_show is None
+    assert_equals(begin_action, Constants.do_nothing_action)
+    assert_equals(end_action, Constants.do_nothing_action)
+    assert_equals(deletes_session, False)

--- a/tests/test_codetransformers.py
+++ b/tests/test_codetransformers.py
@@ -1,5 +1,4 @@
-from mock import MagicMock, call
-from nose.tools import with_setup, raises, assert_equals
+from nose.tools import with_setup, assert_equals
 
 from remotespark.wrapperkernel.codetransformers import *
 from remotespark.utils.constants import Constants
@@ -98,6 +97,20 @@ def test_sql_transformer():
         transformer.get_code_to_execute(True, conn, False, None, code)
 
     assert_equals("%%spark -c sql\n{}".format(code), code_to_run)
+    assert error_to_show is None
+    assert_equals(begin_action, Constants.start_session_action)
+    assert_equals(end_action, Constants.do_nothing_action)
+    assert_equals(deletes_session, False)
+
+
+@with_setup(_setup, _teardown)
+def test_sql_transformer_output_var():
+    transformer = SqlTransformer("command")
+
+    code_to_run, error_to_show, begin_action, end_action, deletes_session = \
+        transformer.get_code_to_execute(True, conn, False, "my_var", code)
+
+    assert_equals("%%spark -c sql -o my_var\n{}".format(code), code_to_run)
     assert error_to_show is None
     assert_equals(begin_action, Constants.start_session_action)
     assert_equals(end_action, Constants.do_nothing_action)

--- a/tests/test_sparkkernelbase.py
+++ b/tests/test_sparkkernelbase.py
@@ -1,9 +1,9 @@
 from mock import MagicMock, call
 from nose.tools import with_setup, raises
 
-from remotespark.sparkkernelbase import SparkKernelBase
 import remotespark.utils.configuration as conf
 from remotespark.utils.utils import get_connection_string
+from remotespark.wrapperkernel.sparkkernelbase import SparkKernelBase
 
 kernel = None
 user_ev = "username"

--- a/tests/test_sparkkernelbase.py
+++ b/tests/test_sparkkernelbase.py
@@ -113,11 +113,13 @@ def test_delete_session():
 
 @with_setup(_setup, _teardown)
 def test_set_config():
-    def _check(prepend, _session_started=False, key_error_expected=False):
+    def _check(prepend, _session_started=False, key_error_expected=False, force=False):
         # Set up
         kernel._show_user_error = MagicMock(side_effect=KeyError)
-        properties = """{"extra": 2}"""
+        properties = '{"extra": 2}'
         code = prepend + properties
+        if force:
+            code = "{} -f".format(code)
         kernel._session_started = _session_started
         execute_cell_mock.reset_mock()
 
@@ -145,9 +147,9 @@ def test_set_config():
     _check("%config\n")
     _check("%%config ")
     _check("%%config\n")
-    _check("%config -f ")
+    _check("%config ", force=True)
     _check("%config ", True, True)
-    _check("%config -f ", True, False)
+    _check("%config ", True, False, force=True)
 
 
 @with_setup(_setup, _teardown)
@@ -191,7 +193,7 @@ def test_info():
 
 @with_setup(_setup, _teardown)
 def test_delete_force():
-    code = "%delete -f 9"
+    code = "%delete 9 -f"
     kernel._session_started = True
     user_error = MagicMock()
     kernel._show_user_error = user_error

--- a/tests/test_sparkkernelbase.py
+++ b/tests/test_sparkkernelbase.py
@@ -1,9 +1,11 @@
 from mock import MagicMock, call
-from nose.tools import with_setup, raises
+from nose.tools import with_setup
 
 import remotespark.utils.configuration as conf
 from remotespark.utils.utils import get_connection_string
 from remotespark.wrapperkernel.sparkkernelbase import SparkKernelBase
+from remotespark.wrapperkernel.usercommandparser import UserCommandParser
+from remotespark.wrapperkernel.codetransformers import *
 
 kernel = None
 user_ev = "username"
@@ -13,6 +15,7 @@ execute_cell_mock = None
 do_shutdown_mock = None
 conn_str = None
 ipython_display = None
+parser = None
 
 
 class TestSparkKernel(SparkKernelBase):
@@ -22,7 +25,7 @@ class TestSparkKernel(SparkKernelBase):
 
 
 def _setup():
-    global kernel, user_ev, pass_ev, url_ev, execute_cell_mock, do_shutdown_mock, conn_str, ipython_display
+    global kernel, user_ev, pass_ev, url_ev, execute_cell_mock, do_shutdown_mock, conn_str, ipython_display, parser
 
     usr = "u"
     pwd = "p"
@@ -41,6 +44,10 @@ def _setup():
     kernel._execute_cell_for_user = execute_cell_mock = MagicMock()
     kernel._do_shutdown_ipykernel = do_shutdown_mock = MagicMock()
     kernel._ipython_display = ipython_display = MagicMock()
+
+    parser = MagicMock()
+    parser.parse_user_command.return_value = (UserCommandParser.run_command, False, None, "my code")
+    kernel.user_command_parser = parser
 
 
 def _teardown():
@@ -76,7 +83,7 @@ def test_get_config_not_set():
 
 
 @with_setup(_setup, _teardown)
-def test_get_config_not_set():
+def test_get_config_not_set_empty_strings():
     conf.override_all({conf.kernel_python_credentials.__name__: {user_ev: '', pass_ev: '', url_ev: ''}})
     kernel._get_configuration()
     assert kernel._fatal_error
@@ -112,161 +119,255 @@ def test_delete_session():
 
 
 @with_setup(_setup, _teardown)
-def test_set_config():
-    def _check(prepend, _session_started=False, key_error_expected=False, force=False):
-        # Set up
-        kernel._show_user_error = MagicMock(side_effect=KeyError)
-        properties = '{"extra": 2}'
-        code = prepend + properties
-        if force:
-            code = "{} -f".format(code)
-        kernel._session_started = _session_started
-        execute_cell_mock.reset_mock()
-
-        # Call method
-        try:
-            kernel.do_execute(code, False)
-        except KeyError:
-            if not key_error_expected:
-                assert False
-
-            # When exception is expected, nothing to check
-            return
-
-        assert _session_started == kernel._session_started
-        assert call("%spark config {}".format(properties), False, True, None, False) \
-            in execute_cell_mock.mock_calls
-
-        if _session_started and not key_error_expected:
-            # This means -f must be present, so check that a restart happened
-            assert call("%spark cleanup", True, False) in execute_cell_mock.mock_calls
-            assert call("%spark add TestKernel python {} skip".format(conn_str), True, False, None, False) \
-                in execute_cell_mock.mock_calls
-
-    _check("%config ")
-    _check("%config\n")
-    _check("%%config ")
-    _check("%%config\n")
-    _check("%config ", force=True)
-    _check("%config ", True, True)
-    _check("%config ", True, False, force=True)
+def test_returns_right_transformer():
+    assert type(kernel._get_code_transformer(UserCommandParser.run_command)) is SparkTransformer
+    assert type(kernel._get_code_transformer(UserCommandParser.sql_command)) is SqlTransformer
+    assert type(kernel._get_code_transformer(UserCommandParser.hive_command)) is HiveTransformer
+    assert type(kernel._get_code_transformer(UserCommandParser.config_command)) is ConfigTransformer
+    assert type(kernel._get_code_transformer(UserCommandParser.info_command)) is InfoTransformer
+    assert type(kernel._get_code_transformer(UserCommandParser.delete_command)) is DeleteSessionTransformer
+    assert type(kernel._get_code_transformer(UserCommandParser.clean_up_command)) is CleanUpTransformer
+    assert type(kernel._get_code_transformer(UserCommandParser.logs_command)) is LogsTransformer
+    assert type(kernel._get_code_transformer("whatever")) is NotSupportedTransformer
 
 
 @with_setup(_setup, _teardown)
-def test_do_execute_initializes_magics_if_not_run():
-    code = "code"
+def test_instructions_from_parser_are_passed_to_transformer():
+    code_to_run = "my code"
 
-    # Call method
-    assert not kernel._session_started
-    kernel.do_execute(code, False)
+    transformer = MagicMock()
+    transformer.get_code_to_execute = MagicMock(side_effect=SyntaxError)
+    kernel._get_code_transformer = MagicMock(return_value=transformer)
+    parser.parse_user_command.return_value = (UserCommandParser.run_command, False, None, code_to_run)
 
-    # Assertions
+    kernel._session_started = True
+
+    kernel._show_user_error = MagicMock()
+
+    # Execute
+    kernel.do_execute(code_to_run, False)
+
+    # Assert
+    transformer.get_code_to_execute.assert_called_with(True, kernel.connection_string, False, None, code_to_run)
+    kernel._show_user_error.assert_called_with("None")
+    assert call("", False, True, None, False) in execute_cell_mock.mock_calls
+
+
+@with_setup(_setup, _teardown)
+def test_instructions_from_transformer_are_executed_code():
+    code_to_run = "my code"
+    error_to_show = None
+    begin_action = Constants.do_nothing_action
+    end_action = Constants.do_nothing_action
+    deletes_session = False
+
+    transformer = MagicMock()
+    transformer.get_code_to_execute.return_value = (code_to_run, error_to_show, begin_action, end_action,
+                                                    deletes_session)
+    kernel._get_code_transformer = MagicMock(return_value=transformer)
+    kernel._show_user_error = MagicMock()
+    kernel._start_session = MagicMock()
+    kernel._delete_session = MagicMock()
+
+    kernel._session_started = True
+
+    # Execute
+    kernel.do_execute(code_to_run, False)
+
+    # Assert
+    assert not kernel._show_user_error.called
+    assert call(code_to_run, False, True, None, False) in execute_cell_mock.mock_calls
+    assert not kernel._start_session.called
+    assert not kernel._delete_session.called
     assert kernel._session_started
-    assert call("%spark add TestKernel python {} skip"
-                .format(conn_str), True, False, None, False) in execute_cell_mock.mock_calls
-    assert call("%%spark\n{}".format(code), False, True, None, False) in execute_cell_mock.mock_calls
 
 
 @with_setup(_setup, _teardown)
-@raises(KeyError)
-def test_magic_not_supported():
-    # Set up
-    code = "%alex some spark code"
+def test_instructions_from_transformer_are_executed_error():
+    code_to_run = ""
+    error_to_show = "error!"
+    begin_action = Constants.do_nothing_action
+    end_action = Constants.do_nothing_action
+    deletes_session = False
+
+    transformer = MagicMock()
+    transformer.get_code_to_execute.return_value = (code_to_run, error_to_show, begin_action, end_action,
+                                                    deletes_session)
+    kernel._get_code_transformer = MagicMock(return_value=transformer)
+    kernel._show_user_error = MagicMock()
+    kernel._start_session = MagicMock()
+    kernel._delete_session = MagicMock()
+
     kernel._session_started = True
-    kernel._show_user_error = MagicMock(side_effect=KeyError)
 
-    # Call method
-    kernel.do_execute(code, False)
+    # Execute
+    kernel.do_execute(code_to_run, False)
 
-
-@with_setup(_setup, _teardown)
-def test_info():
-    code = "%info"
-
-    # Call method
-    kernel.do_execute(code, False)
-
-    # Assertions
-    assert not kernel._session_started
-    assert call("%spark info {}".format(conn_str), False, True, None, False) in execute_cell_mock.mock_calls
-
-
-@with_setup(_setup, _teardown)
-def test_delete_force():
-    code = "%delete 9 -f"
-    kernel._session_started = True
-    user_error = MagicMock()
-    kernel._show_user_error = user_error
-
-    # Call method
-    kernel.do_execute(code, False)
-
-    # Assertions
-    assert not kernel._session_started
-    assert call("%spark delete {} 9".format(conn_str), False, True, None, False) in execute_cell_mock.mock_calls
-    assert len(user_error.mock_calls) == 0
-
-
-@with_setup(_setup, _teardown)
-def test_delete_not_force():
-    code = "%delete 9"
-    kernel._session_started = True
-    user_error = MagicMock()
-    kernel._show_user_error = user_error
-
-    # Call method
-    kernel.do_execute(code, False)
-
-    # Assertions
+    # Assert
+    kernel._show_user_error.assert_called_with(error_to_show)
+    assert call(code_to_run, False, True, None, False) in execute_cell_mock.mock_calls
+    assert not kernel._start_session.called
+    assert not kernel._delete_session.called
     assert kernel._session_started
-    assert not call("%spark delete {} 9".format(conn_str), False, True, None, False) in execute_cell_mock.mock_calls
-    assert len(user_error.mock_calls) == 1
 
 
 @with_setup(_setup, _teardown)
-def test_cleanup_force():
-    code = "%cleanup -f"
+def test_instructions_from_transformer_are_executed_deletes_session():
+    code_to_run = "my code"
+    error_to_show = None
+    begin_action = Constants.do_nothing_action
+    end_action = Constants.do_nothing_action
+    deletes_session = True
+
+    transformer = MagicMock()
+    transformer.get_code_to_execute.return_value = (code_to_run, error_to_show, begin_action, end_action,
+                                                    deletes_session)
+    kernel._get_code_transformer = MagicMock(return_value=transformer)
+    kernel._show_user_error = MagicMock()
+    kernel._start_session = MagicMock()
+    kernel._delete_session = MagicMock()
+
     kernel._session_started = True
-    user_error = MagicMock()
-    kernel._show_user_error = user_error
 
-    # Call method
-    kernel.do_execute(code, False)
+    # Execute
+    kernel.do_execute(code_to_run, False)
 
-    # Assertions
+    # Assert
+    assert not kernel._show_user_error.called
+    assert call(code_to_run, False, True, None, False) in execute_cell_mock.mock_calls
+    assert not kernel._start_session.called
+    assert not kernel._delete_session.called
     assert not kernel._session_started
-    assert call("%spark cleanup {}".format(conn_str), False, True, None, False) in execute_cell_mock.mock_calls
-    assert len(user_error.mock_calls) == 0
 
 
 @with_setup(_setup, _teardown)
-def test_cleanup_not_force():
-    code = "%cleanup"
-    kernel._session_started = True
-    user_error = MagicMock()
-    kernel._show_user_error = user_error
+def test_instructions_from_transformer_are_executed_begin_start():
+    code_to_run = "my code"
+    error_to_show = None
+    begin_action = Constants.start_session_action
+    end_action = Constants.do_nothing_action
+    deletes_session = False
 
-    # Call method
-    kernel.do_execute(code, False)
+    transformer = MagicMock()
+    transformer.get_code_to_execute.return_value = (code_to_run, error_to_show, begin_action, end_action,
+                                                    deletes_session)
+    kernel._get_code_transformer = MagicMock(return_value=transformer)
+    kernel._show_user_error = MagicMock()
+    kernel._start_session = MagicMock()
+    kernel._delete_session = MagicMock()
 
-    # Assertions
-    assert kernel._session_started
-    assert not call("%spark cleanup {}".format(conn_str), False, True, None, False) in execute_cell_mock.mock_calls
-    assert len(user_error.mock_calls) == 1
+    # Execute
+    kernel.do_execute(code_to_run, False)
+
+    # Assert
+    assert not kernel._show_user_error.called
+    assert call(code_to_run, False, True, None, False) in execute_cell_mock.mock_calls
+    kernel._start_session.assert_called_with()
+    assert not kernel._delete_session.called
 
 
 @with_setup(_setup, _teardown)
-def test_call_spark():
-    # Set up
-    code = "some spark code"
-    kernel._session_started = True
+def test_instructions_from_transformer_are_executed_begin_delete():
+    code_to_run = "my code"
+    error_to_show = None
+    begin_action = Constants.delete_session_action
+    end_action = Constants.do_nothing_action
+    deletes_session = False
 
-    # Call method
-    kernel.do_execute(code, False)
+    transformer = MagicMock()
+    transformer.get_code_to_execute.return_value = (code_to_run, error_to_show, begin_action, end_action,
+                                                    deletes_session)
+    kernel._get_code_transformer = MagicMock(return_value=transformer)
+    kernel._show_user_error = MagicMock()
+    kernel._start_session = MagicMock()
+    kernel._delete_session = MagicMock()
 
-    # Assertions
-    assert kernel._session_started
-    execute_cell_mock.assert_called_once_with("%%spark\n{}".format(code), False, True, None, False)
+    # Execute
+    kernel.do_execute(code_to_run, False)
+
+    # Assert
+    assert not kernel._show_user_error.called
+    assert call(code_to_run, False, True, None, False) in execute_cell_mock.mock_calls
+    assert not kernel._start_session.called
+    kernel._delete_session.assert_called_with()
+
+
+@with_setup(_setup, _teardown)
+def test_instructions_from_transformer_are_executed_end_start():
+    code_to_run = "my code"
+    error_to_show = None
+    begin_action = Constants.do_nothing_action
+    end_action = Constants.start_session_action
+    deletes_session = False
+
+    transformer = MagicMock()
+    transformer.get_code_to_execute.return_value = (code_to_run, error_to_show, begin_action, end_action,
+                                                    deletes_session)
+    kernel._get_code_transformer = MagicMock(return_value=transformer)
+    kernel._show_user_error = MagicMock()
+    kernel._start_session = MagicMock()
+    kernel._delete_session = MagicMock()
+
+    # Execute
+    kernel.do_execute(code_to_run, False)
+
+    # Assert
+    assert not kernel._show_user_error.called
+    assert call(code_to_run, False, True, None, False) in execute_cell_mock.mock_calls
+    kernel._start_session.assert_called_with()
+    assert not kernel._delete_session.called
+
+
+@with_setup(_setup, _teardown)
+def test_instructions_from_transformer_are_executed_end_delete():
+    code_to_run = "my code"
+    error_to_show = None
+    begin_action = Constants.do_nothing_action
+    end_action = Constants.delete_session_action
+    deletes_session = False
+
+    transformer = MagicMock()
+    transformer.get_code_to_execute.return_value = (code_to_run, error_to_show, begin_action, end_action,
+                                                    deletes_session)
+    kernel._get_code_transformer = MagicMock(return_value=transformer)
+    kernel._show_user_error = MagicMock()
+    kernel._start_session = MagicMock()
+    kernel._delete_session = MagicMock()
+
+    # Execute
+    kernel.do_execute(code_to_run, False)
+
+    # Assert
+    assert not kernel._show_user_error.called
+    assert call(code_to_run, False, True, None, False) in execute_cell_mock.mock_calls
+    assert not kernel._start_session.called
+    kernel._delete_session.assert_called_with()
+
+
+@with_setup(_setup, _teardown)
+def test_instructions_from_transformer_are_executed_begin_start_end_delete():
+    code_to_run = "my code"
+    error_to_show = None
+    begin_action = Constants.start_session_action
+    end_action = Constants.delete_session_action
+    deletes_session = False
+
+    transformer = MagicMock()
+    transformer.get_code_to_execute.return_value = (code_to_run, error_to_show, begin_action, end_action,
+                                                    deletes_session)
+    kernel._get_code_transformer = MagicMock(return_value=transformer)
+    kernel._show_user_error = MagicMock()
+    kernel._start_session = MagicMock()
+    kernel._delete_session = MagicMock()
+
+    # Execute
+    kernel.do_execute(code_to_run, False)
+
+    # Assert
+    assert not kernel._show_user_error.called
+    assert call(code_to_run, False, True, None, False) in execute_cell_mock.mock_calls
+    kernel._start_session.assert_called_with()
+    kernel._delete_session.assert_called_with()
 
 
 @with_setup(_setup, _teardown)
@@ -294,7 +395,6 @@ def test_execute_throws_if_fatal_error_happens_for_execution():
     # Set up
     fatal_error = u"Error."
     message = "{}\nException details:\n\t\"{}\"".format(fatal_error, fatal_error)
-    stream_content = {"name": "stderr", "text": conf.fatal_error_suggestion().format(message)}
     code = "some spark code"
     reply_content = dict()
     reply_content[u"status"] = u"error"
@@ -312,50 +412,6 @@ def test_execute_throws_if_fatal_error_happens_for_execution():
         assert kernel._fatal_error == message
         assert execute_cell_mock.call_count == 1
         assert ipython_display.send_error.call_count == 1
-
-
-@with_setup(_setup, _teardown)
-def test_call_spark_sql_new_line():
-    def _check(prepend):
-        # Set up
-        plain_code = "select tables"
-        code = prepend + plain_code
-        kernel._session_started = True
-        execute_cell_mock.reset_mock()
-
-        # Call method
-        kernel.do_execute(code, False)
-
-        # Assertions
-        assert kernel._session_started
-        execute_cell_mock.assert_called_once_with("%%spark -c sql\n{}".format(plain_code), False, True, None, False)
-
-    _check("%sql ")
-    _check("%sql\n")
-    _check("%%sql ")
-    _check("%%sql\n")
-
-
-@with_setup(_setup, _teardown)
-def test_call_spark_hive_new_line():
-    def _check(prepend):
-        # Set up
-        plain_code = "select tables"
-        code = prepend + plain_code
-        kernel._session_started = True
-        execute_cell_mock.reset_mock()
-
-        # Call method
-        kernel.do_execute(code, False)
-
-        # Assertions
-        assert kernel._session_started
-        execute_cell_mock.assert_called_once_with("%%spark -c hive\n{}".format(plain_code), False, True, None, False)
-
-    _check("%hive ")
-    _check("%hive\n")
-    _check("%%hive ")
-    _check("%%hive\n")
 
 
 @with_setup(_setup, _teardown)
@@ -390,21 +446,3 @@ def test_register_auto_viz():
     assert call("from remotespark.datawidgets.utils import display_dataframe\nip = get_ipython()\nip.display_formatter"
                 ".ipython_display_formatter.for_type_by_name('pandas.core.frame', 'DataFrame', display_dataframe)",
                 True, False, None, False) in execute_cell_mock.mock_calls
-
-
-@with_setup(_setup(), _teardown())
-def test_logs_magic():
-    kernel._session_started = True
-
-    kernel.do_execute("%logs", False)
-
-    assert call("%spark logs", False, True, None, False) in execute_cell_mock.mock_calls
-
-
-@with_setup(_setup(), _teardown())
-def test_logs_magic_prints_without_session():
-    kernel._session_started = False
-
-    kernel.do_execute("%logs", False)
-
-    assert call("print('No logs yet.')", False, True, None, False) in execute_cell_mock.mock_calls

--- a/tests/test_usercommandparser.py
+++ b/tests/test_usercommandparser.py
@@ -1,0 +1,170 @@
+from mock import MagicMock, call
+from nose.tools import with_setup, raises, assert_equals
+
+from remotespark.wrapperkernel.usercommandparser import UserCommandParser
+
+parser = None
+
+
+def _setup():
+    global parser
+
+    parser = UserCommandParser()
+
+
+def _teardown():
+    pass
+
+
+@with_setup(_setup, _teardown)
+def test_magics_no_command():
+    subcommand, force, output_var, command = parser.parse_user_command('my code')
+    assert_equals(UserCommandParser.run_command, subcommand)
+    assert_equals(False, force)
+    assert output_var is None
+    assert_equals("my code", command)
+
+
+@with_setup(_setup, _teardown)
+def test_magics_parser_capital_letter():
+    subcommand, force, output_var, command = parser.parse_user_command('%Config')
+    assert_equals("config", subcommand)
+    assert_equals(False, force)
+    assert output_var is None
+    assert_equals("", command)
+
+
+@with_setup(_setup, _teardown)
+def test_magics_parser_single_percentage():
+    subcommand, force, output_var, command = parser.parse_user_command('%config')
+    assert_equals("config", subcommand)
+    assert_equals(False, force)
+    assert output_var is None
+    assert_equals("", command)
+
+    subcommand, force, output_var, command = parser.parse_user_command('%config hi')
+    assert_equals("config", subcommand)
+    assert_equals(False, force)
+    assert output_var is None
+    assert_equals("hi", command)
+
+    subcommand, force, output_var, command = parser.parse_user_command('%config -f')
+    assert_equals("config", subcommand)
+    assert_equals(True, force)
+    assert output_var is None
+    assert_equals("", command)
+
+    subcommand, force, output_var, command = parser.parse_user_command('%config -o my_var')
+    assert_equals("config", subcommand)
+    assert_equals(False, force)
+    assert_equals("my_var", output_var)
+    assert_equals("", command)
+
+    subcommand, force, output_var, command = parser.parse_user_command('%config of course -o my_var')
+    assert_equals("config", subcommand)
+    assert_equals(False, force)
+    assert_equals("my_var", output_var)
+    assert_equals("of course", command)
+
+    subcommand, force, output_var, command = parser.parse_user_command('%config hi hello my name -f')
+    assert_equals("config", subcommand)
+    assert_equals(True, force)
+    assert output_var is None
+    assert_equals('hi hello my name', command)
+
+    subcommand, force, output_var, command = parser.parse_user_command('%config {"extra": 2} hi -f True -o my_var')
+    assert_equals("config", subcommand)
+    assert_equals(True, force)
+    assert_equals("my_var", output_var)
+    assert_equals('{"extra": 2} hi', command)
+
+
+@with_setup(_setup, _teardown)
+def test_magics_parser_double_percentage():
+    subcommand, force, output_var, command = parser.parse_user_command('%%config')
+    assert_equals("config", subcommand)
+    assert_equals(False, force)
+    assert output_var is None
+    assert_equals("", command)
+
+    subcommand, force, output_var, command = parser.parse_user_command('%%config hi')
+    assert_equals("config", subcommand)
+    assert_equals(False, force)
+    assert output_var is None
+    assert_equals("hi", command)
+
+    subcommand, force, output_var, command = parser.parse_user_command('%%config -f')
+    assert_equals("config", subcommand)
+    assert_equals(True, force)
+    assert output_var is None
+    assert_equals("", command)
+
+    subcommand, force, output_var, command = parser.parse_user_command('%%config -o my_var')
+    assert_equals("config", subcommand)
+    assert_equals(False, force)
+    assert_equals("my_var", output_var)
+    assert_equals("", command)
+
+    subcommand, force, output_var, command = parser.parse_user_command('%%config of course -o my_var')
+    assert_equals("config", subcommand)
+    assert_equals(False, force)
+    assert_equals("my_var", output_var)
+    assert_equals("of course", command)
+
+    subcommand, force, output_var, command = parser.parse_user_command('%%config hi hello my name -f')
+    assert_equals("config", subcommand)
+    assert_equals(True, force)
+    assert output_var is None
+    assert_equals('hi hello my name', command)
+
+    subcommand, force, output_var, command = parser.parse_user_command('%%config {"extra": 2} hi -f True -o my_var')
+    assert_equals("config", subcommand)
+    assert_equals(True, force)
+    assert_equals("my_var", output_var)
+    assert_equals('{"extra": 2} hi', command)
+
+
+@with_setup(_setup, _teardown)
+def test_magics_parser_multiple_lines():
+    subcommand, force, output_var, command = parser.parse_user_command('%%config\nmy code')
+    assert_equals("config", subcommand)
+    assert_equals(False, force)
+    assert output_var is None
+    assert_equals("my code", command)
+
+    subcommand, force, output_var, command = parser.parse_user_command('%%config hi\nmy code')
+    assert_equals("config", subcommand)
+    assert_equals(False, force)
+    assert output_var is None
+    assert_equals("hi\nmy code", command)
+
+    subcommand, force, output_var, command = parser.parse_user_command('%%config -f\nmy code')
+    assert_equals("config", subcommand)
+    assert_equals(True, force)
+    assert output_var is None
+    assert_equals("my code", command)
+
+    subcommand, force, output_var, command = parser.parse_user_command('%%config -o my_var\nmy code')
+    assert_equals("config", subcommand)
+    assert_equals(False, force)
+    assert_equals("my_var", output_var)
+    assert_equals("my code", command)
+
+    subcommand, force, output_var, command = parser.parse_user_command('%%config of course -o my_var\nmy code')
+    assert_equals("config", subcommand)
+    assert_equals(False, force)
+    assert_equals("my_var", output_var)
+    assert_equals("of course\nmy code", command)
+
+    subcommand, force, output_var, command = parser.parse_user_command('%%config hi hello my name -f\nmy code')
+    assert_equals("config", subcommand)
+    assert_equals(True, force)
+    assert output_var is None
+    assert_equals('hi hello my name\nmy code', command)
+
+    subcommand, force, output_var, command = parser.parse_user_command('%%config {"extra": 2} hi -f True -o my_var\n'
+                                                                       'my code')
+    assert_equals("config", subcommand)
+    assert_equals(True, force)
+    assert_equals("my_var", output_var)
+    assert_equals('{"extra": 2} hi\nmy code', command)

--- a/tests/test_usercommandparser.py
+++ b/tests/test_usercommandparser.py
@@ -1,5 +1,4 @@
-from mock import MagicMock, call
-from nose.tools import with_setup, raises, assert_equals
+from nose.tools import with_setup, assert_equals
 
 from remotespark.wrapperkernel.usercommandparser import UserCommandParser
 


### PR DESCRIPTION
Break it up into:
* UserCommandParser
* CodeTransformers

and tie them to SparkKernelBase.

Also restructured unit tests so that they reflect new contracts between classes.