### PR TITLE
livy 0.4.0 pyspark3 compatibility, fixing #421

### DIFF
--- a/sparkmagic/sparkmagic/kernels/kernelmagics.py
+++ b/sparkmagic/sparkmagic/kernels/kernelmagics.py
@@ -12,7 +12,7 @@ from IPython.core.magic_arguments import argument, magic_arguments
 from hdijupyterutils.utils import generate_uuid
 
 import sparkmagic.utils.configuration as conf
-from sparkmagic.utils.configuration import get_livy_kind
+from sparkmagic.utils.configuration import get_session_kind
 from sparkmagic.utils import constants
 from sparkmagic.utils.utils import parse_argstring_or_throw, get_coerce_value
 from sparkmagic.utils.sparkevents import SparkEvents
@@ -27,15 +27,15 @@ from sparkmagic.livyclientlib.exceptions import handle_expected_exceptions, wrap
 def _event(f):
     def wrapped(self, *args, **kwargs):
         guid = self._generate_uuid()
-        self._spark_events.emit_magic_execution_start_event(f.__name__, get_livy_kind(self.language), guid)
+        self._spark_events.emit_magic_execution_start_event(f.__name__, get_session_kind(self.language), guid)
         try:
             result = f(self, *args, **kwargs)
         except Exception as e:
