### PR TITLE
Add -q feature to silence SQL queries selectively

### DIFF
--- a/remotespark/kernels/kernelmagics.py
+++ b/remotespark/kernels/kernelmagics.py
@@ -161,7 +161,7 @@ class KernelMagics(SparkMagicBase):
     @needs_local_scope
     @argument("-o", "--output", type=str, default=None, help="If present, query will be stored in variable of this "
                                                              "name.")
-    @argument("-q", "--quiet", type=bool, default=False, const=True, nargs="?", help="Do not display visualization")
+    @argument("-q", "--quiet", type=bool, default=False, const=True, nargs="?", help="Return None instead of the dataframe.")
     def sql(self, line, cell="", local_ns=None):
         if self._do_not_call_start_session(""):
             args = parse_argstring(self.sql, line)
@@ -175,7 +175,7 @@ class KernelMagics(SparkMagicBase):
     @needs_local_scope
     @argument("-o", "--output", type=str, default=None, help="If present, query will be stored in variable of this "
                                                              "name.")
-    @argument("-q", "--quiet", type=bool, default=False, const=True, nargs="?", help="Do not display visualization")
+    @argument("-q", "--quiet", type=bool, default=False, const=True, nargs="?", help="Return None instead of the dataframe.")
     def hive(self, line, cell="", local_ns=None):
         if self._do_not_call_start_session(""):
             args = parse_argstring(self.hive, line)

--- a/remotespark/kernels/kernelmagics.py
+++ b/remotespark/kernels/kernelmagics.py
@@ -161,11 +161,12 @@ class KernelMagics(SparkMagicBase):
     @needs_local_scope
     @argument("-o", "--output", type=str, default=None, help="If present, query will be stored in variable of this "
                                                              "name.")
+    @argument("-q", "--quiet", type=bool, default=False, const=True, nargs="?", help="Do not display visualization")
     def sql(self, line, cell="", local_ns=None):
         if self._do_not_call_start_session(""):
             args = parse_argstring(self.sql, line)
             return self.execute_against_context_that_returns_df(self.spark_controller.run_cell_sql, cell,
-                                                            None, args.output)
+                                                                None, args.output, args.quiet)
         else:
             return None
 
@@ -174,11 +175,12 @@ class KernelMagics(SparkMagicBase):
     @needs_local_scope
     @argument("-o", "--output", type=str, default=None, help="If present, query will be stored in variable of this "
                                                              "name.")
+    @argument("-q", "--quiet", type=bool, default=False, const=True, nargs="?", help="Do not display visualization")
     def hive(self, line, cell="", local_ns=None):
         if self._do_not_call_start_session(""):
             args = parse_argstring(self.hive, line)
             return self.execute_against_context_that_returns_df(self.spark_controller.run_cell_hive, cell,
-                                                                None, args.output)
+                                                                None, args.output, args.quiet)
         else:
             return None
 

--- a/remotespark/magics/remotesparkmagics.py
+++ b/remotespark/magics/remotesparkmagics.py
@@ -43,6 +43,7 @@ class RemoteSparkMagics(SparkMagicBase):
                                       "If only one session has been created, there's no need to specify one.")
     @argument("-o", "--output", type=str, default=None, help="If present, output when using SQL or Hive "
                                                              "query will be stored in variable of this name.")
+    @argument("-q", "--quiet", type=bool, default=False, nargs="?", const=True, help="Do not display visualizations")
     @argument("command", type=str, default=[""], nargs="*", help="Commands to execute.")
     @needs_local_scope
     @line_cell_magic
@@ -172,10 +173,10 @@ class RemoteSparkMagics(SparkMagicBase):
                         self.ipython_display.send_error(out)
                 elif args.context == Constants.context_name_sql:
                     return self.execute_against_context_that_returns_df(self.spark_controller.run_cell_sql, cell,
-                                                                        args.session, args.output)
+                                                                        args.session, args.output, args.quiet)
                 elif args.context == Constants.context_name_hive:
                     return self.execute_against_context_that_returns_df(self.spark_controller.run_cell_hive, cell,
-                                                                        args.session, args.output)
+                                                                        args.session, args.output, args.quiet)
                 else:
                     raise ValueError("Context '{}' not found".format(args.context))
             # error

--- a/remotespark/magics/sparkmagicsbase.py
+++ b/remotespark/magics/sparkmagicsbase.py
@@ -43,12 +43,15 @@ class SparkMagicBase(Magics):
 
         self.logger.debug("Initialized spark magics.")
 
-    def execute_against_context_that_returns_df(self, method, cell, session, output_var):
+    def execute_against_context_that_returns_df(self, method, cell, session, output_var, quiet):
         try:
             df = method(cell, session)
             if output_var is not None:
                 self.shell.user_ns[output_var] = df
