### PR TITLE
SSL with custom certfiles path

### DIFF
--- a/sparkmagic/example_config.json
+++ b/sparkmagic/example_config.json
@@ -48,7 +48,7 @@
   "fatal_error_suggestion": "The code failed because of a fatal error:\n\t{}.\n\nSome things to try:\na) Make sure Spark has enough available resources for Jupyter to create a Spark context.\nb) Contact your Jupyter administrator to make sure the Spark magics library is configured correctly.\nc) Restart the kernel.",
 
   "ignore_ssl_errors": false,
-  "custom_certfiles_path": "ca-bundle.crt",
+  "custom_certfiles_path": null,
 
   "session_configs": {
     "driverMemory": "1000M",

--- a/sparkmagic/example_config.json
+++ b/sparkmagic/example_config.json
@@ -48,6 +48,7 @@
   "fatal_error_suggestion": "The code failed because of a fatal error:\n\t{}.\n\nSome things to try:\na) Make sure Spark has enough available resources for Jupyter to create a Spark context.\nb) Contact your Jupyter administrator to make sure the Spark magics library is configured correctly.\nc) Restart the kernel.",
 
   "ignore_ssl_errors": false,
+  "custom_certfiles_path": "cacerts.pem",
 
   "session_configs": {
     "driverMemory": "1000M",

--- a/sparkmagic/example_config.json
+++ b/sparkmagic/example_config.json
@@ -48,7 +48,7 @@
   "fatal_error_suggestion": "The code failed because of a fatal error:\n\t{}.\n\nSome things to try:\na) Make sure Spark has enough available resources for Jupyter to create a Spark context.\nb) Contact your Jupyter administrator to make sure the Spark magics library is configured correctly.\nc) Restart the kernel.",
 
   "ignore_ssl_errors": false,
-  "custom_certfiles_path": "cacerts.pem",
+  "custom_certfiles_path": "ca-bundle.crt",
 
   "session_configs": {
     "driverMemory": "1000M",

--- a/sparkmagic/sparkmagic/livyclientlib/reliablehttpclient.py
+++ b/sparkmagic/sparkmagic/livyclientlib/reliablehttpclient.py
@@ -33,6 +33,10 @@ class ReliableHttpClient(object):
         if not self.verify_ssl:
             self.logger.debug(u"ATTENTION: Will ignore SSL errors. This might render you vulnerable to attacks.")
             requests.packages.urllib3.disable_warnings()
+        else:
+            if conf.custom_certfiles_path is not None:
+                self.logger.debug(u"Using a custom SSL certificate")
+                self.verify_ssl = conf.custom_certfiles_path
 
     def get_headers(self):
         return self._headers

--- a/sparkmagic/sparkmagic/livyclientlib/reliablehttpclient.py
+++ b/sparkmagic/sparkmagic/livyclientlib/reliablehttpclient.py
@@ -34,9 +34,7 @@ class ReliableHttpClient(object):
             self.logger.debug(u"ATTENTION: Will ignore SSL errors. This might render you vulnerable to attacks.")
             requests.packages.urllib3.disable_warnings()
         else:
-            if conf.custom_certfiles_path is not None:
-                self.logger.debug(u"Using a custom SSL certificate")
-                self.verify_ssl = conf.custom_certfiles_path
+            self._set_custom_certfiles_path()
 
     def get_headers(self):
         return self._headers
@@ -98,3 +96,8 @@ class ReliableHttpClient(object):
                     raise HttpClientException(u"Invalid status code '{}' from {} with error payload: {}"
                                               .format(status, url, text))
             return r
+
+    def _set_custom_certfiles_path(self):
+        if conf.custom_certfiles_path is not None:
+            self.logger.debug(u"Using a custom SSL certificate")
+            self.verify_ssl = conf.custom_certfiles_path

--- a/sparkmagic/sparkmagic/tests/test_configuration.py
+++ b/sparkmagic/sparkmagic/tests/test_configuration.py
@@ -78,3 +78,13 @@ def test_share_config_between_pyspark_and_pyspark3():
     kpc = { 'username': 'U', 'password': 'P', 'base64_password': 'cGFzc3dvcmQ=', 'url': 'L', 'auth': AUTH_BASIC }
     overrides = { conf.kernel_python_credentials.__name__: kpc }
     assert_equals(conf.base64_kernel_python3_credentials(), conf.base64_kernel_python_credentials())
+
+@with_setup(_setup)
+def test_custom_certfiles_path():
+    overrides = { }
+    conf.override_all(overrides)
+    assert_equals(conf.custom_certfiles_path(), None)
+    cert = "test.pem"
+    overrides = { conf.custom_certfiles_path.__name__: cert }
+    conf.override_all(overrides)
+    assert_equals(conf.custom_certfiles_path(), cert)

--- a/sparkmagic/sparkmagic/tests/test_reliablehttpclient.py
+++ b/sparkmagic/sparkmagic/tests/test_reliablehttpclient.py
@@ -232,3 +232,4 @@ def test_kerberos_auth_check_auth():
     client = ReliableHttpClient(endpoint, {}, retry_policy)
     assert_is_not_none(client._auth)
     assert isinstance(client._auth, HTTPKerberosAuth)
+

--- a/sparkmagic/sparkmagic/utils/configuration.py
+++ b/sparkmagic/sparkmagic/utils/configuration.py
@@ -164,6 +164,9 @@ def resource_limit_mitigation_suggestion():
 def ignore_ssl_errors():
     return False
 
+@_with_override
+def custom_certfiles_path():
+    return None
 
 @_with_override
 def coerce_dataframe():


### PR DESCRIPTION
Regarding #404 

Using verify to pass the certificate path as shown here 
* http://docs.python-requests.org/en/master/user/advanced/#ssl-cert-verification

Configure it using ` custom_certfiles_path` 