### PR TITLE
Spark statement errors create ipython error messages when configured to do so

### DIFF
--- a/sparkmagic/sparkmagic/livyclientlib/exceptions.py
+++ b/sparkmagic/sparkmagic/livyclientlib/exceptions.py
@@ -51,6 +51,10 @@ class BadUserDataException(LivyClientLibException):
 class SqlContextNotFoundException(LivyClientLibException):
     """Exception that is thrown when the SQL context is not found."""
 
+
+class SparkStatementException(LivyClientLibException):
+    """Exception that is thrown when an error occurs while parsing or executing Spark statements."""
+
 # == DECORATORS FOR EXCEPTION HANDLING ==
 EXPECTED_EXCEPTIONS = [BadUserConfigurationException, BadUserDataException, LivyUnexpectedStatusException, SqlContextNotFoundException,
                        HttpClientException, LivyClientTimeoutException, SessionManagementException]

--- a/sparkmagic/sparkmagic/magics/sparkmagicsbase.py
+++ b/sparkmagic/sparkmagic/magics/sparkmagicsbase.py
@@ -19,6 +19,7 @@ from sparkmagic.livyclientlib.sparkcontroller import SparkController
 from sparkmagic.livyclientlib.sqlquery import SQLQuery
 from sparkmagic.livyclientlib.command import Command
 from sparkmagic.livyclientlib.sparkstorecommand import SparkStoreCommand
+from sparkmagic.livyclientlib.exceptions import SparkStatementException
 
 
 @magics_class
@@ -40,6 +41,12 @@ class SparkMagicBase(Magics):
     def execute_spark(self, cell, output_var, samplemethod, maxrows, samplefraction, session_name, coerce):
         (success, out) = self.spark_controller.run_command(Command(cell), session_name)
         if not success:
+            if conf.spark_statement_errors_are_fatal():
+                if conf.shutdown_session_on_spark_statement_errors():
+                    self.spark_controller.cleanup()
+
+                raise SparkStatementException(out)
+
             self.ipython_display.send_error(out)
         else:
             self.ipython_display.write(out)

--- a/sparkmagic/sparkmagic/tests/test_sparkmagicbase.py
+++ b/sparkmagic/sparkmagic/tests/test_sparkmagicbase.py
@@ -1,4 +1,5 @@
 # -*- coding: UTF-8 -*-
+import sparkmagic.utils.configuration as conf
 from mock import MagicMock
 from nose.tools import with_setup, assert_equals, assert_raises
 
@@ -6,7 +7,7 @@ from sparkmagic.utils.configuration import get_livy_kind
 from sparkmagic.utils.constants import LANGS_SUPPORTED, SESSION_KIND_PYSPARK, SESSION_KIND_SPARK, \
     IDLE_SESSION_STATUS, BUSY_SESSION_STATUS
 from sparkmagic.magics.sparkmagicsbase import SparkMagicBase
-from sparkmagic.livyclientlib.exceptions import DataFrameParseException, BadUserDataException
+from sparkmagic.livyclientlib.exceptions import DataFrameParseException, BadUserDataException, SparkStatementException
 from sparkmagic.livyclientlib.sqlquery import SQLQuery
 from sparkmagic.livyclientlib.sparkstorecommand import SparkStoreCommand
 
@@ -181,3 +182,32 @@ def test_spark_exception_with_output_var():
     magic.ipython_display.write.assert_called_once_with('out')
     magic._spark_store_command.assert_called_once_with(output_var, None, None, None, True)
     assert shell.user_ns == {}
+
+@with_setup(_setup, _teardown)
+def test_spark_statement_exception():
+    conf.override_all({
+        "spark_statement_errors_are_fatal": True
+    })
+
+    mockSparkCommand = MagicMock()
+    magic._spark_store_command = MagicMock(return_value=mockSparkCommand)
+    exception = BadUserDataException("Ka-boom!")
+
+    magic.spark_controller.run_command.side_effect = [(False, 'out'), exception]
+    assert_raises(SparkStatementException, magic.execute_spark,"", None, None, None, None, session, True)
+    magic.spark_controller.cleanup.assert_not_called()
+
+@with_setup(_setup, _teardown)
+def test_spark_statement_exception_shutdowns_livy_session():
+    conf.override_all({
+        "spark_statement_errors_are_fatal": True,
+        "shutdown_session_on_spark_statement_errors": True
+    })
+
+    mockSparkCommand = MagicMock()
+    magic._spark_store_command = MagicMock(return_value=mockSparkCommand)
+    exception = BadUserDataException("Ka-boom!")
+
+    magic.spark_controller.run_command.side_effect = [(False, 'out'), exception]
+    assert_raises(SparkStatementException, magic.execute_spark,"", None, None, None, None, session, True)
+    magic.spark_controller.cleanup.assert_called_once()

--- a/sparkmagic/sparkmagic/utils/configuration.py
+++ b/sparkmagic/sparkmagic/utils/configuration.py
@@ -237,6 +237,20 @@ def configurable_retry_policy_max_retries():
     return 8
 
 
+@_with_override
+def spark_statement_errors_are_fatal():
+    # If set to true, any spark statement errors will be considered
+    # fatal and will raise a SparkStatementException
+    return False
+
+
+@_with_override
+def shutdown_session_on_spark_statement_errors():
+    # If set to true, any spark statement errors will cause the Livy
+    # session to be cleaned up
+    return False
+
+
 def _credentials_override(f):
     """Provides special handling for credentials. It still calls _override().
     If 'base64_password' in config is set, it will base64 decode it and returned in return value's 'password' field.


### PR DESCRIPTION
* Introduce SparkStatementException
* When the `spark_statement_errors_are_fatal` configuration is set to `True`
  and an error occurs origininating from the executing spark statement an
  exception is raised within the ipython notebook that correctly inserts an
  `error` output response.
* When the `shutdown_session_on_spark_statement_errors` configuration is set
  to `True` and `spark_statement_errors_are_fatal` is set to `True` when a
  spark statement error occurs the Livy session will be cleaned up.

In reference to: https://github.com/jupyter-incubator/sparkmagic/issues/518