-            return df
+            if quiet:
+                return None
+            else:
+                return df
         except DataFrameParseException as e:
             self.ipython_display.send_error(e.out)
             return None

--- a/tests/test_kernel_magics.py
+++ b/tests/test_kernel_magics.py
@@ -275,7 +275,7 @@ def test_sql_without_output():
     spark_controller.add_session.assert_called_once_with(magic.session_name, magic.connection_string, False,
                                                          {"kind": Constants.session_kind_pyspark})
     magic.execute_against_context_that_returns_df.assert_called_once_with(spark_controller.run_cell_sql, cell, None,
-                                                                          None)
+                                                                          None, False)
 
 
 @with_setup(_setup, _teardown)
@@ -289,7 +289,7 @@ def test_sql_with_output():
     spark_controller.add_session.assert_called_once_with(magic.session_name, magic.connection_string, False,
                                                          {"kind": Constants.session_kind_pyspark})
     magic.execute_against_context_that_returns_df.assert_called_once_with(spark_controller.run_cell_sql, cell, None,
-                                                                          "my_var")
+                                                                          "my_var", False)
 
 
 @with_setup(_setup, _teardown)
@@ -316,7 +316,7 @@ def test_hive_without_output():
     spark_controller.add_session.assert_called_once_with(magic.session_name, magic.connection_string, False,
                                                          {"kind": Constants.session_kind_pyspark})
     magic.execute_against_context_that_returns_df.assert_called_once_with(spark_controller.run_cell_hive, cell, None,
-                                                                          None)
+                                                                          None, False)
 
 
 @with_setup(_setup, _teardown)
@@ -330,7 +330,7 @@ def test_hive_with_output():
     spark_controller.add_session.assert_called_once_with(magic.session_name, magic.connection_string, False,
                                                          {"kind": Constants.session_kind_pyspark})
     magic.execute_against_context_that_returns_df.assert_called_once_with(spark_controller.run_cell_hive, cell, None,
-                                                                          "my_var")
+                                                                          "my_var", False)
 
 
 @with_setup(_setup, _teardown)

--- a/tests/test_sparkmagicbase.py
+++ b/tests/test_sparkmagicbase.py
@@ -28,7 +28,7 @@ def test_df_execution_without_output_var():
     session = MagicMock()
     output_var = None
 
-    res = magic.execute_against_context_that_returns_df(method, cell, session, output_var)
+    res = magic.execute_against_context_that_returns_df(method, cell, session, output_var, False)
 
     method.assert_called_once_with(cell, session)
     assert res == df
@@ -47,10 +47,48 @@ def test_df_execution_with_output_var():
     session = MagicMock()
     output_var = "var_name"
 
-    res = magic.execute_against_context_that_returns_df(method, cell, session, output_var)
+    res = magic.execute_against_context_that_returns_df(method, cell, session, output_var, False)
 
     method.assert_called_once_with(cell, session)
     assert res == df
+    assert shell.user_ns[output_var] == df
+
+
+def test_df_execution_quiet_without_output_var():
+    shell = MagicMock()
+    shell.user_ns = {}
+    magic = SparkMagicBase(None)
+    magic.shell = shell
+
+    df = 0
+    method = MagicMock(return_value=df)
+    cell = ""
+    session = MagicMock()
+    output_var = None
+
+    res = magic.execute_against_context_that_returns_df(method, cell, session, output_var, True)
+
+    method.assert_called_once_with(cell, session)
+    assert res is None
+    assert_equals(list(shell.user_ns.keys()), [])
+
+
+def test_df_execution_quiet_with_output_var():
+    shell = MagicMock()
+    shell.user_ns = {}
+    magic = SparkMagicBase(None)
+    magic.shell = shell
+
+    df = 0
+    method = MagicMock(return_value=df)
+    cell = ""
+    session = MagicMock()
+    output_var = "var_name"
+
+    res = magic.execute_against_context_that_returns_df(method, cell, session, output_var, True)
+
+    method.assert_called_once_with(cell, session)
+    assert res is None
     assert shell.user_ns[output_var] == df
 
 
@@ -66,8 +104,8 @@ def test_df_execution_throws():
     session = MagicMock()
     output_var = "var_name"
 
-    res = magic.execute_against_context_that_returns_df(method, cell, session, output_var)
+    res = magic.execute_against_context_that_returns_df(method, cell, session, output_var, False)
 
     method.assert_called_once_with(cell, session)
-    assert res == None
+    assert res is None
     assert_equals(list(shell.user_ns.keys()), [])


### PR DESCRIPTION
We do this by returning `None` from the magic (instead of the dataframe) whenever the `-q` argument is passed.

Closes #141 