### PR TITLE
Slightly better error messages for %%configure

### DIFF
--- a/remotespark/kernels/kernelmagics.py
+++ b/remotespark/kernels/kernelmagics.py
@@ -10,7 +10,7 @@ import json
 
 from IPython.core.magic import magics_class
 from IPython.core.magic import needs_local_scope, cell_magic
-from IPython.core.magic_arguments import argument, magic_arguments, parse_argstring
+from IPython.core.magic_arguments import argument, magic_arguments
 
 import remotespark.utils.configuration as conf
 from remotespark.livyclientlib.command import Command
@@ -18,7 +18,7 @@ from remotespark.livyclientlib.endpoint import Endpoint
 from remotespark.magics.sparkmagicsbase import SparkMagicBase
 from remotespark.utils.constants import LANGS_SUPPORTED
 from remotespark.utils.sparkevents import SparkEvents
-from remotespark.utils.utils import generate_uuid, get_livy_kind
+from remotespark.utils.utils import generate_uuid, get_livy_kind, parse_argstring_or_throw
 from remotespark.livyclientlib.exceptions import handle_expected_exceptions, wrap_unexpected_exceptions
 
 
@@ -161,12 +161,12 @@ class KernelMagics(SparkMagicBase):
     @handle_expected_exceptions
     @_event
     def configure(self, line, cell="", local_ns=None):
-        args = parse_argstring(self.configure, line)
         try:
             dictionary = json.loads(cell)
         except ValueError:
             self.ipython_display.send_error("Could not parse JSON object from input '{}'".format(cell))
             return
