### PR TITLE
Livy session deletion bugfix

### DIFF
--- a/tests/test_livysession.py
+++ b/tests/test_livysession.py
@@ -652,9 +652,10 @@ class TestLivySession(object):
 
         session.delete()
 
+        assert_equals(session.id, -1)
         spark_events.emit_session_deletion_start_event.assert_called_once_with(session.guid, session.kind, end_id,
                                                                                end_status)
-        spark_events.emit_session_deletion_end_event.assert_called_once_with(session.guid, session.kind, -1,
+        spark_events.emit_session_deletion_end_event.assert_called_once_with(session.guid, session.kind, end_id,
                                                                              constants.DEAD_SESSION_STATUS,
                                                                              True, "", "")
 


### PR DESCRIPTION
This is a regression that was introduced in #206.

Livy session deletion through `%%cleanup` fails with an exception without this fix, as this line:

    self.id = -1

Introduces an error when we try to log the session with the ID here:

    self._spark_events.emit_session_deletion_end_event(self.guid, self.kind, self.id, self.status, True, "", "")