### PR TITLE
Better error messages for magics

### DIFF
--- a/remotespark/kernels/kernelmagics.py
+++ b/remotespark/kernels/kernelmagics.py
@@ -287,8 +287,10 @@ class KernelMagics(SparkMagicBase):
     @cell_magic
     @handle_expected_exceptions
     def _do_not_call_delete_session(self, line, cell="", local_ns=None):
-        if self.session_started:
-            self.spark_controller.delete_session_by_name(self.session_name)
+        try:
+            if self.session_started:
+                self.spark_controller.delete_session_by_name(self.session_name)
+        finally:
             self.session_started = False
 
     @magic_arguments()

--- a/remotespark/kernels/kernelmagics.py
+++ b/remotespark/kernels/kernelmagics.py
@@ -18,8 +18,8 @@ from remotespark.livyclientlib.endpoint import Endpoint
 from remotespark.magics.sparkmagicsbase import SparkMagicBase
 from remotespark.utils.constants import LANGS_SUPPORTED
 from remotespark.utils.sparkevents import SparkEvents
-from remotespark.utils.utils import generate_uuid, get_livy_kind, wrap_unexpected_exceptions, \
-    handle_expected_exceptions
+from remotespark.utils.utils import generate_uuid, get_livy_kind
+from remotespark.livyclientlib.exceptions import handle_expected_exceptions, wrap_unexpected_exceptions
 
 
 def _event(f):
@@ -290,6 +290,9 @@ class KernelMagics(SparkMagicBase):
         try:
             if self.session_started:
                 self.spark_controller.delete_session_by_name(self.session_name)
+        except:
+            # The exception will be logged and handled in the frontend.
+            raise
         finally:
             self.session_started = False
 

--- a/remotespark/kernels/wrapperkernel/sparkkernelbase.py
+++ b/remotespark/kernels/wrapperkernel/sparkkernelbase.py
@@ -5,6 +5,7 @@ from ipykernel.ipkernel import IPythonKernel
 from remotespark.utils.ipythondisplay import IpythonDisplay
 
 import remotespark.utils.configuration as conf
+from remotespark.utils.utils import wrap_unexpected_exceptions
 from remotespark.utils.log import Log
 from remotespark.kernels.wrapperkernel.usercodeparser import UserCodeParser
 
@@ -24,9 +25,9 @@ class SparkKernelBase(IPythonKernel):
 
         super(SparkKernelBase, self).__init__(**kwargs)
 
-        self._logger = Log("_jupyter_kernel".format(self.session_language))
+        self.logger = Log("_jupyter_kernel".format(self.session_language))
         self._fatal_error = None
-        self._ipython_display = IpythonDisplay()
+        self.ipython_display = IpythonDisplay()
 
         if user_code_parser is None:
             self.user_code_parser = UserCodeParser()
@@ -43,14 +44,12 @@ class SparkKernelBase(IPythonKernel):
                 self._register_auto_viz()
 
     def do_execute(self, code, silent, store_history=True, user_expressions=None, allow_stdin=False):
-        try:
+        def f(self):
             if self._fatal_error is not None:
                 return self._repeat_fatal_error()
 
             return self._do_execute(code, silent, store_history, user_expressions, allow_stdin)
-        except Exception as e:
-            self._show_internal_error(e)
-            return self._complete_cell()
+        return wrap_unexpected_exceptions(f, self._complete_cell)(self)
 
     def do_shutdown(self, restart):
         # Cleanup
@@ -69,13 +68,13 @@ class SparkKernelBase(IPythonKernel):
         register_magics_code = "%load_ext remotespark.kernels"
         self._execute_cell(register_magics_code, True, False, shutdown_if_error=True,
                            log_if_error="Failed to load the Spark kernels magics library.")
-        self._logger.debug("Loaded magics.")
+        self.logger.debug("Loaded magics.")
 
     def _change_language(self):
         register_magics_code = "%%_do_not_call_change_language -l {}\n ".format(self.session_language)
         self._execute_cell(register_magics_code, True, False, shutdown_if_error=True,
                            log_if_error="Failed to change language to {}.".format(self.session_language))
-        self._logger.debug("Changed language.")
+        self.logger.debug("Changed language.")
 
     def _register_auto_viz(self):
         register_auto_viz_code = """from remotespark.datawidgets.utils import display_dataframe
@@ -83,7 +82,7 @@ ip = get_ipython()
 ip.display_formatter.ipython_display_formatter.for_type_by_name('pandas.core.frame', 'DataFrame', display_dataframe)"""
         self._execute_cell(register_auto_viz_code, True, False, shutdown_if_error=True,
                            log_if_error="Failed to register auto viz for notebook.")
-        self._logger.debug("Registered auto viz.")
+        self.logger.debug("Registered auto viz.")
 
     def _delete_session(self):
         code = "%%_do_not_call_delete_session\n "
