### PR TITLE
Appropriately handle when user passes in invalid JSON object to %%configure

### DIFF
--- a/remotespark/kernels/kernelmagics.py
+++ b/remotespark/kernels/kernelmagics.py
@@ -165,6 +165,11 @@ class KernelMagics(SparkMagicBase):
     @_event
     def configure(self, line, cell="", local_ns=None):
         args = parse_argstring(self.configure, line)
+        try:
+            dictionary = json.loads(cell)
+        except ValueError:
+            self.ipython_display.send_error("Could not parse JSON object from input '{}'".format(cell))
+            return
         if self.session_started:
             if not args.force:
                 self.ipython_display.send_error("A session has already been started. If you intend to recreate the "
@@ -172,10 +177,10 @@ class KernelMagics(SparkMagicBase):
                 return
             else:
                 self._do_not_call_delete_session("")
-                self._override_session_settings(cell)
+                self._override_session_settings(dictionary)
                 self._do_not_call_start_session("")
         else:
-            self._override_session_settings(cell)
+            self._override_session_settings(dictionary)
         self.info("")
 
     @cell_magic
@@ -333,7 +338,7 @@ class KernelMagics(SparkMagicBase):
 
     @staticmethod
     def _override_session_settings(settings):
-        conf.override(conf.session_configs.__name__, json.loads(settings))
+        conf.override(conf.session_configs.__name__, settings)
 
     @staticmethod
     def _generate_uuid():

--- a/tests/test_kernel_magics.py
+++ b/tests/test_kernel_magics.py
@@ -267,7 +267,7 @@ def test_configure():
     # Session not started
     conf.override_all({})
     magic.configure('', '{"extra": "yes"}')
-    assert conf.session_configs() == {"extra": "yes"}
+    assert_equals(conf.session_configs(), {"extra": "yes"})
     _assert_magic_successful_event_emitted_once('configure')
     magic.info.assert_called_once_with("")
 
@@ -310,6 +310,16 @@ def test_configure_expected_exception():
     _assert_magic_failure_event_emitted_once('configure', magic._override_session_settings.side_effect)
     ipython_display.send_error.assert_called_once_with(constants.EXPECTED_ERROR_MSG\
                                                        .format(magic._override_session_settings.side_effect))
+
+
+@with_setup(_setup, _teardown)
+def test_configure_cant_parse_object_as_json():
+    magic.info = MagicMock()
+
+    magic._override_session_settings = MagicMock(side_effect=BadUserDataException('help'))
+    magic.configure('', "I CAN'T PARSE THIS AS JSON")
+    _assert_magic_successful_event_emitted_once('configure')
+    assert_equals(ipython_display.send_error.call_count, 1)
 
 
 @with_setup(_setup, _teardown)


### PR DESCRIPTION
Display an appropriate error message when a bad input to `%%configure` is passed in.