### PR TITLE
%%config now a proper cell magic

### DIFF
--- a/remotespark/kernels/kernelmagics.py
+++ b/remotespark/kernels/kernelmagics.py
@@ -127,17 +127,8 @@ class KernelMagics(SparkMagicBase):
     @magic_arguments()
     @cell_magic
     @argument("-f", "--force", type=bool, default=False, nargs="?", const=True, help="If present, user understands.")
-    @argument("settings", type=str, default=[""], nargs="*", help="Settings to configure session with.")
     def configure(self, line, cell="", local_ns=None):
         args = parse_argstring(self.configure, line)
-
-        # We ignore args.settings because argparse removes quotes. Instead, we get them ourselves.
-        settings = self.get_session_settings(line, args.force)
-
-        if settings is None:
-            self.ipython_display.send_error("Force flag must be at the beginning or end of the line as '-f'.")
-            return
-
         if self.session_started:
             if not args.force:
                 self.ipython_display.send_error("A session has already been started. If you intend to recreate the "
@@ -145,11 +136,10 @@ class KernelMagics(SparkMagicBase):
                 return
             else:
                 self._do_not_call_delete_session("")
-                self._override_session_settings(settings)
+                self._override_session_settings(cell)
                 self._do_not_call_start_session("")
         else:
-            self._override_session_settings(settings)
-
+            self._override_session_settings(cell)
         self.info("")
 
     @cell_magic

--- a/remotespark/livyclientlib/sessionmanager.py
+++ b/remotespark/livyclientlib/sessionmanager.py
@@ -48,7 +48,7 @@ class SessionManager(object):
 
     def get_session_id_for_client(self, name):
         if name in self.get_sessions_list():
-            return self._sessions[name].session_id
+            return self._sessions[name].id
         return None
 
     def delete_client(self, name):

--- a/remotespark/magics/remotesparkmagics.py
+++ b/remotespark/magics/remotesparkmagics.py
@@ -76,13 +76,14 @@ class RemoteSparkMagics(SparkMagicBase):
            add
                Add a Livy session given a session name (-s), language (-l), and endpoint credentials.
                The -k argument, if present, will skip adding this session if it already exists.
-               e.g. `%%spark add -s test -l python -u https://sparkcluster.net/livy -a u -p -k`
+               e.g. `%spark add -s test -l python -u https://sparkcluster.net/livy -a u -p -k`
            config
                Override the livy session properties sent to Livy on session creation. All session creations will
                contain these config settings from then on.
                Expected value is a JSON key-value string to be sent as part of the Request Body for the POST /sessions
                endpoint in Livy.
-               e.g. `%%spark config {"driverMemory":"1000M", "executorCores":4}`
+               e.g. `%%spark config`
+                    `{"driverMemory":"1000M", "executorCores":4}`
            run
                Run Spark code against a session.
                e.g. `%%spark -s testsession` will execute the cell code against the testsession previously created
@@ -92,13 +93,13 @@ class RemoteSparkMagics(SparkMagicBase):
                         Python environment.
            logs
                Returns the logs for a given session.
-               e.g. `%%spark logs -s testsession` will return the logs for the testsession previously created
+               e.g. `%spark logs -s testsession` will return the logs for the testsession previously created
            delete
                Delete a Livy session.
-               e.g. `%%spark delete -s defaultlivy`
+               e.g. `%spark delete -s defaultlivy`
            cleanup
                Delete all Livy sessions created by the notebook. No arguments required.
-               e.g. `%%spark cleanup`
+               e.g. `%spark cleanup`
         """
         usage = "Please look at usage of %spark by executing `%spark?`."
         user_input = line
@@ -117,9 +118,7 @@ class RemoteSparkMagics(SparkMagicBase):
                     self._print_local_info()
             # config
             elif subcommand == "config":
-                # Would normally do " ".join(args.command[1:]) but parse_argstring removes quotes...
-                rest_of_line = user_input[7:]
-                conf.override(conf.session_configs.__name__, json.loads(rest_of_line))
+                conf.override(conf.session_configs.__name__, json.loads(cell))
             # add
             elif subcommand == "add":
                 if args.url is None:

--- a/tests/test_kernel_magics.py
+++ b/tests/test_kernel_magics.py
@@ -191,14 +191,14 @@ def test_configure():
 
     # Session not started
     conf.override_all({})
-    magic.configure('{"extra": "yes"}')
+    magic.configure('', '{"extra": "yes"}')
     assert conf.session_configs() == {"extra": "yes"}
     magic.info.assert_called_once_with("")
 
     # Session started - no -f
     magic.session_started = True
     conf.override_all({})
-    magic.configure("{\"extra\": \"yes\"}")
+    magic.configure('', "{\"extra\": \"yes\"}")
 
     assert conf.session_configs() == {}
     assert_equals(ipython_display.send_error.call_count, 1)
@@ -206,7 +206,7 @@ def test_configure():
     # Session started - with -f
     magic.info.reset_mock()
     conf.override_all({})
-    magic.configure("-f {\"extra\": \"yes\"}")
+    magic.configure("-f", "{\"extra\": \"yes\"}")
     assert conf.session_configs() == {"extra": "yes"}
     spark_controller.delete_session_by_name.assert_called_once_with(magic.session_name)
     spark_controller.add_session.assert_called_once_with(magic.session_name, magic.endpoint, False,

--- a/tests/test_remotesparkmagics.py
+++ b/tests/test_remotesparkmagics.py
@@ -85,7 +85,7 @@ def test_add_sessions_command_parses():
 @with_setup(_setup, _teardown)
 def test_add_sessions_command_extra_properties():
     conf.override_all({})
-    magic.spark("config {\"extra\": \"yes\"}")
+    magic.spark("config", "{\"extra\": \"yes\"}")
     assert conf.session_configs() == {"extra": "yes"}
 
     add_sessions_mock = MagicMock()


### PR DESCRIPTION
Closes #192 

Now, `%%config` takes its argument in the cell rather than in-line, like so:

    %%config
    { "blah": "blah" }

... so its API is now more like a proper cell magic.