+        args = parse_argstring_or_throw(self.configure, line)
         if self.session_started:
             if not args.force:
                 self.ipython_display.send_error("A session has already been started. If you intend to recreate the "
@@ -207,7 +207,7 @@ class KernelMagics(SparkMagicBase):
     @handle_expected_exceptions
     def sql(self, line, cell="", local_ns=None):
         if self._do_not_call_start_session(""):
-            args = parse_argstring(self.sql, line)
+            args = parse_argstring_or_throw(self.sql, line)
             return self.execute_sqlquery(cell, args.samplemethod, args.maxrows, args.samplefraction,
                                          None, args.output, args.quiet)
         else:
@@ -220,7 +220,7 @@ class KernelMagics(SparkMagicBase):
     @handle_expected_exceptions
     @_event
     def cleanup(self, line, cell="", local_ns=None):
-        args = parse_argstring(self.cleanup, line)
+        args = parse_argstring_or_throw(self.cleanup, line)
         if args.force:
             self._do_not_call_delete_session("")
 
@@ -239,7 +239,7 @@ class KernelMagics(SparkMagicBase):
     @handle_expected_exceptions
     @_event
     def delete(self, line, cell="", local_ns=None):
-        args = parse_argstring(self.delete, line)
+        args = parse_argstring_or_throw(self.delete, line)
         session = args.session
 
         if args.session is None:
@@ -302,7 +302,7 @@ class KernelMagics(SparkMagicBase):
     @cell_magic
     @argument("-l", "--language", type=str, help="Language to use.")
     def _do_not_call_change_language(self, line, cell="", local_ns=None):
-        args = parse_argstring(self._do_not_call_change_language, line)
+        args = parse_argstring_or_throw(self._do_not_call_change_language, line)
         language = args.language.lower()
 
         if language not in LANGS_SUPPORTED:

--- a/remotespark/magics/remotesparkmagics.py
+++ b/remotespark/magics/remotesparkmagics.py
@@ -10,7 +10,7 @@ import json
 
 from IPython.core.magic import line_cell_magic, needs_local_scope
 from IPython.core.magic import magics_class
-from IPython.core.magic_arguments import argument, magic_arguments, parse_argstring
+from IPython.core.magic_arguments import argument, magic_arguments
 
 import remotespark.utils.configuration as conf
 from remotespark.controllerwidget.magicscontrollerwidget import MagicsControllerWidget
@@ -19,6 +19,7 @@ from remotespark.livyclientlib.endpoint import Endpoint
 from remotespark.magics.sparkmagicsbase import SparkMagicBase
 from remotespark.utils.constants import CONTEXT_NAME_SPARK, CONTEXT_NAME_SQL, LANG_PYTHON, LANG_R, LANG_SCALA
 from remotespark.utils.ipywidgetfactory import IpyWidgetFactory
+from remotespark.utils.utils import parse_argstring_or_throw
 from remotespark.livyclientlib.exceptions import handle_expected_exceptions
 
 
@@ -104,7 +105,7 @@ class RemoteSparkMagics(SparkMagicBase):
         """
         usage = "Please look at usage of %spark by executing `%spark?`."
         user_input = line
-        args = parse_argstring(self.spark, user_input)
+        args = parse_argstring_or_throw(self.spark, user_input)
 
         subcommand = args.command[0].lower()
 

--- a/remotespark/utils/utils.py
+++ b/remotespark/utils/utils.py
@@ -8,6 +8,8 @@
 import os
 import uuid
 
+from IPython.core.error import UsageError
+from IPython.core.magic_arguments import parse_argstring
 import numpy as np
 import pandas as pd
 
@@ -80,3 +82,13 @@ def get_livy_kind(language):
     else:
         raise ValueError("Cannot get session kind for {}.".format(language))
 
+
+def parse_argstring_or_throw(magic_func, argstring, parse_argstring=parse_argstring):
+    """An alternative to the parse_argstring method from IPython.core.magic_arguments.
+    Catches IPython.core.error.UsageError and propagates it as a
+    livyclientlib.exceptions.BadUserDataException."""
+    try:
+        return parse_argstring(magic_func, argstring)
+    except UsageError as e:
+        from remotespark.livyclientlib.exceptions import BadUserDataException
+        raise BadUserDataException(str(e))

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,80 @@
+from mock import MagicMock
+from nose.tools import with_setup, assert_equals, assert_is, raises
+
+from remotespark.livyclientlib.exceptions import *
+from remotespark.livyclientlib.exceptions import handle_expected_exceptions, wrap_unexpected_exceptions
+
+
+self = None
+ipython_display = None
+logger = None
+
+
+def _setup():
+    global self, ipython_display, logger
+    self = MagicMock()
+    ipython_display = self.ipython_display
+    logger = self.logger
+
+
+@with_setup(_setup)
+def test_handle_expected_exceptions():
+    mock_method = MagicMock()
+    mock_method.__name__ = 'MockMethod'
+    decorated = handle_expected_exceptions(mock_method)
+    assert_equals(decorated.__name__, mock_method.__name__)
+
+    result = decorated(self, 1, 2, 3)
+    assert_equals(result, mock_method.return_value)
+    assert_equals(ipython_display.send_error.call_count, 0)
+    mock_method.assert_called_once_with(self, 1, 2, 3)
+
+
+@with_setup(_setup)
+def test_handle_expected_exceptions_handle():
+    mock_method = MagicMock(side_effect=LivyUnexpectedStatusException('ridiculous'))
+    mock_method.__name__ = 'MockMethod2'
+    decorated = handle_expected_exceptions(mock_method)
+    assert_equals(decorated.__name__, mock_method.__name__)
+
+    result = decorated(self, 1, kwarg='foo')
+    assert_is(result, None)
+    assert_equals(ipython_display.send_error.call_count, 1)
+    mock_method.assert_called_once_with(self, 1, kwarg='foo')
+
+
+@raises(ValueError)
+@with_setup(_setup)
+def test_handle_expected_exceptions_throw():
+    mock_method = MagicMock(side_effect=ValueError('HALP'))
+    mock_method.__name__ = 'mock_meth'
+    decorated = handle_expected_exceptions(mock_method)
+    assert_equals(decorated.__name__, mock_method.__name__)
+
+    result = decorated(self, 1, kwarg='foo')
+
+
+@with_setup(_setup)
+def test_wrap_unexpected_exceptions():
+    mock_method = MagicMock()
+    mock_method.__name__ = 'tos'
+    decorated = wrap_unexpected_exceptions(mock_method)
+    assert_equals(decorated.__name__, mock_method.__name__)
+
+    result = decorated(self, 0.0)
+    assert_equals(result, mock_method.return_value)
+    assert_equals(ipython_display.send_error.call_count, 0)
+    mock_method.assert_called_once_with(self, 0.0)
+
+
+@with_setup(_setup)
+def test_wrap_unexpected_exceptions_handle():
+    mock_method = MagicMock(side_effect=ValueError('~~~~~~'))
+    mock_method.__name__ = 'tos'
+    decorated = wrap_unexpected_exceptions(mock_method)
+    assert_equals(decorated.__name__, mock_method.__name__)
+
+    result = decorated(self, 'FOOBAR', FOOBAR='FOOBAR')
+    assert_is(result, None)
+    assert_equals(ipython_display.send_error.call_count, 1)
+    mock_method.assert_called_once_with(self, 'FOOBAR', FOOBAR='FOOBAR')


### PR DESCRIPTION
Slightly better error messages for %%configure:

![image](https://cloud.githubusercontent.com/assets/13972471/14303094/5d4ede40-fb5c-11e5-9392-2304d9a90071.png)

In general, if you passed bad arguments to the magics before, you got a confusing error message; these are better because they're not propagated to the user as internal exceptions.

We might want to make some further tweaks to `%%configure` messages.  That will probably require some changes to our usercodeparser.  We can address that in a later PR.