### PR TITLE
Allow df that have dictionaries to not throw when coercing or being visualized

### DIFF
--- a/remotespark/datawidgets/plotlygraphs/piegraph.py
+++ b/remotespark/datawidgets/plotlygraphs/piegraph.py
@@ -15,9 +15,15 @@ class PieGraph(object):
                 print("\n\n\nPlease select an X axis.")
                 return
 
-        values, labels = PieGraph._get_x_values_labels(df, encoding)
-        max_slices_pie_graph = conf.max_slices_pie_graph()
+        try:
+            values, labels = PieGraph._get_x_values_labels(df, encoding)
+        except TypeError:
+            with output:
+                print("\n\n\nCannot group by X selection because of its type: '{}'. Please select another column."
+                      .format(df[encoding.x].dtype))
+                return
 
+        max_slices_pie_graph = conf.max_slices_pie_graph()
         with output:
             # There's performance issues with a large amount of slices.
             # 1500 rows crash the browser.

--- a/remotespark/utils/utils.py
+++ b/remotespark/utils/utils.py
@@ -108,12 +108,12 @@ def coerce_pandas_df_to_numeric_datetime(df):
             try:
                 df[column_name] = pd.to_datetime(df[column_name], errors="raise")
                 coerced = True
-            except ValueError:
+            except (ValueError, TypeError):
                 pass
 
         if not coerced and df[column_name].dtype == np.dtype("object"):
             try:
                 df[column_name] = pd.to_numeric(df[column_name], errors="raise")
                 coerced = True
-            except ValueError:
+            except (ValueError, TypeError):
                 pass

--- a/tests/test_pd_data_coerce.py
+++ b/tests/test_pd_data_coerce.py
@@ -85,3 +85,40 @@ def test_numeric_none_values_and_no_coercing():
     coerce_pandas_df_to_numeric_datetime(df)
 
     assert_frame_equal(desired_df, df)
+
+
+def test_df_dict_does_not_throw():
+    json_str = """
+[{
+    "id": 580320,
+    "name": "COUSIN'S GRILL",
+    "results": "Fail",
+    "violations": "37. TOILET area.",
+    "words": ["37.",
+    "toilet",
+    "area."],
+    "features": {
+        "type": 0,
+        "size": 262144,
+        "indices": [0,
+        45,
+        97],
+        "values": [7.0,
+        5.0,
+        1.0]
+    },
+    "rawPrediction": {
+        "type": 1,
+        "values": [3.640841752791392,
+        -3.640841752791392]
+    },
+    "probability": {
+        "type": 1,
+        "values": [0.974440185187647,
+        0.025559814812352966]
+    },
+    "prediction": 0.0
+}]
+"""
+    df = pd.read_json(json_str)
+    coerce_pandas_df_to_numeric_datetime(df)


### PR DESCRIPTION
This is done by handling `TypeError`