### PR TITLE
Format %%info as table

### DIFF
--- a/remotespark/kernels/kernelmagics.py
+++ b/remotespark/kernels/kernelmagics.py
@@ -140,26 +140,15 @@ class KernelMagics(SparkMagicBase):
     def info(self, line, cell=u"", local_ns=None):
         parse_argstring_or_throw(self.info, line)
         self._assure_cell_body_is_empty(KernelMagics.info.__name__, cell)
-        app_id = driver_log_url = spark_ui_url = None
         if self.session_started:
-            app_id = self.spark_controller.get_app_id()
-            driver_log_url = self.spark_controller.get_driver_log_url()
-            spark_ui_url = self.spark_controller.get_spark_ui_url()
+            current_session_id = self.spark_controller.get_session_id_for_client(self.session_name)
+        else:
+            current_session_id = None
 
-        self.ipython_display.writeln(u"Endpoint:\n\t{}\n".format(self.endpoint.url))
+        self.ipython_display.html(u"Endpoint: {}\n".format(self._link(self.endpoint.url)))
 
-        self.ipython_display.writeln(u"Current session ID number:\n\t{}\n".format(
-                self.spark_controller.get_session_id_for_client(self.session_name)))
-
-        self.ipython_display.writeln(u"YARN Application ID:\n\t{}\n".format(app_id))
-
-        self.ipython_display.writeln(u"Session configs:\n\t{}\n".format(conf.get_session_properties(self.language)))
-
-        self.ipython_display.writeln(u"Driver log:\n\t{}\n".format(driver_log_url))
-        self.ipython_display.writeln(u"Spark UI:\n\t{}\n".format(spark_ui_url))
-
-        info_sessions = self.spark_controller.get_all_sessions_endpoint_info(self.endpoint)
-        self.print_endpoint_info(info_sessions)
+        info_sessions = self.spark_controller.get_all_sessions_endpoint(self.endpoint)
+        self._print_endpoint_info(info_sessions, current_session_id)
 
     @magic_arguments()
     @cell_magic

--- a/remotespark/kernels/kernelmagics.py
+++ b/remotespark/kernels/kernelmagics.py
@@ -145,7 +145,8 @@ class KernelMagics(SparkMagicBase):
         else:
             current_session_id = None
 
-        self.ipython_display.html(u"Endpoint: {}\n".format(self._link(self.endpoint.url)))
+        self.ipython_display.html(u"Endpoint: {}<br>".format(self._link(self.endpoint.url)))
+        self.ipython_display.html(u"Session configs: <tt>{}</tt><br>".format(conf.get_session_properties(self.language)))
 
         info_sessions = self.spark_controller.get_all_sessions_endpoint(self.endpoint)
         self._print_endpoint_info(info_sessions, current_session_id)

--- a/remotespark/livyclientlib/livysession.py
+++ b/remotespark/livyclientlib/livysession.py
@@ -61,10 +61,6 @@ class LivySession(ObjectWithGuid):
         self.id = session_id
         self.created_sql_context = sql_created
 
-    def __str__(self):
-        return u"Session id: {}\tYARN id: {}\tKind: {}\tState: {}\n\tSpark UI: {}\n\tDriver Log: {}"\
-            .format(self.id, self.get_app_id(), self.kind, self.status, self.get_spark_ui_url(), self.get_driver_log_url())
-
     def start(self, create_sql_context=True):
         """Start the session against actual livy server."""
         self._spark_events.emit_session_creation_start_event(self.guid, self.kind)

--- a/remotespark/livyclientlib/livysession.py
+++ b/remotespark/livyclientlib/livysession.py
@@ -61,6 +61,10 @@ class LivySession(ObjectWithGuid):
         self.id = session_id
         self.created_sql_context = sql_created
 
+    def __str__(self):
+        return u"Session id: {}\tYARN id: {}\tKind: {}\tState: {}\n\tSpark UI: {}\n\tDriver Log: {}"\
+            .format(self.id, self.get_app_id(), self.kind, self.status, self.get_spark_ui_url(), self.get_driver_log_url())
+
     def start(self, create_sql_context=True):
         """Start the session against actual livy server."""
         self._spark_events.emit_session_creation_start_event(self.guid, self.kind)

--- a/remotespark/magics/remotesparkmagics.py
+++ b/remotespark/magics/remotesparkmagics.py
@@ -114,7 +114,7 @@ class RemoteSparkMagics(SparkMagicBase):
             if args.url is not None:
                 endpoint = Endpoint(args.url, args.user, args.password)
                 info_sessions = self.spark_controller.get_all_sessions_endpoint_info(endpoint)
