### PR TITLE
Coerce df data types that we are getting back from Livy via SQL queries

### DIFF
--- a/remotespark/datawidgets/utils.py
+++ b/remotespark/datawidgets/utils.py
@@ -1,5 +1,4 @@
 import pandas as pd
-import numpy as np
 
 from .encoding import Encoding
 from .autovizwidget import AutoVizWidget
@@ -113,23 +112,7 @@ def select_y(data, x_name, order=None, aggregator=None):
     return chosen_y
 
 
-def coerce_pandas_df_to_numeric_datetime(df):
-    for column_name in df.columns:
-        if df[column_name].dtype == np.dtype("object"):
-            try:
-                df[column_name] = pd.to_datetime(df[column_name], errors="raise")
-            except:
-                pass
-
-        if df[column_name].dtype == np.dtype("object"):
-            try:
-                df[column_name] = pd.to_numeric(df[column_name], errors="raise")
-            except:
-                pass
-
-
 def display_dataframe(df):
-    coerce_pandas_df_to_numeric_datetime(df)
     selected_x = select_x(df)
     selected_y = select_y(df, selected_x)
     encoding = Encoding(chart_type=Encoding.chart_type_table, x=selected_x, y=selected_y,

--- a/remotespark/livyclientlib/pandaslivyclientbase.py
+++ b/remotespark/livyclientlib/pandaslivyclientbase.py
@@ -3,8 +3,10 @@
 
 import pandas as pd
 import json
+
 from .livyclient import LivyClient
 from .dataframeparseexception import DataFrameParseException
+from remotespark.utils.utils import coerce_pandas_df_to_numeric_datetime
 
 class PandasLivyClientBase(LivyClient):
     """Spark client for Livy session that produces pandas df for sql and hive commands."""
@@ -47,7 +49,9 @@ class PandasLivyClientBase(LivyClient):
     def get_data_dataframe(self, records_text):
         strings = records_text.split('\n')
         try:
-            return pd.DataFrame([json.loads(s) for s in strings])
+            df = pd.DataFrame([json.loads(s) for s in strings])
+            coerce_pandas_df_to_numeric_datetime(df)
+            return df
         except ValueError:
             raise DataFrameParseException("Cannot parse object as JSON: '{}'".format(strings))
 

--- a/remotespark/utils/utils.py
+++ b/remotespark/utils/utils.py
@@ -117,11 +117,3 @@ def coerce_pandas_df_to_numeric_datetime(df):
                 coerced = True
             except:
                 pass
-
-        # TODO: To be uncommented when https://github.com/pydata/pandas/issues/12108 is fixed
-        # if not coerced and df[column_name].nunique() < SOME_NUMBER:
-        #     try:
-        #         df[column_name] = df[column_name].astype('category')
-        #         coerced = True
-        #     except:
-        #         pass

--- a/remotespark/utils/utils.py
+++ b/remotespark/utils/utils.py
@@ -102,14 +102,26 @@ def get_instance_id():
 
 def coerce_pandas_df_to_numeric_datetime(df):
     for column_name in df.columns:
-        if df[column_name].dtype == np.dtype("object"):
+        coerced = False
+
+        if not coerced and df[column_name].dtype == np.dtype("object"):
             try:
                 df[column_name] = pd.to_datetime(df[column_name], errors="raise")
+                coerced = True
             except:
                 pass
 
-        if df[column_name].dtype == np.dtype("object"):
+        if not coerced and df[column_name].dtype == np.dtype("object"):
             try:
                 df[column_name] = pd.to_numeric(df[column_name], errors="raise")
+                coerced = True
             except:
                 pass
+
+        # TODO: To be uncommented when https://github.com/pydata/pandas/issues/12108 is fixed
+        # if not coerced and df[column_name].nunique() < SOME_NUMBER:
+        #     try:
+        #         df[column_name] = df[column_name].astype('category')
+        #         coerced = True
+        #     except:
+        #         pass

--- a/remotespark/utils/utils.py
+++ b/remotespark/utils/utils.py
@@ -8,6 +8,8 @@
 from collections import namedtuple
 import os
 import uuid
+import pandas as pd
+import numpy as np
 
 from .filesystemreaderwriter import FileSystemReaderWriter
 
@@ -97,3 +99,17 @@ def get_instance_id():
 
     return instance_id
 
+
+def coerce_pandas_df_to_numeric_datetime(df):
+    for column_name in df.columns:
+        if df[column_name].dtype == np.dtype("object"):
+            try:
+                df[column_name] = pd.to_datetime(df[column_name], errors="raise")
+            except:
+                pass
+
+        if df[column_name].dtype == np.dtype("object"):
+            try:
+                df[column_name] = pd.to_numeric(df[column_name], errors="raise")
+            except:
+                pass

--- a/remotespark/utils/utils.py
+++ b/remotespark/utils/utils.py
@@ -108,12 +108,12 @@ def coerce_pandas_df_to_numeric_datetime(df):
             try:
                 df[column_name] = pd.to_datetime(df[column_name], errors="raise")
                 coerced = True
-            except:
+            except ValueError:
                 pass
 
         if not coerced and df[column_name].dtype == np.dtype("object"):
             try:
                 df[column_name] = pd.to_numeric(df[column_name], errors="raise")
                 coerced = True
-            except:
+            except ValueError:
                 pass

--- a/tests/datawidgetstests/test_utils.py
+++ b/tests/datawidgetstests/test_utils.py
@@ -29,7 +29,8 @@ def _teardown():
 
 @with_setup(_setup, _teardown)
 def test_on_render_viz():
-    utils.coerce_pandas_df_to_numeric_datetime(df)
+    df["date"] = pd.to_datetime(df["date"])
+    df["mystr2"] = pd.to_numeric(df["mystr2"])
 
     assert utils.infer_vegalite_type(df["buildingID"]) == "Q"
     assert utils.infer_vegalite_type(df["date"]) == "T"

--- a/tests/test_pandaspysparklivyclient.py
+++ b/tests/test_pandaspysparklivyclient.py
@@ -1,5 +1,5 @@
 from mock import MagicMock
-from nose.tools import with_setup, assert_equal
+from nose.tools import with_setup
 from pandas.util.testing import assert_frame_equal
 import pandas as pd
 
@@ -44,9 +44,11 @@ def test_execute_sql_pandas_pyspark_livy():
     execute_m.return_value = result_json
 
     # desired pandas df
-    records = [{u'buildingID': 0, u'date': u'6/1/13', u'temp_diff': 12},
-               {u'buildingID': 1, u'date': u'6/1/13', u'temp_diff': 0}]
+    records = [{u'buildingID': 0, u'date': u'6/1/13', u'temp_diff': u'12'},
+               {u'buildingID': 1, u'date': u'6/1/13', u'temp_diff': u'0'}]
     desired_df = pd.DataFrame(records)
+    desired_df["date"] = pd.to_datetime(desired_df["date"])
+    desired_df["temp_diff"] = pd.to_numeric(desired_df["temp_diff"])
 
     command = "command"
     df = client.execute_sql(command)

--- a/tests/test_pandasscalalivyclient.py
+++ b/tests/test_pandasscalalivyclient.py
@@ -6,6 +6,7 @@ import pandas as pd
 from remotespark.livyclientlib.pandasscalalivyclient import PandasScalaLivyClient
 from remotespark.livyclientlib.dataframeparseexception import DataFrameParseException
 
+
 mock_spark_session = None
 client = None
 execute_m = None
@@ -42,9 +43,11 @@ def test_execute_sql_pandas_scala_livy():
     execute_m.return_value = (True, result_json)
 
     # desired pandas df
-    records = [{u'buildingID': 0, u'date': u'6/1/13', u'temp_diff': 12},
-               {u'buildingID': 1, u'date': u'6/1/13', u'temp_diff': 0}]
+    records = [{u'buildingID': 0, u'date': u'6/1/13', u'temp_diff': u'12'},
+               {u'buildingID': 1, u'date': u'6/1/13', u'temp_diff': u'0'}]
     desired_df = pd.DataFrame(records)
+    desired_df["date"] = pd.to_datetime(desired_df["date"])
+    desired_df["temp_diff"] = pd.to_numeric(desired_df["temp_diff"])
 
     command = "command"
     df = client.execute_sql(command)

--- a/tests/test_pd_data_coerce.py
+++ b/tests/test_pd_data_coerce.py
@@ -1,0 +1,87 @@
+from pandas.util.testing import assert_frame_equal
+import pandas as pd
+
+from remotespark.utils.utils import coerce_pandas_df_to_numeric_datetime
+
+
+def test_no_coercing():
+    records = [{u'buildingID': 0, u'date': u'6/1/13', u'temp_diff': u'12'},
+               {u'buildingID': 1, u'date': u'random', u'temp_diff': u'0adsf'}]
+    desired_df = pd.DataFrame(records)
+
+    df = pd.DataFrame(records)
+    coerce_pandas_df_to_numeric_datetime(df)
+
+    assert_frame_equal(desired_df, df)
+
+
+def test_date_coercing():
+    records = [{u'buildingID': 0, u'date': u'6/1/13', u'temp_diff': u'12'},
+               {u'buildingID': 1, u'date': u'6/1/13', u'temp_diff': u'0adsf'}]
+    desired_df = pd.DataFrame(records)
+    desired_df["date"] = pd.to_datetime(desired_df["date"])
+
+    df = pd.DataFrame(records)
+    coerce_pandas_df_to_numeric_datetime(df)
+
+    assert_frame_equal(desired_df, df)
+
+
+def test_date_coercing_none_values():
+    records = [{u'buildingID': 0, u'date': u'6/1/13', u'temp_diff': u'12'},
+               {u'buildingID': 1, u'date': None, u'temp_diff': u'0adsf'}]
+    desired_df = pd.DataFrame(records)
+    desired_df["date"] = pd.to_datetime(desired_df["date"])
+
+    df = pd.DataFrame(records)
+    coerce_pandas_df_to_numeric_datetime(df)
+
+    assert_frame_equal(desired_df, df)
+
+
+def test_date_none_values_and_no_coercing():
+    records = [{u'buildingID': 0, u'date': u'6/1/13', u'temp_diff': u'12'},
+               {u'buildingID': 1, u'date': None, u'temp_diff': u'0adsf'},
+               {u'buildingID': 1, u'date': u'adsf', u'temp_diff': u'0adsf'}]
+    desired_df = pd.DataFrame(records)
+
+    df = pd.DataFrame(records)
+    coerce_pandas_df_to_numeric_datetime(df)
+
+    assert_frame_equal(desired_df, df)
+
+
+def test_numeric_coercing():
+    records = [{u'buildingID': 0, u'date': u'6/1/13', u'temp_diff': u'12'},
+               {u'buildingID': 1, u'date': u'adsf', u'temp_diff': u'0'}]
+    desired_df = pd.DataFrame(records)
+    desired_df["temp_diff"] = pd.to_numeric(desired_df["temp_diff"])
+
+    df = pd.DataFrame(records)
+    coerce_pandas_df_to_numeric_datetime(df)
+
+    assert_frame_equal(desired_df, df)
+
+
+def test_numeric_coercing_none_values():
+    records = [{u'buildingID': 0, u'date': u'6/1/13', u'temp_diff': u'12'},
+               {u'buildingID': 1, u'date': u'asdf', u'temp_diff': None}]
+    desired_df = pd.DataFrame(records)
+    desired_df["temp_diff"] = pd.to_numeric(desired_df["temp_diff"])
+
+    df = pd.DataFrame(records)
+    coerce_pandas_df_to_numeric_datetime(df)
+
+    assert_frame_equal(desired_df, df)
+
+
+def test_numeric_none_values_and_no_coercing():
+    records = [{u'buildingID': 0, u'date': u'6/1/13', u'temp_diff': u'12'},
+               {u'buildingID': 1, u'date': u'asdf', u'temp_diff': None},
+               {u'buildingID': 1, u'date': u'adsf', u'temp_diff': u'0asdf'}]
+    desired_df = pd.DataFrame(records)
+
+    df = pd.DataFrame(records)
+    coerce_pandas_df_to_numeric_datetime(df)
+
+    assert_frame_equal(desired_df, df)


### PR DESCRIPTION
This is now done on the livy client and not on datawidgets

Closes #55 
Not coercing into `categorical` because of bug in unit testing framework, outlined in https://github.com/pydata/pandas/issues/12108