### PR TITLE
Add %local to wrapper kernel

### DIFF
--- a/remotespark/wrapperkernel/codetransformers.py
+++ b/remotespark/wrapperkernel/codetransformers.py
@@ -157,3 +157,14 @@ class LogsTransformer(UserCodeTransformerBase):
             code_to_run = "print('No logs yet.')"
 
         return code_to_run, error_to_show, begin_action, end_action, deletes_session
+
+
+class PythonTransformer(UserCodeTransformerBase):
+    def get_code_to_execute(self, session_started, connection_string, force, output_var, command):
+        error_to_show = None
+        code_to_run = command
+        begin_action = Constants.do_nothing_action
+        end_action = Constants.do_nothing_action
+        deletes_session = False
+
+        return code_to_run, error_to_show, begin_action, end_action, deletes_session

--- a/remotespark/wrapperkernel/sparkkernelbase.py
+++ b/remotespark/wrapperkernel/sparkkernelbase.py
@@ -125,6 +125,8 @@ class SparkKernelBase(IPythonKernel):
             return CleanUpTransformer(subcommand)
         elif subcommand == UserCommandParser.logs_command:
             return LogsTransformer(subcommand)
+        elif subcommand == UserCommandParser.local_command:
+            return PythonTransformer(subcommand)
         else:
             return NotSupportedTransformer(subcommand)
 

--- a/remotespark/wrapperkernel/usercommandparser.py
+++ b/remotespark/wrapperkernel/usercommandparser.py
@@ -12,6 +12,7 @@ class UserCommandParser(object):
     delete_command = "delete"
     clean_up_command = "cleanup"
     logs_command = "logs"
+    local_command = "local"
 
     def __init__(self):
         """Code can have a magic or no magic specified (specified with %word sign). If no magic is specified, %run will

--- a/tests/test_codetransformers.py
+++ b/tests/test_codetransformers.py
@@ -227,3 +227,17 @@ def test_logs_transformer_no_session():
     assert_equals(begin_action, Constants.do_nothing_action)
     assert_equals(end_action, Constants.do_nothing_action)
     assert_equals(deletes_session, False)
+
+
+@with_setup(_setup, _teardown)
+def test_python_transformer():
+    transformer = PythonTransformer("command")
+
+    code_to_run, error_to_show, begin_action, end_action, deletes_session = \
+        transformer.get_code_to_execute(False, conn, False, None, code)
+
+    assert_equals(code, code_to_run)
+    assert error_to_show is None
+    assert_equals(begin_action, Constants.do_nothing_action)
+    assert_equals(end_action, Constants.do_nothing_action)
+    assert_equals(deletes_session, False)

--- a/tests/test_sparkkernelbase.py
+++ b/tests/test_sparkkernelbase.py
@@ -129,6 +129,7 @@ def test_returns_right_transformer():
     assert type(kernel._get_code_transformer(UserCommandParser.clean_up_command)) is CleanUpTransformer
     assert type(kernel._get_code_transformer(UserCommandParser.logs_command)) is LogsTransformer
     assert type(kernel._get_code_transformer("whatever")) is NotSupportedTransformer
+    assert type(kernel._get_code_transformer(UserCommandParser.local_command)) is PythonTransformer
 
 
 @with_setup(_setup, _teardown)


### PR DESCRIPTION
This allows you to execute python code locally, without going to Livy at all. Useful in conjunction with -o for SQL and Hive queries. Closes #112.