### PR TITLE
Prevent internal overflow exception when trying to coerce strings to datetime

### DIFF
--- a/remotespark/utils/utils.py
+++ b/remotespark/utils/utils.py
@@ -61,7 +61,7 @@ def coerce_pandas_df_to_numeric_datetime(df):
             try:
                 df[column_name] = pd.to_datetime(df[column_name], errors="raise")
                 coerced = True
-            except (ValueError, TypeError):
+            except (ValueError, TypeError, OverflowError):
                 pass
 
         if not coerced and df[column_name].dtype == np.dtype("object"):

--- a/tests/test_pd_data_coerce.py
+++ b/tests/test_pd_data_coerce.py
@@ -122,3 +122,12 @@ def test_df_dict_does_not_throw():
 """
     df = pd.read_json(json_str)
     coerce_pandas_df_to_numeric_datetime(df)
+
+
+def test_overflow_coercing():
+    records = [{'_c0':'12345678901'}]
+    desired_df = pd.DataFrame(records)
+    desired_df['_c0'] = pd.to_numeric(desired_df['_c0'])
+    df = pd.DataFrame(records)
+    coerce_pandas_df_to_numeric_datetime(df)
+    assert_frame_equal(desired_df, df)


### PR DESCRIPTION
Closes #234 

Explicitly catch overflow exceptions to prevent an internal error when running:

    %%sql
    SELECT '12345678901'