-            self._spark_events.emit_magic_execution_end_event(f.__name__, get_livy_kind(self.language), guid,
+            self._spark_events.emit_magic_execution_end_event(f.__name__, get_session_kind(self.language), guid,
                                                               False, e.__class__.__name__, str(e))
             raise
         else:
-            self._spark_events.emit_magic_execution_end_event(f.__name__, get_livy_kind(self.language), guid,
+            self._spark_events.emit_magic_execution_end_event(f.__name__, get_session_kind(self.language), guid,
                                                               True, u"", u"")
             return result
     wrapped.__name__ = f.__name__

--- a/sparkmagic/sparkmagic/livyclientlib/livysession.py
+++ b/sparkmagic/sparkmagic/livyclientlib/livysession.py
@@ -110,11 +110,22 @@ class LivySession(ObjectWithGuid):
         return u"Session id: {}\tYARN id: {}\tKind: {}\tState: {}\n\tSpark UI: {}\n\tDriver Log: {}"\
             .format(self.id, self.get_app_id(), self.kind, self.status, self.get_spark_ui_url(), self.get_driver_log_url())
 
+    def _translate_to_livy_kind(self, properties, kind):
+        # Livy does not support "pyspark3" as the kind from 0.4 onwards and only "pyspark" is valid.
+        # That's why we are leveraging PYSPARK_PYTHON_PARAM here to specifyf different python versions.
+        if kind in [constants.SESSION_KIND_PYSPARK, constants.SESSION_KIND_PYSPARK3] and not constants.LIVY_CONF_PARAM in properties:
+            properties[constants.LIVY_CONF_PARAM] = dict()
+        if kind == constants.SESSION_KIND_PYSPARK:
+            properties[constants.LIVY_CONF_PARAM][constants.PYSPARK_PYTHON_PARAM] = constants.LANG_PYTHON
+        elif kind == constants.SESSION_KIND_PYSPARK3:
+            properties[constants.LIVY_KIND_PARAM] = constants.SESSION_KIND_PYSPARK
+            properties[constants.LIVY_CONF_PARAM][constants.PYSPARK_PYTHON_PARAM] = constants.LANG_PYTHON3
+
     def start(self):
         """Start the session against actual livy server."""
         self._spark_events.emit_session_creation_start_event(self.guid, self.kind)
         self._printed_resource_warning = False
-
+        self._translate_to_livy_kind(self.properties, self.kind)
         try:
             r = self._http_client.post_session(self.properties)
             self.id = r[u"id"]

--- a/sparkmagic/sparkmagic/tests/test_livysession.py
+++ b/sparkmagic/sparkmagic/tests/test_livysession.py
@@ -220,7 +220,21 @@ class TestLivySession(object):
         assert_equals(kind, session.kind)
         assert_equals("idle", session.status)
         assert_equals(0, session.id)
-        self.http_client.post_session.assert_called_with({"kind": "pyspark", "heartbeatTimeoutInSecond": 60})
+        self.http_client.post_session.assert_called_with({"kind": "pyspark", "heartbeatTimeoutInSecond": 60, "conf": {"spark.pyspark.python": "python"}})
+
+    def test_start_python3_starts_session(self):
+        self.http_client.post_session.return_value = self.session_create_json
+        self.http_client.get_session.return_value = self.ready_sessions_json
+        self.http_client.get_statement.return_value = self.ready_statement_json
+
+        kind = constants.SESSION_KIND_PYSPARK3
+        session = self._create_session(kind=kind)
+        session.start()
+
+        assert_equals(kind, session.kind)
+        assert_equals("idle", session.status)
+        assert_equals(0, session.id)
+        self.http_client.post_session.assert_called_with({"kind": "pyspark", "heartbeatTimeoutInSecond": 60, "conf": {"spark.pyspark.python": "python3"}})
 
     def test_start_passes_in_all_properties(self):
         self.http_client.post_session.return_value = self.session_create_json

--- a/sparkmagic/sparkmagic/tests/test_sparkmagicbase.py
+++ b/sparkmagic/sparkmagic/tests/test_sparkmagicbase.py
@@ -2,7 +2,7 @@
 from mock import MagicMock
 from nose.tools import with_setup, assert_equals, assert_raises
 
-from sparkmagic.utils.configuration import get_livy_kind
+from sparkmagic.utils.configuration import get_session_kind
 from sparkmagic.utils.constants import LANGS_SUPPORTED, SESSION_KIND_PYSPARK, SESSION_KIND_SPARK, \
     IDLE_SESSION_STATUS, BUSY_SESSION_STATUS
 from sparkmagic.magics.sparkmagicsbase import SparkMagicBase
@@ -32,7 +32,7 @@ def test_load_emits_event():
 
 def test_get_livy_kind_covers_all_langs():
     for lang in LANGS_SUPPORTED:
-        get_livy_kind(lang)
+        get_session_kind(lang)
 
 
 @with_setup(_setup, _teardown)

--- a/sparkmagic/sparkmagic/utils/configuration.py
+++ b/sparkmagic/sparkmagic/utils/configuration.py
@@ -32,7 +32,7 @@ _with_override = with_override(d, path)
 
 # Helpers
 
-def get_livy_kind(language):
+def get_session_kind(language):
     if language == LANG_SCALA:
         return SESSION_KIND_SPARK
     elif language == LANG_PYTHON:
@@ -57,7 +57,7 @@ def get_auth_value(username, password):
  
 def get_session_properties(language):
     properties = copy.deepcopy(session_configs())
-    properties[LIVY_KIND_PARAM] = get_livy_kind(language)
+    properties[LIVY_KIND_PARAM] = get_session_kind(language)
     return properties
 
 

--- a/sparkmagic/sparkmagic/utils/constants.py
+++ b/sparkmagic/sparkmagic/utils/constants.py
@@ -89,6 +89,9 @@ RESOURCE_LIMIT_WARNING = "Warning: The Spark session does not have enough YARN r
 
 LIVY_HEARTBEAT_TIMEOUT_PARAM = u"heartbeatTimeoutInSecond"
 LIVY_KIND_PARAM = u"kind"
+LIVY_CONF_PARAM = u"conf"
+# This spark setting is only supported in spark 2.1 onwards, but this is the only generic pyspark setting we can leverage
+PYSPARK_PYTHON_PARAM = u"spark.pyspark.python"
 
 NO_AUTH = "None"
 AUTH_KERBEROS = "Kerberos"


### PR DESCRIPTION
@taoliseki  sorry but I do not know how to modify existing PR #421 so I have amended it on my fork and made a PR myself (file `sparkmagic/sparkmagic/livyclientlib/livysession.py`)

The problem was that if you passed additional parameters in `"conf":{}` like a list of jars the existing PR #421 was removing them instead of only changing the value of `properties[constants.LIVY_CONF_PARAM][constants.PYSPARK_PYTHON_PARAM]`
