### PR TITLE
Ability to add custom headers to HTTP calls

### DIFF
--- a/sparkmagic/example_config.json
+++ b/sparkmagic/example_config.json
@@ -65,5 +65,6 @@
   "livy_server_heartbeat_timeout_seconds": 0,
   "heartbeat_retry_seconds": 10,
 
-  "server_extension_default_kernel_name": "pysparkkernel"
+  "server_extension_default_kernel_name": "pysparkkernel",
+  "custom_headers": {}
 }

--- a/sparkmagic/sparkmagic/livyclientlib/livyreliablehttpclient.py
+++ b/sparkmagic/sparkmagic/livyclientlib/livyreliablehttpclient.py
@@ -41,7 +41,7 @@ class LivyReliableHttpClient(object):
         return self._http_client.get(self._session_url(session_id) + "/log?from=0", [200]).json()
 
     def get_headers(self):
-	return self._http_client.get_headers()
+        return self._http_client.get_headers()
 
     @staticmethod
     def _session_url(session_id):

--- a/sparkmagic/sparkmagic/livyclientlib/livyreliablehttpclient.py
+++ b/sparkmagic/sparkmagic/livyclientlib/livyreliablehttpclient.py
@@ -13,9 +13,10 @@ class LivyReliableHttpClient(object):
 
     @staticmethod
     def from_endpoint(endpoint):
+        headers = {"Content-Type": "application/json" }
+        headers.update(conf.get_custom_headers())
         retry_policy = LinearRetryPolicy(seconds_to_sleep=5, max_retries=5)
-        return LivyReliableHttpClient(ReliableHttpClient(endpoint, {"Content-Type": "application/json"},
-                                                         retry_policy))
+        return LivyReliableHttpClient(ReliableHttpClient(endpoint, headers, retry_policy))
 
     def post_statement(self, session_id, data):
         return self._http_client.post(self._statements_url(session_id), [201], data).json()

--- a/sparkmagic/sparkmagic/livyclientlib/livyreliablehttpclient.py
+++ b/sparkmagic/sparkmagic/livyclientlib/livyreliablehttpclient.py
@@ -15,7 +15,7 @@ class LivyReliableHttpClient(object):
     @staticmethod
     def from_endpoint(endpoint):
         headers = {"Content-Type": "application/json" }
-        headers.update(conf.get_custom_headers())
+        headers.update(conf.custom_headers())
         retry_policy = LinearRetryPolicy(seconds_to_sleep=5, max_retries=5)
         return LivyReliableHttpClient(ReliableHttpClient(endpoint, headers, retry_policy))
 

--- a/sparkmagic/sparkmagic/livyclientlib/livyreliablehttpclient.py
+++ b/sparkmagic/sparkmagic/livyclientlib/livyreliablehttpclient.py
@@ -40,6 +40,9 @@ class LivyReliableHttpClient(object):
     def get_all_session_logs(self, session_id):
         return self._http_client.get(self._session_url(session_id) + "/log?from=0", [200]).json()
 
+    def get_headers(self):
+	return self._http_client.get_headers()
+
     @staticmethod
     def _session_url(session_id):
         return "/sessions/{}".format(session_id)

--- a/sparkmagic/sparkmagic/livyclientlib/livyreliablehttpclient.py
+++ b/sparkmagic/sparkmagic/livyclientlib/livyreliablehttpclient.py
@@ -3,6 +3,7 @@
 
 from .linearretrypolicy import LinearRetryPolicy
 from .reliablehttpclient import ReliableHttpClient
+import sparkmagic.utils.configuration as conf
 
 
 class LivyReliableHttpClient(object):

--- a/sparkmagic/sparkmagic/livyclientlib/reliablehttpclient.py
+++ b/sparkmagic/sparkmagic/livyclientlib/reliablehttpclient.py
@@ -34,6 +34,9 @@ class ReliableHttpClient(object):
             self.logger.debug(u"ATTENTION: Will ignore SSL errors. This might render you vulnerable to attacks.")
             requests.packages.urllib3.disable_warnings()
 
+    def get_headers(self):
+        return self._headers
+
     def compose_url(self, relative_url):
         r_u = "/{}".format(relative_url.rstrip(u"/").lstrip(u"/"))
         return self._endpoint.url + r_u

--- a/sparkmagic/sparkmagic/tests/test_configuration.py
+++ b/sparkmagic/sparkmagic/tests/test_configuration.py
@@ -78,10 +78,3 @@ def test_share_config_between_pyspark_and_pyspark3():
     kpc = { 'username': 'U', 'password': 'P', 'base64_password': 'cGFzc3dvcmQ=', 'url': 'L', 'auth': AUTH_BASIC }
     overrides = { conf.kernel_python_credentials.__name__: kpc }
     assert_equals(conf.base64_kernel_python3_credentials(), conf.base64_kernel_python_credentials())
-
-@with_setup(_setup)
-def test_custom_headers():
-    headers = { 'header1': 'value1'}
-    overrides = { conf.custom_headers.__name__: headers }
-    conf.override_all(overrides)
-    assert_equals(conf.custom_headers(), { 'header1': 'value1'})

--- a/sparkmagic/sparkmagic/tests/test_configuration.py
+++ b/sparkmagic/sparkmagic/tests/test_configuration.py
@@ -84,4 +84,4 @@ def test_custom_headers():
     headers = { 'header1': 'value1'}
     overrides = { conf.custom_headers.__name__: headers }
     conf.override_all(overrides)
-    assert_equals(conf.get_custom_headers(), { 'header1': 'value1'})
+    assert_equals(conf.custom_headers(), { 'header1': 'value1'})

