### PR TITLE
Fixing some small bugs in publicpreview0.3

### DIFF
--- a/remotespark/kernels/kernelmagics.py
+++ b/remotespark/kernels/kernelmagics.py
@@ -36,6 +36,8 @@ def _event(f):
             self._spark_events.emit_magic_execution_end_event(f.__name__, get_livy_kind(self.language), guid,
                                                               True, "", "")
             return result
+    wrapped.__name__ = f.__name__
+    wrapped.__doc__ = f.__doc__
     return wrapped
 
 

--- a/remotespark/livyclientlib/sparkcontroller.py
+++ b/remotespark/livyclientlib/sparkcontroller.py
@@ -2,7 +2,6 @@
 # Distributed under the terms of the Modified BSD License.
 
 from remotespark.utils.log import Log
-from remotespark.utils.sparkevents import SparkEvents
 from .sessionmanager import SessionManager
 from .livyreliablehttpclient import LivyReliableHttpClient
 from .livysession import LivySession
@@ -16,8 +15,12 @@ class SparkController(object):
         self.session_manager = SessionManager()
 
     def get_logs(self, client_name=None):
-        session_to_use = self.get_session_by_name_or_default(client_name)
-        return session_to_use.get_logs()
+        try:
+            session_to_use = self.get_session_by_name_or_default(client_name)
+            out = session_to_use.get_logs()
+            return True, out
+        except ValueError as err:
+            return False, "{}".format(err)
 
     def run_command(self, command, client_name=None):
         session_to_use = self.get_session_by_name_or_default(client_name)

--- a/tests/test_sparkcontroller.py
+++ b/tests/test_sparkcontroller.py
@@ -1,5 +1,5 @@
 from mock import MagicMock, patch
-from nose.tools import with_setup
+from nose.tools import with_setup, assert_equals
 import json
 
 from remotespark.livyclientlib.sparkcontroller import SparkController
@@ -184,9 +184,18 @@ def test_get_logs():
     chosen_client = MagicMock()
     controller.get_session_by_name_or_default = MagicMock(return_value=chosen_client)
 
-    controller.get_logs()
-
+    result = controller.get_logs()
+    assert_equals(result, (True, chosen_client.get_logs.return_value))
     chosen_client.get_logs.assert_called_with()
+
+
+@with_setup(_setup, _teardown)
+def test_get_logs_error():
+    chosen_client = MagicMock()
+    controller.get_session_by_name_or_default = MagicMock(side_effect=ValueError('THERE WAS A SPOOKY GHOST'))
+
+    result = controller.get_logs()
+    assert_equals(result, (False, str(controller.get_session_by_name_or_default.side_effect)))
 
 
 @with_setup(_setup, _teardown)


### PR DESCRIPTION
Fix some bugs:

* Assign docstring and function name to wrapped function in decorator (sparkmagic doesn't successfully load otherwise)

* Catch exception in `SparkController.get_logs` and write it to stderr