-                self.print_endpoint_info(info_sessions)
+                self._print_endpoint_info(info_sessions)
             else:
                 self._print_local_info()
         # config

--- a/remotespark/magics/sparkmagicsbase.py
+++ b/remotespark/magics/sparkmagicsbase.py
@@ -48,6 +48,7 @@ class SparkMagicBase(Magics):
         return SQLQuery(cell, samplemethod, maxrows, samplefraction)
 
     def _print_endpoint_info(self, info_sessions, current_session_id):
+        info_sessions = sorted(info_sessions, key=lambda s: s.id)
         html = u"""<table>
 <tr><th>ID</th><th>YARN application ID</th><th>Kind</th><th>State</th><th>Spark UI link</th><th>Driver log</th><th>Current session?</th></tr>""" + \
             u"".join([SparkMagicBase._session_row_html(session, current_session_id) for session in info_sessions]) + \

--- a/remotespark/magics/sparkmagicsbase.py
+++ b/remotespark/magics/sparkmagicsbase.py
@@ -1,3 +1,5 @@
+# -*- coding: UTF-8 -*-
+
 """Runs Scala, PySpark and SQL statement through Spark using a REST endpoint in remote cluster.
 Provides the %spark magic."""
 
@@ -45,10 +47,24 @@ class SparkMagicBase(Magics):
     def _sqlquery(cell, samplemethod, maxrows, samplefraction):
         return SQLQuery(cell, samplemethod, maxrows, samplefraction)
 
+    def _print_endpoint_info(self, info_sessions, current_session_id):
+        html = u"""<table>
+<tr><th>ID</th><th>YARN application ID</th><th>Kind</th><th>State</th><th>Spark UI link</th><th>Driver log</th><th>Current session?</th></tr>""" + \
+            u"".join([SparkMagicBase._session_row_html(session, current_session_id) for session in info_sessions]) + \
+            u"</table>"
+        self.ipython_display.html(html)
+
     @staticmethod
-    def print_endpoint_info(info_sessions):
-        sessions_info = ["        {}\n".format(i) for i in info_sessions]
-        print("""Info for endpoint:
-    Sessions:
-{}
-""".format("\n".join(sessions_info)))
+    def _session_row_html(session, current_session_id):
+        return u"""<tr><td>{0}</td><td>{1}</td><td>{2}</td><td>{3}</td><td>{4}</td><td>{5}</td><td>{6}</td></tr>""".format(
+            session.id, session.get_app_id(), session.kind, session.status,
+            SparkMagicBase._link(session.get_spark_ui_url()), SparkMagicBase._link(session.get_driver_log_url()),
+            u"" if current_session_id is None or current_session_id != session.id else u"✔"
+        )
+
+    @staticmethod
+    def _link(url):
+        if url is not None:
+            return u"""<a href="{0}">{0}</a>""".format(url)
+        else:
+            return u""

--- a/tests/test_kernel_magics.py
+++ b/tests/test_kernel_magics.py
@@ -161,42 +161,35 @@ def test_change_language_not_valid():
 
 @with_setup(_setup, _teardown)
 def test_info():
-    magic.print_endpoint_info = print_info_mock = MagicMock()
+    magic._print_endpoint_info = print_info_mock = MagicMock()
     line = ""
-    session_info = ["1", "2"]
-    spark_controller.get_all_sessions_endpoint_info = MagicMock(return_value=session_info)
+    session_info = [MagicMock(), MagicMock()]
+    spark_controller.get_all_sessions_endpoint = MagicMock(return_value=session_info)
     magic.session_started = True
 
     magic.info(line)
 
-    print_info_mock.assert_called_once_with(session_info)
+    print_info_mock.assert_called_once_with(session_info, spark_controller.get_session_id_for_client.return_value)
     spark_controller.get_session_id_for_client.assert_called_once_with(magic.session_name)
-    spark_controller.get_app_id.assert_called_once_with()
-    spark_controller.get_driver_log_url.assert_called_once_with()
-    spark_controller.get_spark_ui_url.assert_called_once_with()
 
     _assert_magic_successful_event_emitted_once('info')
 
 @with_setup(_setup, _teardown)
 def test_info_without_active_session():
-    magic.print_endpoint_info = print_info_mock = MagicMock()
+    magic._print_endpoint_info = print_info_mock = MagicMock()
     line = ""
-    session_info = ["1", "2"]
-    spark_controller.get_all_sessions_endpoint_info = MagicMock(return_value=session_info)
+    session_info = [MagicMock(), MagicMock()]
+    spark_controller.get_all_sessions_endpoint = MagicMock(return_value=session_info)
 
     magic.info(line)
 