--- a/sparkmagic/sparkmagic/tests/test_configuration.py
+++ b/sparkmagic/sparkmagic/tests/test_configuration.py
@@ -78,3 +78,10 @@ def test_share_config_between_pyspark_and_pyspark3():
     kpc = { 'username': 'U', 'password': 'P', 'base64_password': 'cGFzc3dvcmQ=', 'url': 'L', 'auth': AUTH_BASIC }
     overrides = { conf.kernel_python_credentials.__name__: kpc }
     assert_equals(conf.base64_kernel_python3_credentials(), conf.base64_kernel_python_credentials())
+
+@with_setup(_setup)
+def test_custom_headers():
+    headers = { 'header1': 'value1'}
+    overrides = { conf.custom_headers.__name__: headers }
+    conf.override_all(overrides)
+    assert_equals(conf.get_custom_headers(), { 'header1': 'value1'})

--- a/sparkmagic/sparkmagic/tests/test_livyreliablehttpclient.py
+++ b/sparkmagic/sparkmagic/tests/test_livyreliablehttpclient.py
@@ -2,6 +2,8 @@ from mock import MagicMock
 from nose.tools import assert_equals
 
 from sparkmagic.livyclientlib.livyreliablehttpclient import LivyReliableHttpClient
+from sparkmagic.livyclientlib.endpoint import Endpoint
+import sparkmagic.utils.configuration as conf
 
 
 def test_post_statement():
@@ -60,3 +62,11 @@ def test_get_all_session_logs():
     assert_equals(out, http_client.get.return_value.json.return_value)
     http_client.get.assert_called_once_with("/sessions/42/log?from=0", [200])
 
+def test_custom_headers():
+    custom_headers = {"header1": "value1"}
+    overrides = { conf.custom_headers.__name__: custom_headers }
+    conf.override_all(overrides)
+    endpoint = Endpoint("http://url.com")
+    client = LivyReliableHttpClient.from_endpoint(endpoint)
+    headers = client.get_headers()
+    assert_equals(custom_headers.items() <= headers.items(), True)

--- a/sparkmagic/sparkmagic/tests/test_livyreliablehttpclient.py
+++ b/sparkmagic/sparkmagic/tests/test_livyreliablehttpclient.py
@@ -4,6 +4,7 @@ from nose.tools import assert_equals
 from sparkmagic.livyclientlib.livyreliablehttpclient import LivyReliableHttpClient
 from sparkmagic.livyclientlib.endpoint import Endpoint
 import sparkmagic.utils.configuration as conf
+import sparkmagic.utils.constants as constants
 
 
 def test_post_statement():
@@ -66,7 +67,7 @@ def test_custom_headers():
     custom_headers = {"header1": "value1"}
     overrides = { conf.custom_headers.__name__: custom_headers }
     conf.override_all(overrides)
-    endpoint = Endpoint("http://url.com")
+    endpoint = Endpoint("http://url.com", constants.NO_AUTH)
     client = LivyReliableHttpClient.from_endpoint(endpoint)
     headers = client.get_headers()
     assert_equals(custom_headers.items() <= headers.items(), True)

--- a/sparkmagic/sparkmagic/tests/test_livyreliablehttpclient.py
+++ b/sparkmagic/sparkmagic/tests/test_livyreliablehttpclient.py
@@ -63,6 +63,7 @@ def test_get_all_session_logs():
     assert_equals(out, http_client.get.return_value.json.return_value)
     http_client.get.assert_called_once_with("/sessions/42/log?from=0", [200])
 
+
 def test_custom_headers():
     custom_headers = {"header1": "value1"}
     overrides = { conf.custom_headers.__name__: custom_headers }
@@ -70,4 +71,6 @@ def test_custom_headers():
     endpoint = Endpoint("http://url.com", constants.NO_AUTH)
     client = LivyReliableHttpClient.from_endpoint(endpoint)
     headers = client.get_headers()
-    assert_equals(custom_headers.items() <= headers.items(), True)
+    assert_equals(len(headers), 2)
+    assert_equals("Content-Type" in headers, True)
+    assert_equals("header1" in headers, True)

--- a/sparkmagic/sparkmagic/utils/configuration.py
+++ b/sparkmagic/sparkmagic/utils/configuration.py
@@ -244,3 +244,6 @@ def _credentials_override(f):
         base64_decoded_credentials['auth'] = get_auth_value(base64_decoded_credentials['username'], base64_decoded_credentials['password'])
     return base64_decoded_credentials
 
+@_with_override
+def get_custom_headers():
+    return {}

--- a/sparkmagic/sparkmagic/utils/configuration.py
+++ b/sparkmagic/sparkmagic/utils/configuration.py
@@ -244,6 +244,7 @@ def _credentials_override(f):
         base64_decoded_credentials['auth'] = get_auth_value(base64_decoded_credentials['username'], base64_decoded_credentials['password'])
     return base64_decoded_credentials
 
+
 @_with_override
 def custom_headers():
     return {}

--- a/sparkmagic/sparkmagic/utils/configuration.py
+++ b/sparkmagic/sparkmagic/utils/configuration.py
@@ -245,5 +245,5 @@ def _credentials_override(f):
     return base64_decoded_credentials
 
 @_with_override
-def get_custom_headers():
+def custom_headers():
     return {}


### PR DESCRIPTION
Closes #285

adding ability to add custom headers to HTTP calls
The following json block has to be added to config.json
```
  "custom_headers": {
    "header1":"value1",
    "header2":"value2",
  }
```