### PR TITLE
Upgrade setuptools for livy python-api

### DIFF
--- a/Dockerfile.spark
+++ b/Dockerfile.spark
@@ -16,6 +16,8 @@ ENV LIVY_BUILD_PATH /apps/build/livy
 ENV PYSPARK_PYTHON python2.7
 ENV PYSPARK3_PYTHON python3.4
 
+RUN pip install --upgrade setuptools
+
 RUN mkdir -p /apps/build && \
     cd /apps/build && \
 	git clone https://github.com/cloudera/livy.git && \


### PR DESCRIPTION
Without upgrading setuptools, the python-api build fails with

```
Installed /apps/build/livy/python-api/pytest_runner-2.12.1-py3.4.egg
Traceback (most recent call last):
  File "setup.py", line 58, in <module>
    tests_require=['pytest']
  File "/usr/lib/python3.4/distutils/core.py", line 108, in setup
    _setup_distribution = dist = klass(attrs)
  File "/usr/lib/python3/dist-packages/setuptools/dist.py", line 262, in __init__
    self.fetch_build_eggs(attrs['setup_requires'])
  File "/usr/lib/python3/dist-packages/setuptools/dist.py", line 287, in fetch_build_eggs
    replace_conflicting=True,
  File "/usr/lib/python3/dist-packages/pkg_resources.py", line 631, in resolve
    dist = best[req.key] = env.best_match(req, ws, installer)
  File "/usr/lib/python3/dist-packages/pkg_resources.py", line 867, in best_match
    dist = working_set.find(req)
  File "/usr/lib/python3/dist-packages/pkg_resources.py", line 509, in find
    raise VersionConflict(dist, req)
pkg_resources.VersionConflict: (setuptools 5.5.1 (/usr/lib/python3/dist-packages), Requirement.parse('setuptools>=30'))
```