### PR TITLE
PySpark kerne uses python3 lexer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug fixes
 
 * Enabled heartbeat by default, so long-running tasks don't time out. Thanks to John Pugliesi for the bug report.
+* The PySpark kernel uses Python 3 lexer, instead of Python 2. Python 2 support is going away in the near future.
 
 ## 0.13.1
 

--- a/sparkmagic/sparkmagic/kernels/pysparkkernel/pysparkkernel.py
+++ b/sparkmagic/sparkmagic/kernels/pysparkkernel/pysparkkernel.py
@@ -13,8 +13,8 @@ class PySparkKernel(SparkKernelBase):
         language_info = {
             'name': 'pyspark',
             'mimetype': 'text/x-python',
-            'codemirror_mode': {'name': 'python', 'version': 2},
-            'pygments_lexer': 'python2'
+            'codemirror_mode': {'name': 'python', 'version': 3},
+            'pygments_lexer': 'python3'
         }
 
         session_language = LANG_PYTHON

--- a/sparkmagic/sparkmagic/tests/test_kernels.py
+++ b/sparkmagic/sparkmagic/tests/test_kernels.py
@@ -32,8 +32,8 @@ def test_pyspark_kernel_configs():
     assert kernel.language_info == {
         'name': 'pyspark',
         'mimetype': 'text/x-python',
-        'codemirror_mode': {'name': 'python', 'version': 2},
-        'pygments_lexer': 'python2'
+        'codemirror_mode': {'name': 'python', 'version': 3},
+        'pygments_lexer': 'python3'
     }
 
 


### PR DESCRIPTION
Fixes #557.