### PR TITLE
Added support for storing endpoint password in base64 encoding in con…

### DIFF
--- a/remotespark/livyclientlib/exceptions.py
+++ b/remotespark/livyclientlib/exceptions.py
@@ -48,6 +48,11 @@ class BadUserDataException(LivyClientLibException):
     in some way."""
 
 
+class BadUserConfigurationException(LivyClientLibException):
+    """An exception that is thrown when configuration provided by the user is invalid
+    in some way."""
+
+
 # == DECORATORS FOR EXCEPTION HANDLING ==
 EXPECTED_EXCEPTIONS = [BadUserDataException, LivyUnexpectedStatusException, FailedToCreateSqlContextException,
                        HttpClientException, LivyClientTimeoutException, SessionManagementException]

--- a/remotespark/livyclientlib/exceptions.py
+++ b/remotespark/livyclientlib/exceptions.py
@@ -43,18 +43,18 @@ class SessionManagementException(LivyClientLibException):
     given session name is invalid in some way."""
 
 
-class BadUserDataException(LivyClientLibException):
-    """An exception that is thrown when data provided by the user is invalid
-    in some way."""
-
-
 class BadUserConfigurationException(LivyClientLibException):
     """An exception that is thrown when configuration provided by the user is invalid
     in some way."""
 
 
+class BadUserDataException(LivyClientLibException):
+    """An exception that is thrown when data provided by the user is invalid
+    in some way."""
+
+
 # == DECORATORS FOR EXCEPTION HANDLING ==
-EXPECTED_EXCEPTIONS = [BadUserDataException, LivyUnexpectedStatusException, FailedToCreateSqlContextException,
+EXPECTED_EXCEPTIONS = [BadUserConfigurationException, BadUserDataException, LivyUnexpectedStatusException, FailedToCreateSqlContextException,
                        HttpClientException, LivyClientTimeoutException, SessionManagementException]
 
 

--- a/remotespark/utils/configuration.py
+++ b/remotespark/utils/configuration.py
@@ -8,10 +8,10 @@ import copy
 import json
 import sys
 
+from remotespark.livyclientlib.exceptions import BadUserConfigurationException
 from remotespark.utils.constants import CONFIG_JSON
 from remotespark.utils.utils import join_paths, get_magics_home_path, get_livy_kind
 from remotespark.utils.filesystemreaderwriter import FileSystemReaderWriter
-
 _overrides = None
 
 
@@ -106,7 +106,7 @@ def _credentials_override(f):
             except Exception:
                 exception_type, exception, traceback = sys.exc_info()
                 msg = "base64_password for %s contains invalid base64 string: %s %s" % (f.__name__, exception_type, exception)
-                raise RuntimeError(msg)
+                raise BadUserConfigurationException(msg)
         return base64_decoded_credentials
 
     # Hack! We do this so that we can query the .__name__ of the function

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -1,6 +1,6 @@
 import remotespark.utils.configuration as conf
 from mock import MagicMock
-from nose.tools import with_setup, assert_equals, assert_not_equals
+from nose.tools import assert_equals, assert_not_equals, raises, with_setup
 import json
 
 def _setup():
@@ -63,7 +63,19 @@ def test_configuration_load_not_lazy():
 
 
 @with_setup(_setup)
-def test_configuration_override():
+def test_configuration_override_base64_password():
+    kpc = { 'username': 'U', 'password': 'P', 'base64_password': 'cGFzc3dvcmQ=', 'url': 'L' }
+    overrides = { conf.kernel_python_credentials.__name__: kpc }
+    conf.override_all(overrides)
+    conf.override(conf.status_sleep_seconds.__name__, 1)
+    assert_equals(conf._overrides, { conf.kernel_python_credentials.__name__: kpc,
+                                     conf.status_sleep_seconds.__name__: 1 })
+    assert_equals(conf.status_sleep_seconds(), 1)
+    assert_equals(conf.kernel_python_credentials(), { 'username': 'U', 'password': 'password', 'url': 'L' })
+
+
+@with_setup(_setup)
+def test_configuration_override_fallback_to_password():
     kpc = { 'username': 'U', 'password': 'P', 'url': 'L' }
     overrides = { conf.kernel_python_credentials.__name__: kpc }
     conf.override_all(overrides)
@@ -72,6 +84,16 @@ def test_configuration_override():
                                      conf.status_sleep_seconds.__name__: 1 })
     assert_equals(conf.status_sleep_seconds(), 1)
     assert_equals(conf.kernel_python_credentials(), kpc)
+
+
+@raises(RuntimeError)
+@with_setup(_setup)
+def test_configuration_raise_error_for_bad_base64_password():
+    kpc = { 'username': 'U', 'base64_password': 'P', 'url': 'L' }
+    overrides = { conf.kernel_python_credentials.__name__: kpc }
+    conf.override_all(overrides)
+    conf.override(conf.status_sleep_seconds.__name__, 1)
+    conf.kernel_python_credentials()
 
 
 @with_setup(_setup)

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -87,6 +87,18 @@ def test_configuration_override_fallback_to_password():
     assert_equals(conf.kernel_python_credentials(), kpc)
 
 
+@with_setup(_setup)
+def test_configuration_override_work_with_empty_password():
+    kpc = { 'username': 'U', 'base64_password': '', 'password': '', 'url': '' }
+    overrides = { conf.kernel_python_credentials.__name__: kpc }
+    conf.override_all(overrides)
+    conf.override(conf.status_sleep_seconds.__name__, 1)
+    assert_equals(conf._overrides, { conf.kernel_python_credentials.__name__: kpc,
+                                     conf.status_sleep_seconds.__name__: 1 })
+    assert_equals(conf.status_sleep_seconds(), 1)
+    assert_equals(conf.kernel_python_credentials(),  { 'username': 'U', 'password': '', 'url': '' })
+
+
 @raises(BadUserConfigurationException)
 @with_setup(_setup)
 def test_configuration_raise_error_for_bad_base64_password():

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -1,6 +1,7 @@
 import remotespark.utils.configuration as conf
 from mock import MagicMock
 from nose.tools import assert_equals, assert_not_equals, raises, with_setup
+from remotespark.livyclientlib.exceptions import BadUserConfigurationException
 import json
 
 def _setup():
@@ -86,7 +87,7 @@ def test_configuration_override_fallback_to_password():
     assert_equals(conf.kernel_python_credentials(), kpc)
 
 
-@raises(RuntimeError)
+@raises(BadUserConfigurationException)
 @with_setup(_setup)
 def test_configuration_raise_error_for_bad_base64_password():
     kpc = { 'username': 'U', 'base64_password': 'P', 'url': 'L' }


### PR DESCRIPTION
…figuration.

If 'base64_password' is present in config, it's used. Else, it will fallback to 'password'.