### PR TITLE
Display 'no results' message if empty dataframe came back from Livy server for SQL queries

### DIFF
--- a/remotespark/datawidgets/encodingwidget.py
+++ b/remotespark/datawidgets/encodingwidget.py
@@ -13,7 +13,6 @@ class EncodingWidget(FlexBox):
         assert encoding is not None
         assert df is not None
         assert type(df) is pd.DataFrame
-        assert len(df.columns) > 0
 
         kwargs['orientation'] = 'vertical'
         if not testing:

--- a/remotespark/datawidgets/plotlygraphs/graphrenderer.py
+++ b/remotespark/datawidgets/plotlygraphs/graphrenderer.py
@@ -20,6 +20,7 @@ class GraphRenderer(object):
             init_notebook_mode()
         GraphRenderer._get_graph(encoding.chart_type).render(df, encoding, output)
 
+
     @staticmethod
     def display_x(chart_type):
         return GraphRenderer._get_graph(chart_type).display_x()

--- a/remotespark/datawidgets/plotlygraphs/graphrenderer.py
+++ b/remotespark/datawidgets/plotlygraphs/graphrenderer.py
@@ -20,7 +20,6 @@ class GraphRenderer(object):
             init_notebook_mode()
         GraphRenderer._get_graph(encoding.chart_type).render(df, encoding, output)
 
-
     @staticmethod
     def display_x(chart_type):
         return GraphRenderer._get_graph(chart_type).display_x()

--- a/tests/datawidgetstests/test_autovizwidget.py
+++ b/tests/datawidgetstests/test_autovizwidget.py
@@ -73,6 +73,16 @@ def test_create_viz_types_buttons():
 
 
 @with_setup(_setup, _teardown)
+def test_create_viz_empty_df():
+    df = pd.DataFrame([])
+    widget = AutoVizWidget(df, encoding, renderer, ipywidget_factory,
+                           encoding_widget, ipython_display, testing=True)
+
+    ipywidget_factory.get_button.assert_not_called()
+    ipywidget_factory.get_html.assert_called_once_with("No results.")
+    ipython_display.display.assert_called_with(ipywidget_factory.get_html.return_value)
+
+@with_setup(_setup, _teardown)
 def test_convert_to_displayable_dataframe():
     bool_df = pd.DataFrame([{u'bool_col': True, u'int_col': 0, u'float_col': 3.0},
                             {u'bool_col': False, u'int_col': 100, u'float_col': 0.7}])


### PR DESCRIPTION
Closes #200 

Only run SQL queries against the server once and display "No results." if a SQL query had no results.

![image](https://cloud.githubusercontent.com/assets/13972471/13996073/6139db18-f0e9-11e5-96d1-671bad01f325.png)