### PR TITLE
Fix the issue that pyspark3 not supported by Livy 0.4

### DIFF
--- a/sparkmagic/sparkmagic/kernels/kernelmagics.py
+++ b/sparkmagic/sparkmagic/kernels/kernelmagics.py
@@ -12,7 +12,7 @@ from IPython.core.magic_arguments import argument, magic_arguments
 from hdijupyterutils.utils import generate_uuid
 
 import sparkmagic.utils.configuration as conf
-from sparkmagic.utils.configuration import get_livy_kind
+from sparkmagic.utils.configuration import get_session_kind
 from sparkmagic.utils import constants
 from sparkmagic.utils.utils import parse_argstring_or_throw, get_coerce_value
 from sparkmagic.utils.sparkevents import SparkEvents
@@ -27,15 +27,15 @@ from sparkmagic.livyclientlib.exceptions import handle_expected_exceptions, wrap
 def _event(f):
     def wrapped(self, *args, **kwargs):
         guid = self._generate_uuid()
-        self._spark_events.emit_magic_execution_start_event(f.__name__, get_livy_kind(self.language), guid)
+        self._spark_events.emit_magic_execution_start_event(f.__name__, get_session_kind(self.language), guid)
         try:
             result = f(self, *args, **kwargs)
         except Exception as e:
