### PR TITLE
Add sources.list to point to archive.debian.org for docker build

### DIFF
--- a/Dockerfile.spark
+++ b/Dockerfile.spark
@@ -1,5 +1,7 @@
 FROM gettyimages/spark:2.1.0-hadoop-2.7
 
+RUN printf "deb http://archive.debian.org/debian/ jessie main\ndeb-src http://archive.debian.org/debian/ jessie main\ndeb http://security.debian.org jessie/updates main\ndeb-src http://security.debian.org jessie/updates main" > /etc/apt/sources.list
+
 RUN apt-get update && apt-get install -yq --no-install-recommends --force-yes \
     git \
     openjdk-7-jdk \


### PR DESCRIPTION
Since jessie packages have moved to archive.debian.org [1], add a `sources.list` to point the `Dockerfile.spark` to the archived packages.

Without this change, a fresh checkout of the code and a `docker-compose build` will result in:
```
W: Failed to fetch http://deb.debian.org/debian/dists/jessie-updates/InRelease  Unable to find expected entry 'main/binary-amd64/Packages' in Release file (Wrong sources.list entry or malformed file)

E: Some index files failed to download. They have been ignored, or old ones used instead.
ERROR: Service 'spark' failed to build:
```

At some point, the base image should be updated but I don't use sparkmagic enough yet to know what other problems the new image might introduce.  I'm just suggesting this PR as an expedient method of getting the `docker-compose build` to work again.

[1] https://lists.debian.org/debian-devel-announce/2019/03/msg00006.html