### PR TITLE
Rapids Spark docker compose and Notebook example

### DIFF
--- a/Dockerfile.sparkgpu
+++ b/Dockerfile.sparkgpu
@@ -1,0 +1,63 @@
+FROM nvidia/cuda:10.0-cudnn7-devel-ubuntu18.04
+
+ENV DEBIAN_FRONTEND=noninteractive 
+RUN ln -fs /usr/share/zoneinfo/America/los_angeles /etc/localtime
+
+RUN apt-get update && apt-get install -yq --no-install-recommends --force-yes \
+    curl wget \
+    git \
+    openjdk-8-jdk \
+    maven \
+    python2.7 python2.7-setuptools python-pip python-dev \
+    python3 python3-setuptools python3-pip python3-dev \
+    r-base \
+    r-base-core && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN dpkg-reconfigure --frontend noninteractive tzdata
+
+RUN pip install py4j
+RUN pip install --upgrade setuptools
+
+ENV PYTHONHASHSEED 0
+ENV PYTHONIOENCODING UTF-8
+# ENV PIP_DISABLE_PIP_VERSION_CHECK 1
+
+ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
+RUN export PATH=$PATH:$JAVA_HOME/bin
+ENV SPARK_BUILD_VERSION 2.4.0
+ENV SPARK_HOME /apps/spark-$SPARK_BUILD_VERSION
+ENV SPARK_BUILD_PATH /apps/build/spark
+RUN mkdir -p /apps/build && \
+  cd /apps/build && \
+  git clone https://github.com/apache/spark.git spark && \
+  cd $SPARK_BUILD_PATH && \
+  git checkout v$SPARK_BUILD_VERSION && \
+  dev/make-distribution.sh --name spark-$SPARK_BUILD_VERSION -Phive -Phive-thriftserver -Pyarn && \
+  cp -r /apps/build/spark/dist $SPARK_HOME && \
+  rm -rf $SPARK_BUILD_PATH
+
+ENV LIVY_BUILD_VERSION 0.6.0-incubating
+ENV LIVY_APP_PATH /apps/apache-livy-$LIVY_BUILD_VERSION-bin
+ENV LIVY_BUILD_PATH /apps/build/livy
+RUN cd /apps/build && \
+	git clone https://github.com/apache/incubator-livy.git livy && \
+	cd $LIVY_BUILD_PATH && \
+  git checkout v$LIVY_BUILD_VERSION-rc2 && \
+    mvn -DskipTests -Dspark.version=$SPARK_BUILD_VERSION clean package && \
+    ls -al $LIVY_BUILD_PATH && ls -al $LIVY_BUILD_PATH/assembly && ls -al $LIVY_BUILD_PATH/assembly/target && \
+    unzip $LIVY_BUILD_PATH/assembly/target/apache-livy-${LIVY_BUILD_VERSION}-bin.zip -d /apps && \
+    rm -rf $LIVY_BUILD_PATH && \
+	mkdir -p $LIVY_APP_PATH/upload && \
+  mkdir -p $LIVY_APP_PATH/logs
+
+RUN apt-get update && apt-get install -y python-matplotlib python-pandas
+# RUN pip install matplotlib
+# RUN pip install pandas
+RUN cd /root && wget https://rapidsai-data.s3.us-east-2.amazonaws.com/spark/mortgage.zip && unzip mortgage.zip
+
+ENV LD_LIBRARY_PATH /usr/local/cuda-10.0/lib64${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+ENV PATH /usr/local/cuda-10.0/bin${PATH:+:${PATH}}
+EXPOSE 8998
+
+CMD $LIVY_APP_PATH/bin/livy-server

--- a/README.md
+++ b/README.md
@@ -106,6 +106,17 @@ re-build the container. This will cause the container to install your
 local version of autovizwidget, hdijupyterutils, and sparkmagic. Make
 sure to re-run `docker-compose build` before each test run.
 
+## NVIDIA docker
+
+The included `nvidia-docker-compose.yml` file will let you run same sparkmagic stack but enable [SparkGPU](https://github.com/rapidsai/spark-examples) functionality, you can modify `NVIDIA_VISIBLE_DEVICES` to designate which GPU in your system to use. Also you need to copy `nvidia-docker-compose.yml` to `docker-compose.yml`.
+
+     cp docker-compose.yml docker-compose.yml.backup
+     cp nvidia-docker-compose.yml docker-compose.yml
+     docker-compose build
+     docker-compose up
+
+`SparkGPU Kernel.ipynb` inside `work` directory will provide the example to run mortgage data through SparkGPU. The rest is the same as docker instruction. 
+
 ## Server extension API
 
 ### `/reconnectsparkmagic`:

--- a/examples/SparkGPU Kernel.ipynb
+++ b/examples/SparkGPU Kernel.ipynb
@@ -1,0 +1,513 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "Current session configs: <tt>{'driverMemory': '1000M', 'numExecutors': 1, 'executorCores': 2, 'jars': ['https://repo1.maven.org/maven2/ai/rapids/cudf/0.8/cudf-0.8-cuda10.jar', 'https://repo1.maven.org/maven2/ai/rapids/xgboost4j-spark/0.90.1-Beta/xgboost4j-spark-0.90.1-Beta-cuda10.jar', 'https://repo1.maven.org/maven2/ai/rapids/xgboost4j/0.90.1-Beta/xgboost4j-0.90.1-Beta-cuda10.jar'], 'kind': 'spark'}</tt><br>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "No active sessions."
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "%%configure -f\n",
+    "{ \n",
+    "    \"driverMemory\": \"1000M\",\n",
+    "    \"numExecutors\": 1,\n",
+    "    \"executorCores\": 2,\n",
+    "    \"jars\" : [\"https://repo1.maven.org/maven2/ai/rapids/cudf/0.8/cudf-0.8-cuda10.jar\", \n",
+    "      \"https://repo1.maven.org/maven2/ai/rapids/xgboost4j-spark/0.90.1-Beta/xgboost4j-spark-0.90.1-Beta-cuda10.jar\", \n",
+    "      \"https://repo1.maven.org/maven2/ai/rapids/xgboost4j/0.90.1-Beta/xgboost4j-0.90.1-Beta-cuda10.jar\"]\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "Current session configs: <tt>{'driverMemory': '1000M', 'numExecutors': 1, 'executorCores': 2, 'jars': ['https://repo1.maven.org/maven2/ai/rapids/cudf/0.8/cudf-0.8-cuda10.jar', 'https://repo1.maven.org/maven2/ai/rapids/xgboost4j-spark/0.90.1-Beta/xgboost4j-spark-0.90.1-Beta-cuda10.jar', 'https://repo1.maven.org/maven2/ai/rapids/xgboost4j/0.90.1-Beta/xgboost4j-0.90.1-Beta-cuda10.jar'], 'kind': 'spark'}</tt><br>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "No active sessions."
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "%%info"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Starting Spark application\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<table>\n",
+       "<tr><th>ID</th><th>YARN Application ID</th><th>Kind</th><th>State</th><th>Spark UI</th><th>Driver log</th><th>Current session?</th></tr><tr><td>0</td><td>None</td><td>spark</td><td>idle</td><td></td><td></td><td>✔</td></tr></table>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "FloatProgress(value=0.0, bar_style='info', description='Progress:', layout=Layout(height='25px', width='50%'),…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "SparkSession available as 'spark'.\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "FloatProgress(value=0.0, bar_style='info', description='Progress:', layout=Layout(height='25px', width='50%'),…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "import ml.dmlc.xgboost4j.scala.spark.{XGBoostClassifier, XGBoostClassificationModel}\n",
+      "import ml.dmlc.xgboost4j.scala.spark.rapids.GpuDataReader\n",
+      "import ml.dmlc.xgboost4j.scala.spark.XGBoostClassifier\n",
+      "import org.apache.spark.sql.SparkSession\n",
+      "import org.apache.spark.ml.evaluation.RegressionEvaluator\n",
+      "import org.apache.spark.ml.evaluation.MulticlassClassificationEvaluator\n",
+      "import org.apache.spark.sql.types.{DoubleType, IntegerType, StructField, StructType}\n",
+      "trainPath: String = file:///root/mortgage/csv/train/\n",
+      "evalPath: String = file:///root/mortgage/csv/test/\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Databricks notebook source\n",
+    "import ml.dmlc.xgboost4j.scala.spark.{XGBoostClassifier, XGBoostClassificationModel}\n",
+    "import ml.dmlc.xgboost4j.scala.spark.rapids.GpuDataReader\n",
+    "import ml.dmlc.xgboost4j.scala.spark.XGBoostClassifier\n",
+    "import org.apache.spark.sql.SparkSession\n",
+    "import org.apache.spark.ml.evaluation.RegressionEvaluator\n",
+    "import org.apache.spark.ml.evaluation.MulticlassClassificationEvaluator\n",
+    "import org.apache.spark.sql.types.{DoubleType, IntegerType, StructField, StructType}\n",
+    "\n",
+    "\n",
+    "// COMMAND ----------\n",
+    "\n",
+    "// val trainPath = \"s3://sagemaker-gpu-xgboost/mortgage/csv/train/\"\n",
+    "// val evalPath  = \"s3://sagemaker-gpu-xgboost/mortgage/csv/test/\"\n",
+    "\n",
+    "val trainPath = \"file:///root/mortgage/csv/train/\"\n",
+    "val evalPath  = \"file:///root/mortgage/csv/test/\"\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "FloatProgress(value=0.0, bar_style='info', description='Progress:', layout=Layout(height='25px', width='50%'),…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "spark://spark:35981/jars/livy-repl_2.11-0.6.0-incubating.jar\n",
+      "https://repo1.maven.org/maven2/ai/rapids/cudf/0.8/cudf-0.8-cuda10.jar\n",
+      "spark://spark:35981/jars/livy-core_2.11-0.6.0-incubating.jar\n",
+      "spark://spark:35981/jars/livy-rsc-0.6.0-incubating.jar\n",
+      "https://repo1.maven.org/maven2/ai/rapids/xgboost4j-spark/0.90.1-Beta/xgboost4j-spark-0.90.1-Beta-cuda10.jar\n",
+      "https://repo1.maven.org/maven2/ai/rapids/xgboost4j/0.90.1-Beta/xgboost4j-0.90.1-Beta-cuda10.jar\n",
+      "spark://spark:35981/jars/livy-api-0.6.0-incubating.jar\n",
+      "spark://spark:35981/jars/netty-all-4.0.37.Final.jar\n",
+      "spark://spark:35981/jars/commons-codec-1.9.jar\n",
+      "spark: org.apache.spark.sql.SparkSession = org.apache.spark.sql.SparkSession@1f36fa5d\n",
+      "dataReader: ml.dmlc.xgboost4j.scala.spark.rapids.GpuDataReader = ml.dmlc.xgboost4j.scala.spark.rapids.GpuDataReader@5afbb607\n",
+      "labelColName: String = delinquency_12\n",
+      "schema: org.apache.spark.sql.types.StructType = StructType(StructField(orig_channel,DoubleType,true), StructField(first_home_buyer,DoubleType,true), StructField(loan_purpose,DoubleType,true), StructField(property_type,DoubleType,true), StructField(occupancy_status,DoubleType,true), StructField(property_state,DoubleType,true), StructField(product_type,DoubleType,true), StructField(relocation_mortgage_indicator,DoubleType,true), StructField(seller_name,DoubleType,true), StructField(mod_flag,DoubleType,true), StructField(orig_interest_rate,DoubleType,true), StructField(orig_upb,IntegerType,true), StructField(orig_loan_term,IntegerType,true), StructField(orig_ltv,DoubleType,true), StructField(orig_cltv,DoubleType,true), StructField(num_borrowers,DoubleType,true), StructField(dti,DoubleType,...commParamMap: scala.collection.immutable.Map[String,Any] = Map(min_child_weight -> 30, grow_policy -> depthwise, scale_pos_weight -> 2, num_workers -> 1, subsample -> 1, lambda -> 1, max_depth -> 10, num_round -> 100, missing -> 0.0, tree_method -> gpu_hist, eta -> 0.1, max_leaves -> 256, gamma -> 0.1, nthread -> 1)\n"
+     ]
+    }
+   ],
+   "source": [
+    "\n",
+    "// COMMAND ----------\n",
+    "\n",
+    "sc.listJars.foreach(println)\n",
+    "\n",
+    "// COMMAND ----------\n",
+    "\n",
+    "val spark = SparkSession.builder.appName(\"mortgage-gpu\").getOrCreate\n",
+    "\n",
+    "// COMMAND ----------\n",
+    "\n",
+    " val dataReader = new GpuDataReader(spark)\n",
+    "\n",
+    "// COMMAND ----------\n",
+    "\n",
+    "val labelColName = \"delinquency_12\"\n",
+    "\n",
+    "val schema = StructType(List(\n",
+    "    StructField(\"orig_channel\", DoubleType),\n",
+    "    StructField(\"first_home_buyer\", DoubleType),\n",
+    "    StructField(\"loan_purpose\", DoubleType),\n",
+    "    StructField(\"property_type\", DoubleType),\n",
+    "    StructField(\"occupancy_status\", DoubleType),\n",
+    "    StructField(\"property_state\", DoubleType),\n",
+    "    StructField(\"product_type\", DoubleType),\n",
+    "    StructField(\"relocation_mortgage_indicator\", DoubleType),\n",
+    "    StructField(\"seller_name\", DoubleType),\n",
+    "    StructField(\"mod_flag\", DoubleType),\n",
+    "    StructField(\"orig_interest_rate\", DoubleType),\n",
+    "    StructField(\"orig_upb\", IntegerType),\n",
+    "    StructField(\"orig_loan_term\", IntegerType),\n",
+    "    StructField(\"orig_ltv\", DoubleType),\n",
+    "    StructField(\"orig_cltv\", DoubleType),\n",
+    "    StructField(\"num_borrowers\", DoubleType),\n",
+    "    StructField(\"dti\", DoubleType),\n",
+    "    StructField(\"borrower_credit_score\", DoubleType),\n",
+    "    StructField(\"num_units\", IntegerType),\n",
+    "    StructField(\"zip\", IntegerType),\n",
+    "    StructField(\"mortgage_insurance_percent\", DoubleType),\n",
+    "    StructField(\"current_loan_delinquency_status\", IntegerType),\n",
+    "    StructField(\"current_actual_upb\", DoubleType),\n",
+    "    StructField(\"interest_rate\", DoubleType),\n",
+    "    StructField(\"loan_age\", DoubleType),\n",
+    "    StructField(\"msa\", DoubleType),\n",
+    "    StructField(\"non_interest_bearing_upb\", DoubleType),\n",
+    "    StructField(labelColName, IntegerType)))\n",
+    "\n",
+    " val commParamMap = Map(\n",
+    "    \"eta\" -> 0.1,\n",
+    "    \"gamma\" -> 0.1,\n",
+    "    \"missing\" -> 0.0,\n",
+    "    \"max_depth\" -> 10,\n",
+    "    \"max_leaves\" -> 256,\n",
+    "    \"grow_policy\" -> \"depthwise\",\n",
+    "    \"min_child_weight\" -> 30,\n",
+    "    \"lambda\" -> 1,\n",
+    "    \"scale_pos_weight\" -> 2,\n",
+    "    \"subsample\" -> 1,\n",
+    "    \"nthread\" -> 1,\n",
+    "    \"num_round\" -> 100,\n",
+    "    \"num_workers\" -> 1,\n",
+    "    \"tree_method\" -> \"gpu_hist\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "FloatProgress(value=0.0, bar_style='info', description='Progress:', layout=Layout(height='25px', width='50%'),…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "trainSet: ml.dmlc.xgboost4j.scala.spark.rapids.GpuDataset = ml.dmlc.xgboost4j.scala.spark.rapids.GpuDataset@2fff8496\n",
+      "evalSet: ml.dmlc.xgboost4j.scala.spark.rapids.GpuDataset = ml.dmlc.xgboost4j.scala.spark.rapids.GpuDataset@798ad87f\n",
+      "featureNames: Seq[String] = List(orig_channel, first_home_buyer, loan_purpose, property_type, occupancy_status, property_state, product_type, relocation_mortgage_indicator, seller_name, mod_flag, orig_interest_rate, orig_upb, orig_loan_term, orig_ltv, orig_cltv, num_borrowers, dti, borrower_credit_score, num_units, zip, mortgage_insurance_percent, current_loan_delinquency_status, current_actual_upb, interest_rate, loan_age, msa, non_interest_bearing_upb)\n"
+     ]
+    }
+   ],
+   "source": [
+    "// COMMAND ----------\n",
+    "\n",
+    "var (trainSet, evalSet) = {\n",
+    "  dataReader.option(\"header\", true).schema(schema)\n",
+    "  (dataReader.csv(trainPath), dataReader.csv(evalPath))}\n",
+    "\n",
+    "val featureNames = schema.filter(_.name != labelColName).map(_.name)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "FloatProgress(value=0.0, bar_style='info', description='Progress:', layout=Layout(height='25px', width='50%'),…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "defined object Benchmark\n"
+     ]
+    }
+   ],
+   "source": [
+    "// COMMAND ----------\n",
+    "\n",
+    "\n",
+    "object Benchmark {\n",
+    "  def time[R](phase: String)(block: => R): (R, Float) = {\n",
+    "    val t0 = System.currentTimeMillis\n",
+    "    val result = block // call-by-name\n",
+    "    val t1 = System.currentTimeMillis\n",
+    "    println(\"==> Benchmark: Elapsed time for [\" + phase + \"]: \" + ((t1 - t0).toFloat / 1000) + \"s\")\n",
+    "    (result, (t1 - t0).toFloat / 1000)\n",
+    "  }\n",
+    "}\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "FloatProgress(value=0.0, bar_style='info', description='Progress:', layout=Layout(height='25px', width='50%'),…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "modelPath: String = /tmp/model\n",
+      "xgbClassifier: ml.dmlc.xgboost4j.scala.spark.XGBoostClassifier = xgbc_6c4ce4a690f8\n",
+      "\n",
+      "------ Training ------\n",
+      "==> Benchmark: Elapsed time for [train]: 17.737s\n",
+      "model: ml.dmlc.xgboost4j.scala.spark.XGBoostClassificationModel = xgbc_6c4ce4a690f8\n",
+      "xgbClassificationModel: ml.dmlc.xgboost4j.scala.spark.XGBoostClassificationModel = xgbc_6c4ce4a690f8\n"
+     ]
+    }
+   ],
+   "source": [
+    "// COMMAND ----------\n",
+    "\n",
+    "val modelPath = \"/tmp/model\"\n",
+    "val xgbClassifier = new XGBoostClassifier(commParamMap).setLabelCol(labelColName).setFeaturesCols(featureNames)\n",
+    "println(\"\\n------ Training ------\")\n",
+    "\n",
+    "val (model, _) = Benchmark.time(\"train\") {\n",
+    "        xgbClassifier.fit(trainSet)\n",
+    "}\n",
+    "// Save model if modelPath exists\n",
+    "model.write.overwrite().save(modelPath)\n",
+    "val xgbClassificationModel = model\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "FloatProgress(value=0.0, bar_style='info', description='Progress:', layout=Layout(height='25px', width='50%'),…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "------ Transforming ------\n",
+      "==> Benchmark: Elapsed time for [transform]: 0.48s\n",
+      "results: org.apache.spark.sql.DataFrame = [orig_channel: float, first_home_buyer: float ... 29 more fields]\n"
+     ]
+    }
+   ],
+   "source": [
+    "// COMMAND ----------\n",
+    "\n",
+    "println(\"\\n------ Transforming ------\")\n",
+    "val (results, _) = Benchmark.time(\"transform\") {\n",
+    "  xgbClassificationModel.transform(evalSet)\n",
+    "}\n",
+    "// results.show(10)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "FloatProgress(value=0.0, bar_style='info', description='Progress:', layout=Layout(height='25px', width='50%'),…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "------Accuracy of Evaluation------\n",
+      "evaluator: org.apache.spark.ml.evaluation.MulticlassClassificationEvaluator = mcEval_60310ef193bc\n",
+      "accuracy: Double = 0.9875245818304412\n",
+      "0.9875245818304412\n"
+     ]
+    }
+   ],
+   "source": [
+    "// COMMAND ----------\n",
+    "\n",
+    "println(\"\\n------Accuracy of Evaluation------\")\n",
+    "val evaluator = new MulticlassClassificationEvaluator().setLabelCol(labelColName)\n",
+    "val accuracy = evaluator.evaluate(results)\n",
+    "println(accuracy)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Spark",
+   "language": "",
+   "name": "sparkkernel"
+  },
+  "language_info": {
+   "codemirror_mode": "text/x-scala",
+   "mimetype": "text/x-scala",
+   "name": "scala",
+   "pygments_lexer": "scala"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/nvidia-docker-compose.yml
+++ b/nvidia-docker-compose.yml
@@ -1,0 +1,25 @@
+version: "2.3"
+services:
+  spark:
+    image: jupyter/sparkmagic-livy-gpu
+    runtime: nvidia
+    environment:
+      - "NVIDIA_VISIBLE_DEVICES=0"
+    build:
+      context: .
+      dockerfile: Dockerfile.sparkgpu
+    hostname: spark
+    ports:
+      - "8998:8998"
+  jupyter:
+    image: jupyter/sparkmagic
+    runtime: nvidia
+    build:
+      context: .
+      dockerfile: Dockerfile.jupyter
+      args:
+        dev_mode: "false"
+    links:
+      - spark
+    ports:
+      - "8888:8888"


### PR DESCRIPTION
RAPIDS.ai provides a great speedup of XGBoost and in future to many other spark features through NVIDIA GPU. This pull request includes example applications that demonstrate the RAPIDS.ai GPU-accelerated XGBoost-Spark project as well as NVIDIA Docker enabled docker-compose setup. I hope sparkmagic could accept this commit so that more people can test out Spark on GPU in a convenient local setup. 