### PR TITLE
Fix enconding issue for Python3.x

### DIFF
--- a/sparkmagic/sparkmagic/livyclientlib/sparkstorecommand.py
+++ b/sparkmagic/sparkmagic/livyclientlib/sparkstorecommand.py
@@ -61,7 +61,7 @@ class SparkStoreCommand(Command):
             raise BadUserDataException(u"Kind '{}' is not supported.".format(kind))
 
 
-    def _pyspark_command(self, spark_context_variable_name, encode_result=True):
+    def _pyspark_command(self, spark_context_variable_name, encode_result=False):
         command = u'{}.toJSON()'.format(spark_context_variable_name)
         if self.samplemethod == u'sample':
             command = u'{}.sample(False, {})'.format(command, self.samplefraction)

--- a/sparkmagic/sparkmagic/livyclientlib/sqlquery.py
+++ b/sparkmagic/sparkmagic/livyclientlib/sqlquery.py
@@ -69,7 +69,7 @@ class SQLQuery(ObjectWithGuid):
             return result
 
 
-    def _pyspark_command(self, sql_context_variable_name, encode_result=True):
+    def _pyspark_command(self, sql_context_variable_name, encode_result=False):
         command = u'{}.sql(u"""{} """).toJSON()'.format(sql_context_variable_name, self.query)
         if self.samplemethod == u'sample':
             command = u'{}.sample(False, {})'.format(command, self.samplefraction)


### PR DESCRIPTION
When using SQL to query a table the following errors is shown:
```ipynb
%%spark -c sql
select * from cars limit 10

---------------------------------------------------------------------------
JSONDecodeError                           Traceback (most recent call last)
/opt/conda/lib/python3.5/site-packages/sparkmagic/utils/utils.py in records_to_dataframe(records_text, kind, coerce)
     57     try:
---> 58         data_array = [json.JSONDecoder(object_pairs_hook=OrderedDict).decode(s) for s in strings]
     59 

/opt/conda/lib/python3.5/site-packages/sparkmagic/utils/utils.py in <listcomp>(.0)
     57     try:
---> 58         data_array = [json.JSONDecoder(object_pairs_hook=OrderedDict).decode(s) for s in strings]
     59 

/opt/conda/lib/python3.5/json/decoder.py in decode(self, s, _w)
    338         """
--> 339         obj, end = self.raw_decode(s, idx=_w(s, 0).end())
    340         end = _w(s, end).end()

/opt/conda/lib/python3.5/json/decoder.py in raw_decode(self, s, idx)
    356         except StopIteration as err:
--> 357             raise JSONDecodeError("Expecting value", s, err.value) from None
    358         return obj, end

JSONDecodeError: Expecting value: line 1 column 1 (char 0)

During handling of the above exception, another exception occurred:

DataFrameParseException                   Traceback (most recent call last)
<ipython-input-6-04d8c2a49c16> in <module>()
----> 1 get_ipython().run_cell_magic('spark', '-c sql', 'select * from cars limit 10')

/opt/conda/lib/python3.5/site-packages/IPython/core/interactiveshell.py in run_cell_magic(self, magic_name, line, cell)
   2113             magic_arg_s = self.var_expand(line, stack_depth)
   2114             with self.builtin_trap:
-> 2115                 result = fn(magic_arg_s, cell)
   2116             return result
   2117 

<decorator-gen-124> in spark(self, *args, **kwargs)

/opt/conda/lib/python3.5/site-packages/IPython/core/magic.py in <lambda>(f, *a, **k)
    186     # but it's overkill for just that one bit of state.
    187     def magic_deco(arg):
--> 188         call = lambda f, *a, **k: f(*a, **k)
    189 
    190         if callable(arg):

/opt/conda/lib/python3.5/site-packages/sparkmagic/livyclientlib/exceptions.py in wrapped(self, *args, **kwargs)
     70     def wrapped(self, *args, **kwargs):
     71         try:
---> 72             out = f(self, *args, **kwargs)
     73         except exceptions_to_handle as err:
     74             # Do not log! as some messages may contain private client information

/opt/conda/lib/python3.5/site-packages/sparkmagic/magics/remotesparkmagics.py in spark(self, line, cell, local_ns)
    174             elif args.context == CONTEXT_NAME_SQL:
    175                 return self.execute_sqlquery(cell, args.samplemethod, args.maxrows, args.samplefraction,
--> 176                                              args.session, args.output, args.quiet, coerce)
    177             else:
    178                 self.ipython_display.send_error("Context '{}' not found".format(args.context))

/opt/conda/lib/python3.5/site-packages/sparkmagic/magics/sparkmagicsbase.py in execute_sqlquery(self, cell, samplemethod, maxrows, samplefraction, session, output_var, quiet, coerce)
     56                          session, output_var, quiet, coerce):
     57         sqlquery = self._sqlquery(cell, samplemethod, maxrows, samplefraction, coerce)
---> 58         df = self.spark_controller.run_sqlquery(sqlquery, session)
     59         if output_var is not None:
     60             self.shell.user_ns[output_var] = df

/opt/conda/lib/python3.5/site-packages/sparkmagic/livyclientlib/sparkcontroller.py in run_sqlquery(self, sqlquery, client_name)
     38     def run_sqlquery(self, sqlquery, client_name=None):
     39         session_to_use = self.get_session_by_name_or_default(client_name)
---> 40         return sqlquery.execute(session_to_use)
     41 
     42     def get_all_sessions_endpoint(self, endpoint):

/opt/conda/lib/python3.5/site-packages/sparkmagic/livyclientlib/sqlquery.py in execute(self, session)
     58             if not success:
     59                 raise BadUserDataException(records_text)
---> 60             result = records_to_dataframe(records_text, session.kind, self._coerce)
     61         except Exception as e:
     62             self._spark_events.emit_sql_execution_end_event(session.guid, session.kind, session.id, self.guid,

/opt/conda/lib/python3.5/site-packages/sparkmagic/utils/utils.py in records_to_dataframe(records_text, kind, coerce)
     82         return df
     83     except ValueError:
---> 84         raise DataFrameParseException(u"Cannot parse object as JSON: '{}'".format(strings))
     85 
     86 

DataFrameParseException: Cannot parse object as JSON: '['b\'{...}\'']'
```
*Content above has been truncated*

With 2 simple changes to `sqlquery.py` and `sparkstorecommand.py` in their definiton of:
```python
def _pyspark_command(self, sql_context_variable_name, encode_result=True):
```
To:
```python
def _pyspark_command(self, sql_context_variable_name, encode_result=False):
```

It solves the issues and outputs the table correctly.

Although #507 solves this issue as well as many other, this small fix tackles specifically the encoding issue for Python3.x. Total credit for this goes to @juliusvonkohout who made the changes.

These changes has been tested with both Python 2.7 and Python3