-            self._spark_events.emit_magic_execution_end_event(f.__name__, get_livy_kind(self.language), guid,
+            self._spark_events.emit_magic_execution_end_event(f.__name__, get_session_kind(self.language), guid,
                                                               False, e.__class__.__name__, str(e))
             raise
         else:
-            self._spark_events.emit_magic_execution_end_event(f.__name__, get_livy_kind(self.language), guid,
+            self._spark_events.emit_magic_execution_end_event(f.__name__, get_session_kind(self.language), guid,
                                                               True, u"", u"")
             return result
     wrapped.__name__ = f.__name__

--- a/sparkmagic/sparkmagic/livyclientlib/livysession.py
+++ b/sparkmagic/sparkmagic/livyclientlib/livysession.py
@@ -113,6 +113,10 @@ class LivySession(ObjectWithGuid):
     def _translate_to_livy_kind(self, properties, kind):
         # Livy does not support "pyspark3" as the kind from 0.4 onwards and only "pyspark" is valid.
         # That's why we are leveraging PYSPARK_PYTHON_PARAM here to specifyf different python versions.
+
+        if kind != constants.SESSION_KIND_PYSPARK and kind != constants.SESSION_KIND_PYSPARK3:
+            return
+
         sparkConfigs = {}
         if constants.LIVY_CONF_PARAM in properties:
             sparkConfigs = properties[constants.LIVY_CONF_PARAM]

--- a/sparkmagic/sparkmagic/livyclientlib/livysession.py
+++ b/sparkmagic/sparkmagic/livyclientlib/livysession.py
@@ -113,13 +113,17 @@ class LivySession(ObjectWithGuid):
     def _translate_to_livy_kind(self, properties, kind):
         # Livy does not support "pyspark3" as the kind from 0.4 onwards and only "pyspark" is valid.
         # That's why we are leveraging PYSPARK_PYTHON_PARAM here to specifyf different python versions.
+        sparkConfigs = {}
+        if constants.LIVY_CONF_PARAM in properties:
+            sparkConfigs = properties[constants.LIVY_CONF_PARAM]
+
         if kind == constants.SESSION_KIND_PYSPARK:
-            python_properties = {constants.PYSPARK_PYTHON_PARAM: constants.LANG_PYTHON}
-            properties[constants.LIVY_CONF_PARAM] = python_properties
+            sparkConfigs[constants.PYSPARK_PYTHON_PARAM] = conf.python2_executable_path()
         elif kind == constants.SESSION_KIND_PYSPARK3:
             properties[constants.LIVY_KIND_PARAM] = constants.SESSION_KIND_PYSPARK
-            python_properties = {constants.PYSPARK_PYTHON_PARAM: constants.LANG_PYTHON3}
-            properties[constants.LIVY_CONF_PARAM] = python_properties
+            sparkConfigs[constants.PYSPARK_PYTHON_PARAM] = conf.python3_executable_path()
+
+        properties[constants.LIVY_CONF_PARAM] = sparkConfigs
 
     def start(self):
         """Start the session against actual livy server."""

--- a/sparkmagic/sparkmagic/tests/test_livysession.py
+++ b/sparkmagic/sparkmagic/tests/test_livysession.py
@@ -220,7 +220,21 @@ class TestLivySession(object):
         assert_equals(kind, session.kind)
         assert_equals("idle", session.status)
         assert_equals(0, session.id)
-        self.http_client.post_session.assert_called_with({"kind": "pyspark", "heartbeatTimeoutInSecond": 60})
+        self.http_client.post_session.assert_called_with({"kind": "pyspark", "heartbeatTimeoutInSecond": 60, "conf": {"spark.yarn.appMasterEnv.PYSPARK_PYTHON": "python"}})
+
+    def test_start_python3_starts_session(self):
+        self.http_client.post_session.return_value = self.session_create_json
+        self.http_client.get_session.return_value = self.ready_sessions_json
+        self.http_client.get_statement.return_value = self.ready_statement_json
+
+        kind = constants.SESSION_KIND_PYSPARK3
+        session = self._create_session(kind=kind)
+        session.start()
+
+        assert_equals(kind, session.kind)
+        assert_equals("idle", session.status)
+        assert_equals(0, session.id)
+        self.http_client.post_session.assert_called_with({"kind": "pyspark", "heartbeatTimeoutInSecond": 60, "conf": {"spark.yarn.appMasterEnv.PYSPARK_PYTHON": "python3"}})
 
     def test_start_passes_in_all_properties(self):
         self.http_client.post_session.return_value = self.session_create_json

--- a/sparkmagic/sparkmagic/tests/test_livysession.py
+++ b/sparkmagic/sparkmagic/tests/test_livysession.py
@@ -220,7 +220,7 @@ class TestLivySession(object):
         assert_equals(kind, session.kind)
         assert_equals("idle", session.status)
         assert_equals(0, session.id)
-        self.http_client.post_session.assert_called_with({"kind": "pyspark", "heartbeatTimeoutInSecond": 60, "conf": {"spark.yarn.appMasterEnv.PYSPARK_PYTHON": "python"}})
+        self.http_client.post_session.assert_called_with({"kind": "pyspark", "heartbeatTimeoutInSecond": 60, "conf": {"spark.pyspark.python": "python"}})
 
     def test_start_python3_starts_session(self):
         self.http_client.post_session.return_value = self.session_create_json
@@ -234,7 +234,7 @@ class TestLivySession(object):
         assert_equals(kind, session.kind)
         assert_equals("idle", session.status)
         assert_equals(0, session.id)
-        self.http_client.post_session.assert_called_with({"kind": "pyspark", "heartbeatTimeoutInSecond": 60, "conf": {"spark.yarn.appMasterEnv.PYSPARK_PYTHON": "python3"}})
+        self.http_client.post_session.assert_called_with({"kind": "pyspark", "heartbeatTimeoutInSecond": 60, "conf": {"spark.pyspark.python": "python3"}})
 
     def test_start_passes_in_all_properties(self):
         self.http_client.post_session.return_value = self.session_create_json

--- a/sparkmagic/sparkmagic/tests/test_sparkmagicbase.py
+++ b/sparkmagic/sparkmagic/tests/test_sparkmagicbase.py
@@ -2,7 +2,7 @@
 from mock import MagicMock
 from nose.tools import with_setup, assert_equals, assert_raises
 
-from sparkmagic.utils.configuration import get_livy_kind
+from sparkmagic.utils.configuration import get_session_kind
 from sparkmagic.utils.constants import LANGS_SUPPORTED, SESSION_KIND_PYSPARK, SESSION_KIND_SPARK, \
     IDLE_SESSION_STATUS, BUSY_SESSION_STATUS
 from sparkmagic.magics.sparkmagicsbase import SparkMagicBase
@@ -32,7 +32,7 @@ def test_load_emits_event():
 
 def test_get_livy_kind_covers_all_langs():
     for lang in LANGS_SUPPORTED:
-        get_livy_kind(lang)
+        get_session_kind(lang)
 
 
 @with_setup(_setup, _teardown)

--- a/sparkmagic/sparkmagic/utils/configuration.py
+++ b/sparkmagic/sparkmagic/utils/configuration.py
@@ -32,7 +32,7 @@ _with_override = with_override(d, path)
 
 # Helpers
 
-def get_livy_kind(language):
+def get_session_kind(language):
     if language == LANG_SCALA:
         return SESSION_KIND_SPARK
     elif language == LANG_PYTHON:
@@ -57,7 +57,7 @@ def get_auth_value(username, password):
  
 def get_session_properties(language):
     properties = copy.deepcopy(session_configs())
-    properties[LIVY_KIND_PARAM] = get_livy_kind(language)
+    properties[LIVY_KIND_PARAM] = get_session_kind(language)
     return properties
 
 

--- a/sparkmagic/sparkmagic/utils/configuration.py
+++ b/sparkmagic/sparkmagic/utils/configuration.py
@@ -236,6 +236,13 @@ def configurable_retry_policy_max_retries():
     # Plus 15 seconds more wanted, that's 3 more 5 second retries.
     return 8
 
+@_with_override
+def python2_executable_path():
+    return "python"
+
+@_with_override
+def python3_executable_path():
+    return "python3"
 
 def _credentials_override(f):
     """Provides special handling for credentials. It still calls _override().

--- a/sparkmagic/sparkmagic/utils/constants.py
+++ b/sparkmagic/sparkmagic/utils/constants.py
@@ -89,6 +89,8 @@ RESOURCE_LIMIT_WARNING = "Warning: The Spark session does not have enough YARN r
 
 LIVY_HEARTBEAT_TIMEOUT_PARAM = u"heartbeatTimeoutInSecond"
 LIVY_KIND_PARAM = u"kind"
+LIVY_CONF_PARAM = u"conf"
+PYSPARK_PYTHON_PARAM = u"spark.yarn.appMasterEnv.PYSPARK_PYTHON"
 
 NO_AUTH = "None"
 AUTH_KERBEROS = "Kerberos"

--- a/sparkmagic/sparkmagic/utils/constants.py
+++ b/sparkmagic/sparkmagic/utils/constants.py
@@ -90,7 +90,8 @@ RESOURCE_LIMIT_WARNING = "Warning: The Spark session does not have enough YARN r
 LIVY_HEARTBEAT_TIMEOUT_PARAM = u"heartbeatTimeoutInSecond"
 LIVY_KIND_PARAM = u"kind"
 LIVY_CONF_PARAM = u"conf"
-PYSPARK_PYTHON_PARAM = u"spark.yarn.appMasterEnv.PYSPARK_PYTHON"
+# This spark setting is only supported in spark 2.1 onwards, but this is the only generic pyspark setting we can leverage
+PYSPARK_PYTHON_PARAM = u"spark.pyspark.python"
 
 NO_AUTH = "None"
 AUTH_KERBEROS = "Kerberos"


### PR DESCRIPTION
Livy 0.4 onwards removed the "pyspark3" as the session kind, so sparkmagic receives a 400 response when we create a pyspark3 notebook on Jupyter. So pyspark3 kernel is not working due to this Livy breaking change.

In this PR, we are specifying "spark.yarn.appMasterEnv.PYSPARK_PYTHON" to "python" or "python3" to kick off different python versions, which is the new approach to differentiate pyspark/pyspark3 sessions. This approach works with the old livy version (e.g. 0.3) as well as 0.4 onwards. Also "spark.yarn.appMasterEnv.PYSPARK_PYTHON"  is supported both spark 1.6 and spark 2.