@@ -114,14 +113,8 @@ ip.display_formatter.ipython_display_formatter.for_type_by_name('pandas.core.fra
         return self._execute_cell("None", False, True, None, False)
 
     def _show_user_error(self, message):
-        self._logger.error(message)
-        self._ipython_display.send_error(message)
-
-    def _show_internal_error(self, e):
-        self._logger.error("ENCOUNTERED AN INTERNAL ERROR: {}".format(e))
-        self._ipython_display.send_error("An internal error was encountered.\n"
-                                         "Please file an issue at https://github.com/jupyter-incubator/sparkmagic\n"
-                                         "Error:\n{}".format(e))
+        self.logger.error(message)
+        self.ipython_display.send_error(message)
 
     def _queue_fatal_error(self, message):
         """Queues up a fatal error to be thrown when the next cell is executed; does not
@@ -137,6 +130,6 @@ ip.display_formatter.ipython_display_formatter.for_type_by_name('pandas.core.fra
     def _repeat_fatal_error(self):
         """Throws an error that has already been queued."""
         error = conf.fatal_error_suggestion().format(self._fatal_error)
-        self._logger.error(error)
-        self._ipython_display.send_error(error)
+        self.logger.error(error)
+        self.ipython_display.send_error(error)
         return self._complete_cell()

--- a/remotespark/kernels/wrapperkernel/sparkkernelbase.py
+++ b/remotespark/kernels/wrapperkernel/sparkkernelbase.py
@@ -5,7 +5,7 @@ from ipykernel.ipkernel import IPythonKernel
 from remotespark.utils.ipythondisplay import IpythonDisplay
 
 import remotespark.utils.configuration as conf
-from remotespark.utils.utils import wrap_unexpected_exceptions
+from remotespark.livyclientlib.exceptions import wrap_unexpected_exceptions
 from remotespark.utils.log import Log
 from remotespark.kernels.wrapperkernel.usercodeparser import UserCodeParser
 

--- a/remotespark/livyclientlib/command.py
+++ b/remotespark/livyclientlib/command.py
@@ -4,6 +4,9 @@ from remotespark.utils.guid import ObjectWithGuid
 from remotespark.utils.log import Log
 from remotespark.utils.sparkevents import SparkEvents
 
+from .exceptions import LivyUnexpectedStatusException
+
+
 class Command(ObjectWithGuid):
     def __init__(self, code, spark_events=None):
         super(Command, self).__init__()
@@ -59,6 +62,7 @@ class Command(ObjectWithGuid):
                     out = (False,
                            statement_output["evalue"] + "\n" + "".join(statement_output["traceback"]))
                 else:
-                    raise ValueError("Unknown output status: '{}'".format(statement_output["status"]))
+                    raise LivyUnexpectedStatusException("Unknown output status from Livy: '{}'"
+                                                        .format(statement_output["status"]))
 
         return out

--- a/remotespark/livyclientlib/dataframeparseexception.py
+++ b/remotespark/livyclientlib/dataframeparseexception.py
@@ -1,6 +1,0 @@
-"""An exception that is thrown by the Livy client when it can't parse a dataframe
-(i.e. when the query resulted in an error"""
-
-class DataFrameParseException(Exception):
-    def __init__(self, out=None):
-        self.out = out

--- a/remotespark/livyclientlib/endpoint.py
+++ b/remotespark/livyclientlib/endpoint.py
@@ -1,7 +1,10 @@
+from .exceptions import BadUserDataException
+
+
 class Endpoint(object):
     def __init__(self, url, username="", password=""):
         if not url:
-            raise ValueError("URL must not be empty")
+            raise BadUserDataException("URL must not be empty")
         self.url = url.rstrip("/")
         self.username = username
         self.password = password

--- a/remotespark/livyclientlib/exceptions.py
+++ b/remotespark/livyclientlib/exceptions.py
@@ -12,8 +12,8 @@ class LivyClientLibException(Exception):
 
     We distinguish between "expected" errors, which represent errors that a user is likely
     to encounter in normal use, and "internal" errors, which represents exceptions that happen
-    due to a bug in the underlying source. Check the source for the wrap_unexpected_exceptions
-    function to see which exceptions are considered internal."""
+    due to a bug in the library. Check EXPECTED_EXCEPTIONS to see which exceptions
+    are considered "expected"."""
 
 
 class FailedToCreateSqlContextException(LivyClientLibException):
@@ -45,10 +45,14 @@ class SessionManagementException(LivyClientLibException):
 
 class BadUserDataException(LivyClientLibException):
     """An exception that is thrown when data provided by the user is invalid
-    in some way"""
+    in some way."""
 
 
 # == DECORATORS FOR EXCEPTION HANDLING ==
+EXPECTED_EXCEPTIONS = [BadUserDataException, LivyUnexpectedStatusException, FailedToCreateSqlContextException,
+                       HttpClientException, LivyClientTimeoutException, SessionManagementException]
+
+
 def handle_expected_exceptions(f):
     """A decorator that handles expected exceptions. Self can be any object with
     an "ipython_display" attribute.
@@ -56,8 +60,7 @@ def handle_expected_exceptions(f):
     @handle_expected_exceptions
     def fn(self, ...):
         etc..."""
-    exceptions_to_handle = (BadUserDataException, LivyUnexpectedStatusException, FailedToCreateSqlContextException,
-                            HttpClientException, LivyClientTimeoutException, SessionManagementException)
+    exceptions_to_handle = tuple(EXPECTED_EXCEPTIONS)
 
     # Notice that we're NOT handling e.DataFrameParseException here. That's because DataFrameParseException
     # is an internal error that suggests something is wrong with LivyClientLib's implementation.

--- a/remotespark/livyclientlib/exceptions.py
+++ b/remotespark/livyclientlib/exceptions.py
@@ -1,0 +1,34 @@
+class LivyClientLibException(Exception):
+    pass
+
+
+class FailedToCreateSqlContextException(LivyClientLibException):
+    """Exception that is thrown when the SQL context fails to be created on session start."""
+
+
+class HttpClientException(LivyClientLibException):
+    """An exception thrown by the HTTP client when it fails to make a request."""
+
+
+class LivyClientTimeoutException(LivyClientLibException):
+    """An exception for timeouts while interacting with Livy."""
+
+
+class DataFrameParseException(LivyClientLibException):
+    """An internal error which suggests a bad implementation of dataframe parsing from JSON --
+    if we get a JSON parsing error when parsing the results from the Livy server, this exception
+    is thrown."""
+
+
+class LivyUnexpectedStatusException(LivyClientLibException):
+    """An exception that will be shown if some unexpected error happens on the Livy side."""
+
+
+class SessionManagementException(LivyClientLibException):
+    """An exception that is thrown by the Session Manager when it is a
+    given session name is invalid in some way."""
+
+
+class BadUserDataException(LivyClientLibException):
+    """An exception that is thrown when data provided by the user is invalid
+    in some way"""

--- a/remotespark/livyclientlib/livyclienttimeouterror.py
+++ b/remotespark/livyclientlib/livyclienttimeouterror.py
@@ -1,6 +1,0 @@
-# Copyright (c) 2015  aggftw@gmail.com
-# Distributed under the terms of the Modified BSD License.
-
-
-class LivyClientTimeoutError(Exception):
-    """An exception for timeouts while interacting with Livy."""

--- a/remotespark/livyclientlib/livyreliablehttpclient.py
+++ b/remotespark/livyclientlib/livyreliablehttpclient.py
@@ -6,8 +6,8 @@ from .reliablehttpclient import ReliableHttpClient
 
 
 class LivyReliableHttpClient(object):
-    """Default headers."""
-
+    """A Livy-specific Http client which wraps the normal ReliableHttpClient. Propagates
+    HttpClientExceptions up."""
     def __init__(self, http_client):
         self._http_client = http_client
 

--- a/remotespark/livyclientlib/livyunexpectedstatuserror.py
+++ b/remotespark/livyclientlib/livyunexpectedstatuserror.py
@@ -1,3 +1,0 @@
-class LivyUnexpectedStatusError(Exception):
-    """An exception that will be shown if some unexpected error happens on the Livy side."""
-    pass

--- a/remotespark/livyclientlib/reliablehttpclient.py
+++ b/remotespark/livyclientlib/reliablehttpclient.py
@@ -8,6 +8,7 @@ import requests
 
 import remotespark.utils.configuration as conf
 from remotespark.utils.log import Log
+from remotespark.livyclientlib.exceptions import HttpClientException
 
 
 class ReliableHttpClient(object):
@@ -74,6 +75,6 @@ class ReliableHttpClient(object):
                     retry_count += 1
                     continue
                 else:
-                    raise ValueError("Invalid status code '{}' or error '{}' from {}"
-                                     .format(status, error, url))
+                    raise HttpClientException("Invalid status code '{}' or error '{}' from {}"
+                                              .format(status, error, url))
             return r

--- a/remotespark/livyclientlib/sessionmanager.py
+++ b/remotespark/livyclientlib/sessionmanager.py
@@ -2,11 +2,10 @@
 # Distributed under the terms of the Modified BSD License.
 
 from remotespark.utils.log import Log
+from remotespark.livyclientlib.exceptions import SessionManagementException
 
 
 class SessionManager(object):
-    """Livy session manager"""
-
     def __init__(self):
         self.logger = Log("SessionManager")
 
@@ -24,8 +23,8 @@ class SessionManager(object):
 
     def add_session(self, name, session):
         if name in self._sessions:
-            raise ValueError("Session with name '{}' already exists. Please delete the session"
-                             " first if you intend to replace it.".format(name))
+            raise SessionManagementException("Session with name '{}' already exists. Please delete the session"
+                                             " first if you intend to replace it.".format(name))
 
         self._sessions[name] = session
 
@@ -35,15 +34,15 @@ class SessionManager(object):
             key = self.get_sessions_list()[0]
             return self._sessions[key]
         elif number_of_sessions == 0:
-            raise AssertionError("You need to have at least 1 client created to execute commands.")
+            raise SessionManagementException("You need to have at least 1 client created to execute commands.")
         else:
-            raise AssertionError("Please specify the client to use. Possible sessions are {}".format(
+            raise SessionManagementException("Please specify the client to use. Possible sessions are {}".format(
                 self.get_sessions_list()))
         
     def get_session(self, name):
         if name in self._sessions:
             return self._sessions[name]
-        raise ValueError("Could not find '{}' session in list of saved sessions. Possible sessions are {}".format(
+        raise SessionManagementException("Could not find '{}' session in list of saved sessions. Possible sessions are {}".format(
             name, self.get_sessions_list()))
 
     def get_session_id_for_client(self, name):
@@ -63,5 +62,5 @@ class SessionManager(object):
             self._sessions[name].delete()
             del self._sessions[name]
         else:
-            raise ValueError("Could not find '{}' session in list of saved sessions. Possible sessions are {}"
-                             .format(name, self.get_sessions_list()))
+            raise SessionManagementException("Could not find '{}' session in list of saved sessions. Possible sessions are {}"
+                                             .format(name, self.get_sessions_list()))

--- a/remotespark/livyclientlib/sparkcontroller.py
+++ b/remotespark/livyclientlib/sparkcontroller.py
@@ -8,19 +8,14 @@ from .livysession import LivySession
 
 
 class SparkController(object):
-
     def __init__(self, ipython_display):
         self.logger = Log("SparkController")
         self.ipython_display = ipython_display
         self.session_manager = SessionManager()
 
     def get_logs(self, client_name=None):
-        try:
-            session_to_use = self.get_session_by_name_or_default(client_name)
-            out = session_to_use.get_logs()
-            return True, out
-        except ValueError as err:
-            return False, "{}".format(err)
+        session_to_use = self.get_session_by_name_or_default(client_name)
+        return session_to_use.get_logs()
 
     def run_command(self, command, client_name=None):
         session_to_use = self.get_session_by_name_or_default(client_name)
@@ -37,7 +32,7 @@ class SparkController(object):
                                            self.ipython_display, s["id"])
                         for s in sessions]
         for s in session_list:
-            s._refresh_status()
+            s.refresh_status()
         return session_list
 
     def get_all_sessions_endpoint_info(self, endpoint):
@@ -56,15 +51,11 @@ class SparkController(object):
 
     def delete_session_by_id(self, endpoint, session_id):
         http_client = self._http_client(endpoint)
-        try:
-            response = http_client.get_session(session_id)
-            http_client = self._http_client(endpoint)
-            session = self._livy_session(http_client, {"kind": response["kind"]},
-                                         self.ipython_display, session_id, False)
-            session.delete()
-        except ValueError:
-            # Session does not exist; do nothing
-            pass
+        response = http_client.get_session(session_id)
+        http_client = self._http_client(endpoint)
+        session = self._livy_session(http_client, {"kind": response["kind"]},
+                                     self.ipython_display, session_id, False)
+        session.delete()
 
     def add_session(self, name, endpoint, skip_if_exists, properties):
         if skip_if_exists and (name in self.session_manager.get_sessions_list()):

--- a/remotespark/livyclientlib/sqlquery.py
+++ b/remotespark/livyclientlib/sqlquery.py
@@ -8,7 +8,7 @@ from remotespark.utils.sparkevents import SparkEvents
 from remotespark.utils.utils import coerce_pandas_df_to_numeric_datetime
 
 from .command import Command
-from .dataframeparseexception import DataFrameParseException
+from .exceptions import DataFrameParseException, BadUserDataException
 
 
 class SQLQuery(ObjectWithGuid):
@@ -22,11 +22,11 @@ class SQLQuery(ObjectWithGuid):
             samplefraction = conf.default_samplefraction()
 
         if samplemethod not in {'take', 'sample'}:
-            raise ValueError('samplemethod (-m) must be one of (take, sample)')
+            raise BadUserDataException('samplemethod (-m) must be one of (take, sample)')
         if not isinstance(maxrows, int):
-            raise ValueError('maxrows (-n) must be an integer')
+            raise BadUserDataException('maxrows (-n) must be an integer')
         if not 0.0 <= samplefraction <= 1.0:
-            raise ValueError('samplefraction (-r) must be a float between 0.0 and 1.0')
+            raise BadUserDataException('samplefraction (-r) must be a float between 0.0 and 1.0')
 
         self.query = query
         self.samplemethod = samplemethod
@@ -44,7 +44,7 @@ class SQLQuery(ObjectWithGuid):
         elif kind == constants.SESSION_KIND_SPARKR:
             return self._r_command()
         else:
-            raise ValueError("Kind '{}' is not supported.".format(kind))
+            raise BadUserDataException("Kind '{}' is not supported.".format(kind))
 
     def execute(self, session):
         self._spark_events.emit_sql_execution_start_event(session.guid, session.kind, session.id, self.guid,

--- a/remotespark/livyclientlib/sqlquery.py
+++ b/remotespark/livyclientlib/sqlquery.py
@@ -21,9 +21,12 @@ class SQLQuery(ObjectWithGuid):
         if samplefraction is None:
             samplefraction = conf.default_samplefraction()
 
-        assert samplemethod == 'take' or samplemethod == 'sample'
-        assert isinstance(maxrows, int)
-        assert 0.0 <= samplefraction <= 1.0
+        if samplemethod not in {'take', 'sample'}:
+            raise ValueError('samplemethod (-m) must be one of (take, sample)')
+        if not isinstance(maxrows, int):
+            raise ValueError('maxrows (-n) must be an integer')
+        if not 0.0 <= samplefraction <= 1.0:
+            raise ValueError('samplefraction (-r) must be a float between 0.0 and 1.0')
 
         self.query = query
         self.samplemethod = samplemethod

--- a/remotespark/magics/remotesparkmagics.py
+++ b/remotespark/magics/remotesparkmagics.py
@@ -19,7 +19,7 @@ from remotespark.livyclientlib.endpoint import Endpoint
 from remotespark.magics.sparkmagicsbase import SparkMagicBase
 from remotespark.utils.constants import CONTEXT_NAME_SPARK, CONTEXT_NAME_SQL, LANG_PYTHON, LANG_R, LANG_SCALA
 from remotespark.utils.ipywidgetfactory import IpyWidgetFactory
-from remotespark.utils.utils import handle_expected_exceptions
+from remotespark.livyclientlib.exceptions import handle_expected_exceptions
 
 
 @magics_class

--- a/remotespark/magics/sparkmagicsbase.py
+++ b/remotespark/magics/sparkmagicsbase.py
@@ -32,11 +32,7 @@ class SparkMagicBase(Magics):
 
     def execute_sqlquery(self, cell, samplemethod, maxrows, samplefraction,
                          session, output_var, quiet):
-        try:
-            sqlquery = self._sqlquery(cell, samplemethod, maxrows, samplefraction)
-        except ValueError as e:
-            self.ipython_display.send_error('Cannot create SQL query with given options: "{}"'.format(str(e)))
-            return None
+        sqlquery = self._sqlquery(cell, samplemethod, maxrows, samplefraction)
         df = self.spark_controller.run_sqlquery(sqlquery, session)
         if output_var is not None:
             self.shell.user_ns[output_var] = df

--- a/remotespark/magics/sparkmagicsbase.py
+++ b/remotespark/magics/sparkmagicsbase.py
@@ -11,7 +11,7 @@ from remotespark.utils.ipythondisplay import IpythonDisplay
 from remotespark.utils.log import Log
 from remotespark.utils.sparkevents import SparkEvents
 from remotespark.livyclientlib.sparkcontroller import SparkController
-from remotespark.livyclientlib.dataframeparseexception import DataFrameParseException
+from remotespark.livyclientlib.sqlquery import SQLQuery
 
 
 @magics_class
@@ -30,18 +30,24 @@ class SparkMagicBase(Magics):
             spark_events = SparkEvents()
         spark_events.emit_library_loaded_event()
 
-    def execute_sqlquery(self, sqlquery, session, output_var, quiet):
+    def execute_sqlquery(self, cell, samplemethod, maxrows, samplefraction,
+                         session, output_var, quiet):
         try:
-            df = self.spark_controller.run_sqlquery(sqlquery, session)
-            if output_var is not None:
-                self.shell.user_ns[output_var] = df
-            if quiet:
-                return None
-            else:
-                return df
-        except DataFrameParseException as e:
-            self.ipython_display.send_error(e.out)
+            sqlquery = self._sqlquery(cell, samplemethod, maxrows, samplefraction)
+        except ValueError as e:
+            self.ipython_display.send_error('Cannot create SQL query with given options: "{}"'.format(str(e)))
             return None
+        df = self.spark_controller.run_sqlquery(sqlquery, session)
+        if output_var is not None:
+            self.shell.user_ns[output_var] = df
+        if quiet:
+            return None
+        else:
+            return df
+
+    @staticmethod
+    def _sqlquery(cell, samplemethod, maxrows, samplefraction):
+        return SQLQuery(cell, samplemethod, maxrows, samplefraction)
 
     @staticmethod
     def print_endpoint_info(info_sessions):

--- a/remotespark/utils/constants.py
+++ b/remotespark/utils/constants.py
@@ -68,3 +68,7 @@ FINAL_STATUS = [DEAD_SESSION_STATUS, ERROR_SESSION_STATUS]
 DELETE_SESSION_ACTION = "delete"
 START_SESSION_ACTION = "start"
 DO_NOTHING_ACTION = "nothing"
+
+INTERNAL_ERROR_MSG = "An internal error was encountered.\n" \
+                     "Please file an issue at https://github.com/jupyter-incubator/sparkmagic\nError:\n{}"
+EXPECTED_ERROR_MSG = "An error was encountered:\n{}"

--- a/remotespark/utils/sparkevents.py
+++ b/remotespark/utils/sparkevents.py
@@ -41,8 +41,6 @@ class SparkEvents:
     def emit_session_creation_end_event(self, session_guid, language, session_id, status,
                                         success, exception_type, exception_message):
         self._verify_language_ok(language)
-        assert session_id >= 0
-        assert status in constants.POSSIBLE_SESSION_STATUS
 
         event_name = constants.SESSION_CREATION_END_EVENT
         time_stamp = self._get_utc_date_time()
@@ -61,8 +59,6 @@ class SparkEvents:
 
     def emit_session_deletion_start_event(self, session_guid, language, session_id, status):
         self._verify_language_ok(language)
-        assert session_id >= 0
-        assert status in constants.POSSIBLE_SESSION_STATUS
 
         event_name = constants.SESSION_DELETION_START_EVENT
         time_stamp = self._get_utc_date_time()
@@ -79,8 +75,6 @@ class SparkEvents:
     def emit_session_deletion_end_event(self, session_guid, language, session_id, status,
                                         success, exception_type, exception_message):
         self._verify_language_ok(language)
-        assert session_id >= 0
-        assert status in constants.POSSIBLE_SESSION_STATUS
 
         event_name = constants.SESSION_DELETION_END_EVENT
         time_stamp = self._get_utc_date_time()

--- a/remotespark/utils/utils.py
+++ b/remotespark/utils/utils.py
@@ -7,68 +7,16 @@
 
 import os
 import uuid
-import pandas as pd
+
 import numpy as np
-import traceback
+import pandas as pd
 
-from .filesystemreaderwriter import FileSystemReaderWriter
 from .constants import LANG_SCALA, LANG_PYTHON, LANG_R, \
-    SESSION_KIND_SPARKR, SESSION_KIND_SPARK, SESSION_KIND_PYSPARK, INTERNAL_ERROR_MSG, \
-    EXPECTED_ERROR_MSG
-
+    SESSION_KIND_SPARKR, SESSION_KIND_SPARK, SESSION_KIND_PYSPARK
+from .filesystemreaderwriter import FileSystemReaderWriter
 
 first_run = True
 instance_id = None
-
-
-def handle_expected_exceptions(f):
-    """A decorator that handles expected exceptions. Self can be any object with
-    an "ipython_display" attribute.
-    Usage:
-    @handle_expected_exceptions
-    def fn(self, ...):
-        etc..."""
-    import remotespark.livyclientlib.exceptions as e
-    exceptions_to_handle = (e.BadUserDataException, e.LivyUnexpectedStatusException, e.FailedToCreateSqlContextException,
-                            e.HttpClientException, e.LivyClientTimeoutException, e.SessionManagementException)
-
-    # Notice that we're NOT handling e.DataFrameParseException here. That's because DataFrameParseException
-    # is an internal error that suggests something is wrong with LivyClientLib's implementation.
-    def wrapped(self, *args, **kwargs):
-        try:
-            out = f(self, *args, **kwargs)
-        except exceptions_to_handle as err:
-            self.ipython_display.send_error(EXPECTED_ERROR_MSG.format(err))
-            return None
-        else:
-            return out
-    wrapped.__name__ = f.__name__
-    wrapped.__doc__ = f.__doc__
-    return wrapped
-
-
-def wrap_unexpected_exceptions(f, execute_if_error=None):
-    """A decorator that catches all exceptions from the function f and alerts the user about them.
-    Self can be any object with a "logger" attribute and a "ipython_display" attribute.
-    All exceptions are logged as "unexpected" exceptions, and a request is made to the user to file an issue
-    at the Github repository. If there is an error, returns None if execute_if_error is None, or else
-    returns the output of the function execute_if_error.
-    Usage:
-    @wrap_unexpected_exceptions
-    def fn(self, ...):
-        ..etc """
-    def wrapped(self, *args, **kwargs):
-        try:
-            out = f(self, *args, **kwargs)
-        except Exception as e:
-            self.logger.error("ENCOUNTERED AN INTERNAL ERROR: {}\n\tTraceback:\n{}".format(e, traceback.format_exc()))
-            self.ipython_display.send_error(INTERNAL_ERROR_MSG.format(e))
-            return None if execute_if_error is None else execute_if_error()
-        else:
-            return out
-    wrapped.__name__ = f.__name__
-    wrapped.__doc__ = f.__doc__
-    return wrapped
 
 
 def expand_path(path):

--- a/remotespark/utils/utils.py
+++ b/remotespark/utils/utils.py
@@ -25,13 +25,9 @@ def handle_expected_exceptions(f):
     """A decorator that handles expected exceptions. Self can be any object with
     an "ipython_display" attribute.
     Usage:
-    @handle_expected_exceptions()
+    @handle_expected_exceptions
     def fn(self, ...):
-
-    or
-
-    @handle_expected_exceptions(value_to_return)
-    def fn(self, ...)"""
+        etc..."""
     import remotespark.livyclientlib.exceptions as e
     exceptions_to_handle = (e.BadUserDataException, e.LivyUnexpectedStatusException, e.FailedToCreateSqlContextException,
                             e.HttpClientException, e.LivyClientTimeoutException, e.SessionManagementException)

--- a/tests/test_kernel_magics.py
+++ b/tests/test_kernel_magics.py
@@ -3,7 +3,7 @@ from nose.tools import with_setup, raises, assert_equals, assert_is
 from IPython.core.magic import magics_class
 
 from remotespark.kernels.kernelmagics import KernelMagics
-from remotespark.livyclientlib.livyclienttimeouterror import LivyClientTimeoutError
+from remotespark.livyclientlib.exceptions import LivyClientTimeoutException
 from remotespark.livyclientlib.endpoint import Endpoint
 from remotespark.livyclientlib.command import Command
 from remotespark.livyclientlib.sqlquery import SQLQuery
@@ -49,9 +49,7 @@ def _teardown():
 @with_setup(_setup, _teardown)
 @raises(NotImplementedError)
 def test_local():
-    line = ""
-
-    magic.local(line)
+    magic.local("")
 
 
 @with_setup(_setup, _teardown)
@@ -76,7 +74,7 @@ def test_start_session():
 @with_setup(_setup, _teardown)
 def test_start_session_times_out():
     line = ""
-    spark_controller.add_session = MagicMock(side_effect=LivyClientTimeoutError)
+    spark_controller.add_session = MagicMock(side_effect=LivyClientTimeoutException)
     assert not magic.session_started
 
     ret = magic._do_not_call_start_session(line)

--- a/tests/test_reliablehttpclient.py
+++ b/tests/test_reliablehttpclient.py
@@ -6,6 +6,7 @@ from nose.tools import raises, assert_equals, with_setup
 import requests
 
 from remotespark.livyclientlib.endpoint import Endpoint
+from remotespark.livyclientlib.exceptions import HttpClientException
 from remotespark.livyclientlib.linearretrypolicy import LinearRetryPolicy
 from remotespark.livyclientlib.reliablehttpclient import ReliableHttpClient
 
@@ -62,7 +63,7 @@ def test_get():
         assert_equals(200, result.status_code)
 
 
-@raises(ValueError)
+@raises(HttpClientException)
 @with_setup(_setup, _teardown)
 def test_get_throws():
     with patch('requests.get') as patched_get:
@@ -108,7 +109,7 @@ def test_post():
         assert_equals(200, result.status_code)
 
 
-@raises(ValueError)
+@raises(HttpClientException)
 @with_setup(_setup, _teardown)
 def test_post_throws():
     with patch('requests.post') as patched_post:
@@ -154,7 +155,7 @@ def test_delete():
         assert_equals(200, result.status_code)
 
 
-@raises(ValueError)
+@raises(HttpClientException)
 @with_setup(_setup, _teardown)
 def test_delete_throws():
     with patch('requests.delete') as patched_delete:
@@ -202,7 +203,7 @@ def test_will_retry_error_no():
         try:
             client.get("r", [200])
             assert False
-        except ValueError:
+        except HttpClientException:
             retry_policy.should_retry.assert_called_once_with(None, True, 0)
 
 

--- a/tests/test_remotesparkmagics.py
+++ b/tests/test_remotesparkmagics.py
@@ -2,7 +2,7 @@ from mock import MagicMock
 from nose.tools import with_setup
 
 import remotespark.utils.configuration as conf
-import remotespark.utils.constants as constants
+from remotespark.utils.constants import EXPECTED_ERROR_MSG
 from remotespark.magics.remotesparkmagics import RemoteSparkMagics
 from remotespark.livyclientlib.command import Command
 from remotespark.livyclientlib.endpoint import Endpoint
@@ -63,7 +63,7 @@ def test_info_command_exception():
     magic.spark(command)
 
     print_info_mock.assert_called_once_with()
-    ipython_display.send_error.assert_called_once_with(constants.EXPECTED_ERROR_MSG
+    ipython_display.send_error.assert_called_once_with(EXPECTED_ERROR_MSG
                                                        .format(print_info_mock.side_effect))
 
 
@@ -113,7 +113,7 @@ def test_add_sessions_command_exception():
 
     add_sessions_mock.assert_called_once_with("name", Endpoint("http://url.com", "sdf", "w"),
                                               False, {"kind": "pyspark"})
-    ipython_display.send_error.assert_called_once_with(constants.EXPECTED_ERROR_MSG
+    ipython_display.send_error.assert_called_once_with(EXPECTED_ERROR_MSG
                                                        .format(add_sessions_mock.side_effect))
 
 
@@ -160,7 +160,7 @@ def test_delete_sessions_command_exception():
     command = "delete -s name"
     magic.spark(command)
     mock_method.assert_called_once_with("name")
-    ipython_display.send_error.assert_called_once_with(constants.EXPECTED_ERROR_MSG
+    ipython_display.send_error.assert_called_once_with(EXPECTED_ERROR_MSG
                                                        .format(mock_method.side_effect))
 
 
@@ -183,7 +183,7 @@ def test_cleanup_command_exception():
 
     magic.spark(line)
     mock_method.assert_called_once_with()
-    ipython_display.send_error.assert_called_once_with(constants.EXPECTED_ERROR_MSG
+    ipython_display.send_error.assert_called_once_with(EXPECTED_ERROR_MSG
                                                        .format(mock_method.side_effect))
 
 
@@ -265,7 +265,7 @@ def test_run_cell_command_exception():
 
     run_cell_method.assert_called_once_with(Command(cell), name)
     assert result is None
-    ipython_display.send_error.assert_called_once_with(constants.EXPECTED_ERROR_MSG
+    ipython_display.send_error.assert_called_once_with(EXPECTED_ERROR_MSG
                                                        .format(run_cell_method.side_effect))
 
 
@@ -308,7 +308,7 @@ def test_run_sql_command_exception():
     result = magic.spark(line, cell)
 
     run_cell_method.assert_called_once_with(SQLQuery(cell, samplemethod=method_name), name)
-    ipython_display.send_error.assert_called_once_with(constants.EXPECTED_ERROR_MSG
+    ipython_display.send_error.assert_called_once_with(EXPECTED_ERROR_MSG
                                                        .format(run_cell_method.side_effect))
 
 
@@ -369,5 +369,5 @@ def test_logs_exception():
 
     get_logs_method.assert_called_once_with(name)
     assert result is None
-    ipython_display.send_error.assert_called_once_with(constants.EXPECTED_ERROR_MSG
+    ipython_display.send_error.assert_called_once_with(EXPECTED_ERROR_MSG
                                                        .format(get_logs_method.side_effect))

--- a/tests/test_remotesparkmagics.py
+++ b/tests/test_remotesparkmagics.py
@@ -2,10 +2,13 @@ from mock import MagicMock
 from nose.tools import with_setup
 
 import remotespark.utils.configuration as conf
+import remotespark.utils.constants as constants
 from remotespark.magics.remotesparkmagics import RemoteSparkMagics
 from remotespark.livyclientlib.command import Command
 from remotespark.livyclientlib.endpoint import Endpoint
+from remotespark.livyclientlib.exceptions import *
 from remotespark.livyclientlib.sqlquery import SQLQuery
+
 
 magic = None
 spark_controller = None
@@ -52,6 +55,19 @@ def test_info_endpoint_command_parses():
 
 
 @with_setup(_setup, _teardown)
+def test_info_command_exception():
+    print_info_mock = MagicMock(side_effect=LivyClientTimeoutException('OHHHHHOHOHOHO'))
+    magic._print_local_info = print_info_mock
+    command = "info"
+
+    magic.spark(command)
+
+    print_info_mock.assert_called_once_with()
+    ipython_display.send_error.assert_called_once_with(constants.EXPECTED_ERROR_MSG
+                                                       .format(print_info_mock.side_effect))
+
+
+@with_setup(_setup, _teardown)
 def test_add_sessions_command_parses():
     # Do not skip and python
     add_sessions_mock = MagicMock()
@@ -80,6 +96,25 @@ def test_add_sessions_command_parses():
 
     add_sessions_mock.assert_called_once_with("name", Endpoint("http://location:port"),
                                               True, {"kind": "spark"})
+
+
+@with_setup(_setup, _teardown)
+def test_add_sessions_command_exception():
+    # Do not skip and python
+    add_sessions_mock = MagicMock(side_effect=BadUserDataException('hehe'))
+    spark_controller.add_session = add_sessions_mock
+    command = "add"
+    name = "-s name"
+    language = "-l python"
+    connection_string = "-u http://url.com -a sdf -p w"
+    line = " ".join([command, name, language, connection_string])
+
+    magic.spark(line)
+
+    add_sessions_mock.assert_called_once_with("name", Endpoint("http://url.com", "sdf", "w"),
+                                              False, {"kind": "pyspark"})
+    ipython_display.send_error.assert_called_once_with(constants.EXPECTED_ERROR_MSG
+                                                       .format(add_sessions_mock.side_effect))
 
 
 @with_setup(_setup, _teardown)
@@ -119,6 +154,17 @@ def test_delete_sessions_command_parses():
 
 
 @with_setup(_setup, _teardown)
+def test_delete_sessions_command_exception():
+    mock_method = MagicMock(side_effect=LivyUnexpectedStatusException('FEEEEEELINGS'))
+    spark_controller.delete_session_by_name = mock_method
+    command = "delete -s name"
+    magic.spark(command)
+    mock_method.assert_called_once_with("name")
+    ipython_display.send_error.assert_called_once_with(constants.EXPECTED_ERROR_MSG
+                                                       .format(mock_method.side_effect))
+
+
+@with_setup(_setup, _teardown)
 def test_cleanup_command_parses():
     mock_method = MagicMock()
     spark_controller.cleanup = mock_method
@@ -127,6 +173,18 @@ def test_cleanup_command_parses():
     magic.spark(line)
 
     mock_method.assert_called_once_with()
+
+
+@with_setup(_setup, _teardown)
+def test_cleanup_command_exception():
+    mock_method = MagicMock(side_effect=SessionManagementException('Livy did something VERY BAD'))
+    spark_controller.cleanup = mock_method
+    line = "cleanup"
+
+    magic.spark(line)
+    mock_method.assert_called_once_with()
+    ipython_display.send_error.assert_called_once_with(constants.EXPECTED_ERROR_MSG
+                                                       .format(mock_method.side_effect))
 
 
 @with_setup(_setup, _teardown)
@@ -193,6 +251,25 @@ def test_run_cell_command_writes_to_err():
 
 
 @with_setup(_setup, _teardown)
+def test_run_cell_command_exception():
+    run_cell_method = MagicMock()
+    run_cell_method.side_effect = HttpClientException('meh')
+    spark_controller.run_command = run_cell_method
+
+    command = "-s"
+    name = "sessions_name"
+    line = " ".join([command, name])
+    cell = "cell code"
+
+    result = magic.spark(line, cell)
+
+    run_cell_method.assert_called_once_with(Command(cell), name)
+    assert result is None
+    ipython_display.send_error.assert_called_once_with(constants.EXPECTED_ERROR_MSG
+                                                       .format(run_cell_method.side_effect))
+
+
+@with_setup(_setup, _teardown)
 def test_run_sql_command_parses():
     run_cell_method = MagicMock()
     run_cell_method.return_value = (True, "")
@@ -211,6 +288,28 @@ def test_run_sql_command_parses():
 
     run_cell_method.assert_called_once_with(SQLQuery(cell, samplemethod=method_name), name)
     assert result is not None
+
+
+@with_setup(_setup, _teardown)
+def test_run_sql_command_exception():
+    run_cell_method = MagicMock()
+    run_cell_method.side_effect = LivyUnexpectedStatusException('WOW')
+    spark_controller.run_sqlquery = run_cell_method
+
+    command = "-s"
+    name = "sessions_name"
+    context = "-c"
+    context_name = "sql"
+    meth = "-m"
+    method_name = "sample"
+    line = " ".join([command, name, context, context_name, meth, method_name])
+    cell = "cell code"
+
+    result = magic.spark(line, cell)
+
+    run_cell_method.assert_called_once_with(SQLQuery(cell, samplemethod=method_name), name)
+    ipython_display.send_error.assert_called_once_with(constants.EXPECTED_ERROR_MSG
+                                                       .format(run_cell_method.side_effect))
 
 
 @with_setup(_setup, _teardown)
@@ -252,3 +351,23 @@ def test_logs_subcommand():
     get_logs_method.assert_called_once_with(name)
     assert result is None
     ipython_display.write.assert_called_once_with(result_value)
+
+
+@with_setup(_setup, _teardown)
+def test_logs_exception():
+    get_logs_method = MagicMock(side_effect=LivyUnexpectedStatusException('How did this happen?'))
+    result_value = ""
+    get_logs_method.return_value = result_value
+    spark_controller.get_logs = get_logs_method
+
+    command = "logs -s"
+    name = "sessions_name"
+    line = " ".join([command, name])
+    cell = "cell code"
+
+    result = magic.spark(line, cell)
+
+    get_logs_method.assert_called_once_with(name)
+    assert result is None
+    ipython_display.send_error.assert_called_once_with(constants.EXPECTED_ERROR_MSG
+                                                       .format(get_logs_method.side_effect))

--- a/tests/test_remotesparkmagics.py
+++ b/tests/test_remotesparkmagics.py
@@ -239,7 +239,7 @@ def test_run_sql_command_knows_how_to_be_quiet():
 def test_logs_subcommand():
     get_logs_method = MagicMock()
     result_value = ""
-    get_logs_method.return_value = (True, result_value)
+    get_logs_method.return_value = result_value
     spark_controller.get_logs = get_logs_method
 
     command = "logs -s"
@@ -247,19 +247,8 @@ def test_logs_subcommand():
     line = " ".join([command, name])
     cell = "cell code"
 
-    # Could get results
     result = magic.spark(line, cell)
 
     get_logs_method.assert_called_once_with(name)
     assert result is None
     ipython_display.write.assert_called_once_with(result_value)
-
-    # Could not get results
-    get_logs_method.reset_mock()
-    get_logs_method.return_value = (False, result_value)
-
-    result = magic.spark(line, cell)
-
-    get_logs_method.assert_called_once_with(name)
-    assert result is None
-    ipython_display.send_error.assert_called_once_with(result_value)

--- a/tests/test_sessionmanager.py
+++ b/tests/test_sessionmanager.py
@@ -1,10 +1,11 @@
 ﻿from mock import MagicMock
 from nose.tools import raises, assert_equals
 
+from remotespark.livyclientlib.exceptions import SessionManagementException
 from remotespark.livyclientlib.sessionmanager import SessionManager
 
 
-@raises(ValueError)
+@raises(SessionManagementException)
 def test_get_client_throws_when_client_not_exists():
     manager = SessionManager()
 
@@ -20,7 +21,7 @@ def test_get_client():
     assert_equals(client, manager.get_session("name"))
 
 
-@raises(ValueError)
+@raises(SessionManagementException)
 def test_delete_client():
     client = MagicMock()
     manager = SessionManager()
@@ -31,14 +32,14 @@ def test_delete_client():
     manager.get_session("name")
 
 
-@raises(ValueError)
+@raises(SessionManagementException)
 def test_delete_client_throws_when_client_not_exists():
     manager = SessionManager()
 
     manager.delete_client("name")
 
 
-@raises(ValueError)
+@raises(SessionManagementException)
 def test_add_client_throws_when_client_exists():
     client = MagicMock()
     manager = SessionManager()
@@ -66,14 +67,14 @@ def test_get_any_client():
     assert_equals(client, manager.get_any_session())
 
 
-@raises(AssertionError)
+@raises(SessionManagementException)
 def test_get_any_client_raises_exception_with_no_client():
     manager = SessionManager()
 
     manager.get_any_session()
 
 
-@raises(AssertionError)
+@raises(SessionManagementException)
 def test_get_any_client_raises_exception_with_two_clients():
     client = MagicMock()
     manager = SessionManager()

--- a/tests/test_sparkkernelbase.py
+++ b/tests/test_sparkkernelbase.py
@@ -28,7 +28,7 @@ def _setup():
     kernel._execute_cell_for_user = execute_cell_mock = MagicMock(return_value={'test': 'ing', 'a': 'b',
                                                                                 'status': 'ok'})
     kernel._do_shutdown_ipykernel = do_shutdown_mock = MagicMock()
-    kernel._ipython_display = ipython_display = MagicMock()
+    kernel.ipython_display = ipython_display = MagicMock()
 
 
 def _teardown():

--- a/tests/test_sparkmagicbase.py
+++ b/tests/test_sparkmagicbase.py
@@ -4,7 +4,7 @@ from nose.tools import assert_equals
 from remotespark.utils.constants import LANGS_SUPPORTED
 from remotespark.utils.utils import get_livy_kind
 from remotespark.magics.sparkmagicsbase import SparkMagicBase
-from remotespark.livyclientlib.dataframeparseexception import DataFrameParseException
+from remotespark.livyclientlib.exceptions import DataFrameParseException
 from remotespark.livyclientlib.sqlquery import SQLQuery
 
 

--- a/tests/test_sparkmagicbase.py
+++ b/tests/test_sparkmagicbase.py
@@ -39,7 +39,7 @@ def test_df_execution_without_output_var():
     magic.spark_controller = MagicMock()
     magic.spark_controller.run_sqlquery = MagicMock(return_value=df)
 
-    res = magic.execute_sqlquery(query, session, output_var, False)
+    res = magic.execute_sqlquery("", None, None, None, session, output_var, False)
 
     magic.spark_controller.run_sqlquery.assert_called_once_with(query, session)
     assert res == df
@@ -60,7 +60,7 @@ def test_df_execution_with_output_var():
     magic.spark_controller = MagicMock()
     magic.spark_controller.run_sqlquery = MagicMock(return_value=df)
 
-    res = magic.execute_sqlquery(query, session, output_var, False)
+    res = magic.execute_sqlquery("", None, None, None, session, output_var, False)
 
     magic.spark_controller.run_sqlquery.assert_called_once_with(query, session)
     assert res == df
@@ -81,7 +81,7 @@ def test_df_execution_quiet_without_output_var():
     magic.spark_controller = MagicMock()
     magic.spark_controller.run_sqlquery = MagicMock(return_value=df)
 
-    res = magic.execute_sqlquery(cell, session, output_var, True)
+    res = magic.execute_sqlquery("", None, None, None, session, output_var, True)
 
     magic.spark_controller.run_sqlquery.assert_called_once_with(cell, session)
     assert res is None
@@ -102,29 +102,8 @@ def test_df_execution_quiet_with_output_var():
     magic.spark_controller = MagicMock()
     magic.spark_controller.run_sqlquery = MagicMock(return_value=df)
 
-    res = magic.execute_sqlquery(cell, session, output_var, True)
+    res = magic.execute_sqlquery("", None, None, None, session, output_var, True)
 
     magic.spark_controller.run_sqlquery.assert_called_once_with(cell, session)
     assert res is None
     assert shell.user_ns[output_var] == df
-
-
-def test_df_execution_throws():
-    shell = MagicMock()
-    shell.user_ns = {}
-    magic = SparkMagicBase(None)
-    magic.shell = shell
-    error = "error"
-
-    query = SQLQuery("")
-    session = MagicMock()
-    output_var = "var_name"
-
-    magic.spark_controller = MagicMock()
-    magic.spark_controller.run_sqlquery = MagicMock(side_effect=DataFrameParseException(error))
-
-    res = magic.execute_sqlquery(query, session, output_var, False)
-
-    magic.spark_controller.run_sqlquery.assert_called_once_with(query, session)
-    assert res is None
-    assert_equals(list(shell.user_ns.keys()), [])

--- a/tests/test_sqlquery.py
+++ b/tests/test_sqlquery.py
@@ -42,7 +42,7 @@ def test_sqlquery_loads_defaults():
     assert_equals(sqlquery.samplefraction, defaults[conf.default_samplefraction.__name__])
 
 
-@raises(AssertionError)
+@raises(ValueError)
 def test_sqlquery_rejects_bad_data():
     query = "HERE IS MY SQL QUERY SELECT * FROM CREATE DROP TABLE"
     samplemethod = "foo"

--- a/tests/test_sqlquery.py
+++ b/tests/test_sqlquery.py
@@ -11,7 +11,6 @@ from remotespark.livyclientlib.exceptions import BadUserDataException
 import remotespark.utils.configuration as conf
 
 
-
 def _teardown():
     conf.load()
 

--- a/tests/test_sqlquery.py
+++ b/tests/test_sqlquery.py
@@ -7,7 +7,9 @@ from pandas.util.testing import assert_frame_equal
 from remotespark.utils.constants import LONG_RANDOM_VARIABLE_NAME
 from remotespark.livyclientlib.sqlquery import SQLQuery
 from remotespark.livyclientlib.command import Command
+from remotespark.livyclientlib.exceptions import BadUserDataException
 import remotespark.utils.configuration as conf
+
 
 
 def _teardown():
@@ -42,7 +44,7 @@ def test_sqlquery_loads_defaults():
     assert_equals(sqlquery.samplefraction, defaults[conf.default_samplefraction.__name__])
 
 
-@raises(ValueError)
+@raises(BadUserDataException)
 def test_sqlquery_rejects_bad_data():
     query = "HERE IS MY SQL QUERY SELECT * FROM CREATE DROP TABLE"
     samplemethod = "foo"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,1 +1,81 @@
+from mock import MagicMock
+from nose.tools import with_setup, assert_equals, assert_is, raises
+
+from remotespark.utils.constants import EXPECTED_ERROR_MSG, INTERNAL_ERROR_MSG
+from remotespark.livyclientlib.exceptions import *
 from remotespark.utils.utils import handle_expected_exceptions, wrap_unexpected_exceptions
+
+
+self = None
+ipython_display = None
+logger = None
+
+
+def _setup():
+    global self, ipython_display, logger
+    self = MagicMock()
+    ipython_display = self.ipython_display
+    logger = self.logger
+
+
+@with_setup(_setup)
+def test_handle_expected_exceptions():
+    mock_method = MagicMock()
+    mock_method.__name__ = 'MockMethod'
+    decorated = handle_expected_exceptions(mock_method)
+    assert_equals(decorated.__name__, mock_method.__name__)
+
+    result = decorated(self, 1, 2, 3)
+    assert_equals(result, mock_method.return_value)
+    assert_equals(ipython_display.send_error.call_count, 0)
+    mock_method.assert_called_once_with(self, 1, 2, 3)
+
+
+@with_setup(_setup)
+def test_handle_expected_exceptions_handle():
+    mock_method = MagicMock(side_effect=LivyUnexpectedStatusException('ridiculous'))
+    mock_method.__name__ = 'MockMethod2'
+    decorated = handle_expected_exceptions(mock_method)
+    assert_equals(decorated.__name__, mock_method.__name__)
+
+    result = decorated(self, 1, kwarg='foo')
+    assert_is(result, None)
+    assert_equals(ipython_display.send_error.call_count, 1)
+    mock_method.assert_called_once_with(self, 1, kwarg='foo')
+
+
+@raises(ValueError)
+@with_setup(_setup)
+def test_handle_expected_exceptions_throw():
+    mock_method = MagicMock(side_effect=ValueError('HALP'))
+    mock_method.__name__ = 'mock_meth'
+    decorated = handle_expected_exceptions(mock_method)
+    assert_equals(decorated.__name__, mock_method.__name__)
+
+    result = decorated(self, 1, kwarg='foo')
+
+
+@with_setup(_setup)
+def test_wrap_unexpected_exceptions():
+    mock_method = MagicMock()
+    mock_method.__name__ = 'tos'
+    decorated = wrap_unexpected_exceptions(mock_method)
+    assert_equals(decorated.__name__, mock_method.__name__)
+
+    result = decorated(self, 0.0)
+    assert_equals(result, mock_method.return_value)
+    assert_equals(ipython_display.send_error.call_count, 0)
+    mock_method.assert_called_once_with(self, 0.0)
+
+
+@with_setup(_setup)
+def test_wrap_unexpected_exceptions_handle():
+    mock_method = MagicMock(side_effect=ValueError('~~~~~~'))
+    mock_method.__name__ = 'tos'
+    decorated = wrap_unexpected_exceptions(mock_method)
+    assert_equals(decorated.__name__, mock_method.__name__)
+
+    result = decorated(self, 'FOOBAR', FOOBAR='FOOBAR')
+    assert_is(result, None)
+    assert_equals(ipython_display.send_error.call_count, 1)
+    mock_method.assert_called_once_with(self, 'FOOBAR', FOOBAR='FOOBAR')

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,1 @@
+from remotespark.utils.utils import handle_expected_exceptions, wrap_unexpected_exceptions

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,10 +1,8 @@
 from mock import MagicMock
 from nose.tools import with_setup, assert_equals, assert_is, raises
 
-from remotespark.utils.constants import EXPECTED_ERROR_MSG, INTERNAL_ERROR_MSG
 from remotespark.livyclientlib.exceptions import *
-from remotespark.utils.utils import handle_expected_exceptions, wrap_unexpected_exceptions
-
+from remotespark.livyclientlib.exceptions import handle_expected_exceptions, wrap_unexpected_exceptions
 
 self = None
 ipython_display = None


### PR DESCRIPTION
Closes #215

* Add new exceptions. There are two "types" of exceptions, "expected" exceptions (those that we are likely to find in day-to-day use: HTTP client failing, bad input data to methods, etc.) and "unexpected" or "internal" exceptions (which we hide from the user and prompt them to send an issue to the Github repository)

* Add decorators and utilities for detecting errors and displaying appropriate messages to the user

* Different logic for error handling and reporting, especially in remotesparkmagics

* Remove some input data validation from SparkEvents which can throw errors under certain error conditions.

* Lots more unit tests