-    print_info_mock.assert_called_once_with(session_info)
-    spark_controller.get_session_id_for_client.assert_called_once_with(magic.session_name)
-    assert_equals(False, spark_controller.get_app_id.called)
-    assert_equals(False, spark_controller.get_driver_log_url.called)
-    assert_equals(False, spark_controller.get_spark_ui_url.called)
+    print_info_mock.assert_called_once_with(session_info, None)
 
     _assert_magic_successful_event_emitted_once('info')
 
 @with_setup(_setup, _teardown)
 def test_info_with_cell_content():
-    magic.print_endpoint_info = print_info_mock = MagicMock()
+    magic._print_endpoint_info = print_info_mock = MagicMock()
     line = ""
     session_info = ["1", "2"]
     spark_controller.get_all_sessions_endpoint_info = MagicMock(return_value=session_info)
@@ -212,7 +205,7 @@ def test_info_with_cell_content():
 
 @with_setup(_setup, _teardown)
 def test_info_with_argument():
-    magic.print_endpoint_info = print_info_mock = MagicMock()
+    magic._print_endpoint_info = print_info_mock = MagicMock()
     line = "hey"
     session_info = ["1", "2"]
     spark_controller.get_all_sessions_endpoint_info = MagicMock(return_value=session_info)
@@ -226,28 +219,26 @@ def test_info_with_argument():
 
 @with_setup(_setup, _teardown)
 def test_info_unexpected_exception():
-    magic.print_endpoint_info = MagicMock()
+    magic._print_endpoint_info = MagicMock()
     line = ""
-    spark_controller.get_all_sessions_endpoint_info = MagicMock(side_effect=ValueError('utter failure'))
+    spark_controller.get_all_sessions_endpoint = MagicMock(side_effect=ValueError('utter failure'))
 
     magic.info(line)
-    spark_controller.get_session_id_for_client.assert_called_once_with(magic.session_name)
-    _assert_magic_failure_event_emitted_once('info', spark_controller.get_all_sessions_endpoint_info.side_effect)
+    _assert_magic_failure_event_emitted_once('info', spark_controller.get_all_sessions_endpoint.side_effect)
     ipython_display.send_error.assert_called_once_with(constants.INTERNAL_ERROR_MSG
-                                                       .format(spark_controller.get_all_sessions_endpoint_info.side_effect))
+                                                       .format(spark_controller.get_all_sessions_endpoint.side_effect))
 
 
 @with_setup(_setup, _teardown)
 def test_info_expected_exception():
-    magic.print_endpoint_info = MagicMock()
+    magic._print_endpoint_info = MagicMock()
     line = ""
-    spark_controller.get_all_sessions_endpoint_info = MagicMock(side_effect=FailedToCreateSqlContextException('utter failure'))
+    spark_controller.get_all_sessions_endpoint = MagicMock(side_effect=FailedToCreateSqlContextException('utter failure'))
 
     magic.info(line)
-    spark_controller.get_session_id_for_client.assert_called_once_with(magic.session_name)
-    _assert_magic_failure_event_emitted_once('info', spark_controller.get_all_sessions_endpoint_info.side_effect)
+    _assert_magic_failure_event_emitted_once('info', spark_controller.get_all_sessions_endpoint.side_effect)
     ipython_display.send_error.assert_called_once_with(constants.EXPECTED_ERROR_MSG
-                                                       .format(spark_controller.get_all_sessions_endpoint_info.side_effect))
+                                                       .format(spark_controller.get_all_sessions_endpoint.side_effect))
 
 
 @with_setup(_setup, _teardown)

--- a/tests/test_remotesparkmagics.py
+++ b/tests/test_remotesparkmagics.py
@@ -45,7 +45,7 @@ def test_info_command_parses():
 @with_setup(_setup, _teardown)
 def test_info_endpoint_command_parses():
     print_info_mock = MagicMock()
-    magic.print_endpoint_info = print_info_mock
+    magic._print_endpoint_info = print_info_mock
     command = "info -u http://microsoft.com"
     spark_controller.get_all_sessions_endpoint_info = MagicMock(return_value=None)
 

--- a/tests/test_sparkkernelbase.py
+++ b/tests/test_sparkkernelbase.py
@@ -138,8 +138,9 @@ def test_load_magics():
     assert call("%load_ext remotespark.kernels", True, False, None, False) in execute_cell_mock.mock_calls
 
 
-@with_setup(_setup(), _teardown())
+@with_setup(_setup, _teardown)
 def test_delete_session():
     kernel._delete_session()
 
     assert call("%%_do_not_call_delete_session\n ", True, False) in execute_cell_mock.mock_calls
+

