### PR TITLE
Allow for -o to store any serializable type in pyspark kernels

### DIFF
--- a/sparkmagic/sparkmagic/utils/utils.py
+++ b/sparkmagic/sparkmagic/utils/utils.py
@@ -52,6 +52,10 @@ def coerce_pandas_df_to_numeric_datetime(df):
 def records_to_dataframe(records_text, kind, coerce=None):
     if records_text in ['', '[]']:
         strings = []
+    elif isinstance(records_text, list):
+        # Temporary workaround - once the old serialization is removed from the other kernels
+        # we can simplify this parsing step for everyone
+        strings = records_text
     else:
         strings = records_text.split('\n')
     try:


### PR DESCRIPTION
Currently the `-o` flag only lets Spark `DataFrame` objects to be pulled out of the PySpark session into the local kernel. This patch expands that support for *any* type that is serializable with `pyspark.cloudpickle`. The old behaviour is still maintained - `pyspark.sql.DataFrame` still gets converted to `pandas.DataFrame`.

There's still a few things to sort out:
  1. Only the PySpark and PySpark3 kernels have this applied, still need to do Scala and R. Once all the kernels support the new serialization scheme, some surrounding code can be removed and simplified
  2. No tests have been updated or added yet, although manual testing has been successful for me
  3. `pyspark.RDD` should also get special treatment, converting to a `list` and taking `samplemethod` and `max_rows` into account
  4. I would like to also support a `-i` flag for passing cloudpickle-able types *into* the Spark session, using basically the same logic as here (generating a command with the base64-encoded pickles in there)

I will get to these once I get some confirmation that my approach is valid and the patch is conceptually welcome.

Thanks!