### PR TITLE
Don't ask for write permissions during read

### DIFF
--- a/hdijupyterutils/hdijupyterutils/filesystemreaderwriter.py
+++ b/hdijupyterutils/hdijupyterutils/filesystemreaderwriter.py
@@ -20,7 +20,7 @@ class FileSystemReaderWriter(object):
 
     def read_lines(self):
         if os.path.isfile(self.path):
-            with open(self.path, "r+") as f:
+            with open(self.path, "r") as f:
                 return f.readlines()
         else:
             return ""


### PR DESCRIPTION
The `read_lines` function only seems to only need read permissions, not write permissions. Requesting read and write permissions (`"r+a"`) causes issues on multi-user systems, where the `config.json` file would require write permissions for all users needing to read it.

See documentation for permissions in `open`:
 * [Python 2.7](https://docs.python.org/2/library/functions.html#open)
 * [Python 3.6](https://docs.python.org/3/library/functions.html#open)

All unit tests are passing after this change.
```
$ nosetests hdijupyterutils autovizwidget sparkmagic
................................................................................................................................................................................................................................................................................................................................................................
----------------------------------------------------------------------
Ran 352 tests in 5.072s

OK

```