--- a/tests/test_sparkmagicbase.py
+++ b/tests/test_sparkmagicbase.py
@@ -135,7 +135,7 @@ def test_print_endpoint_info():
     session2.status = BUSY_SESSION_STATUS
     session2.get_spark_ui_url.return_value = None
     session2.get_driver_log_url.return_value = None
-    magic._print_endpoint_info([session1, session2], current_session_id)
+    magic._print_endpoint_info([session2, session1], current_session_id)
     magic.ipython_display.html.assert_called_once_with(u"""<table>
 <tr><th>ID</th><th>YARN application ID</th><th>Kind</th><th>State</th><th>Spark UI link</th><th>Driver log</th><th>Current session?</th></tr>\
 <tr><td>1</td><td>app1234</td><td>pyspark</td><td>idle</td><td><a href="https://microsoft.com/sparkui">https://microsoft.com/sparkui</a></td><td><a href="https://microsoft.com/driverlog">https://microsoft.com/driverlog</a></td><td>✔</td></tr>\

--- a/tests/test_sparkmagicbase.py
+++ b/tests/test_sparkmagicbase.py
@@ -1,7 +1,10 @@
+# -*- coding: UTF-8 -*-
+
 from mock import MagicMock
 from nose.tools import assert_equals
 
-from remotespark.utils.constants import LANGS_SUPPORTED
+from remotespark.utils.constants import LANGS_SUPPORTED, SESSION_KIND_PYSPARK, SESSION_KIND_SPARK, \
+    IDLE_SESSION_STATUS, BUSY_SESSION_STATUS
 from remotespark.utils.utils import get_livy_kind
 from remotespark.magics.sparkmagicsbase import SparkMagicBase
 from remotespark.livyclientlib.exceptions import DataFrameParseException
@@ -19,10 +22,6 @@ def test_load_emits_event():
 def test_get_livy_kind_covers_all_langs():
     for lang in LANGS_SUPPORTED:
         get_livy_kind(lang)
-
-
-def test_print_endpoint_info_doesnt_throw():
-    SparkMagicBase.print_endpoint_info(range(5))
 
 
 def test_df_execution_without_output_var():
@@ -107,3 +106,38 @@ def test_df_execution_quiet_with_output_var():
     magic.spark_controller.run_sqlquery.assert_called_once_with(cell, session)
     assert res is None
     assert shell.user_ns[output_var] == df
+
+
+def test_link():
+    url = u"https://microsoft.com"
+    magic = SparkMagicBase(None)
+    assert_equals(magic._link(url), u"""<a href="https://microsoft.com">https://microsoft.com</a>""")
+
+    url = None
+    assert_equals(magic._link(url), u"")
+
+
+def test_print_endpoint_info():
+    magic = SparkMagicBase(None)
+    magic.ipython_display = MagicMock()
+    current_session_id = 1
+    session1 = MagicMock()
+    session1.id = 1
+    session1.get_app_id.return_value = 'app1234'
+    session1.kind = SESSION_KIND_PYSPARK
+    session1.status = IDLE_SESSION_STATUS
+    session1.get_spark_ui_url.return_value = 'https://microsoft.com/sparkui'
+    session1.get_driver_log_url.return_value = 'https://microsoft.com/driverlog'
+    session2 = MagicMock()
+    session2.id = 3
+    session2.get_app_id.return_value = 'app5069'
+    session2.kind = SESSION_KIND_SPARK
+    session2.status = BUSY_SESSION_STATUS
+    session2.get_spark_ui_url.return_value = None
+    session2.get_driver_log_url.return_value = None
+    magic._print_endpoint_info([session1, session2], current_session_id)
+    magic.ipython_display.html.assert_called_once_with(u"""<table>
+<tr><th>ID</th><th>YARN application ID</th><th>Kind</th><th>State</th><th>Spark UI link</th><th>Driver log</th><th>Current session?</th></tr>\
+<tr><td>1</td><td>app1234</td><td>pyspark</td><td>idle</td><td><a href="https://microsoft.com/sparkui">https://microsoft.com/sparkui</a></td><td><a href="https://microsoft.com/driverlog">https://microsoft.com/driverlog</a></td><td>✔</td></tr>\
+<tr><td>3</td><td>app5069</td><td>spark</td><td>busy</td><td></td><td></td><td></td></tr>\
+</table>""")


### PR DESCRIPTION
Closes #230 

Format the output of `%%info` as a table:

![image](https://cloud.githubusercontent.com/assets/13972471/15334573/a00836ea-1c23-11e6-81b1-ff5e2ea2a963.png)

The formatting of the output of the magic `%%spark info` hasn't been updated in this PR; that will require more refactoring.