### PR TITLE
Update .travis.yml to test on python 3.6 and not 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python:
 - '2.7'
+- '3.3'
 - '3.6'
 install:
 - pip install -r hdijupyterutils/requirements.txt -e hdijupyterutils

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 python:
 - '2.7'
-- '3.3'
+- '3.6'
 install:
 - pip install -r hdijupyterutils/requirements.txt -e hdijupyterutils
 - pip install -r autovizwidget/requirements.txt -e autovizwidget


### PR DESCRIPTION
3.6 is the official release. Testing to see what would happen to unit tests running on 3.6 via Travis