### PR TITLE
Support Client Side Cert for Livy

### DIFF
--- a/sparkmagic/sparkmagic/kernels/kernelmagics.py
+++ b/sparkmagic/sparkmagic/kernels/kernelmagics.py
@@ -18,7 +18,7 @@ from sparkmagic.utils.utils import parse_argstring_or_throw, get_coerce_value
 from sparkmagic.utils.sparkevents import SparkEvents
 from sparkmagic.utils.constants import LANGS_SUPPORTED
 from sparkmagic.livyclientlib.command import Command
-from sparkmagic.livyclientlib.endpoint import Endpoint
+from sparkmagic.livyclientlib.endpoint import Endpoint, SSLInfo
 from sparkmagic.magics.sparkmagicsbase import SparkMagicBase
 from sparkmagic.livyclientlib.exceptions import handle_expected_exceptions, wrap_unexpected_exceptions, \
     BadUserDataException
@@ -389,7 +389,12 @@ class KernelMagics(SparkMagicBase):
     def refresh_configuration(self):
         credentials = getattr(conf, 'base64_kernel_' + self.language + '_credentials')()
         (username, password, auth, url) = (credentials['username'], credentials['password'], credentials['auth'], credentials['url'])
-        self.endpoint = Endpoint(url, auth, username, password)
+        (ssl_client_cert, ssl_client_key, ssl_verify) = (credentials.get('ssl_client_cert'), credentials.get('ssl_client_key'), credentials.get('ssl_verify'),)
+        if ssl_client_cert is None:
+            ssl_info = None
+        else:
+            ssl_info = SSLInfo(ssl_client_cert, ssl_client_key, ssl_verify)
+        self.endpoint = Endpoint(url, auth, username, password, ssl_info=ssl_info)
 
     def get_session_settings(self, line, force):
         line = line.strip()

--- a/sparkmagic/sparkmagic/livyclientlib/endpoint.py
+++ b/sparkmagic/sparkmagic/livyclientlib/endpoint.py
@@ -3,7 +3,7 @@ from sparkmagic.utils.constants import AUTHS_SUPPORTED
 
 
 class Endpoint(object):
-    def __init__(self, url, auth, username="", password="", implicitly_added=False):
+    def __init__(self, url, auth, username="", password="", implicitly_added=False, ssl_info=None):
         if not url:
             raise BadUserDataException(u"URL must not be empty")
         if auth not in AUTHS_SUPPORTED:
@@ -13,6 +13,7 @@ class Endpoint(object):
         self.username = username
         self.password = password
         self.auth = auth
+        self.ssl_info = ssl_info
         # implicitly_added is set to True only if the endpoint wasn't configured manually by the user through
         # a widget, but was instead implicitly defined as an endpoint to a wrapper kernel in the configuration
         # JSON file.
@@ -21,13 +22,37 @@ class Endpoint(object):
     def __eq__(self, other):
         if type(other) is not Endpoint:
             return False
-        return self.url == other.url and self.username == other.username and self.password == other.password and self.auth == other.auth
+        return self.url == other.url and self.username == other.username and self.password == other.password and self.auth == other.auth and self.ssl_info == other.ssl_info
 
     def __hash__(self):
-        return hash((self.url, self.username, self.password, self.auth))
+        return hash((self.url, self.username, self.password, self.auth, self.ssl_info))
 
     def __ne__(self, other):
         return not self == other
 
     def __str__(self):
         return u"Endpoint({})".format(self.url)
+
+class SSLInfo(object):
+    def __init__(self, client_cert, client_key, ssl_verify):
+        self.client_cert = client_cert
+        self.client_key = client_key
+        self.ssl_verify = ssl_verify
+    
+    @property
+    def cert(self):
+        return (self.client_cert, self.client_key, )
+
+    def __eq__(self, other):
+        if type(other) is not SSLInfo:
+            return False
+        return self.client_cert == other.client_cert and self.client_key == other.client_key and self.ssl_verify == other.ssl_verify
+
+    def __hash__(self):
+        return hash((self.client_cert, self.client_key, self.ssl_verify))
+
+    def __ne__(self, other):
+        return not self == other
+
+    def __str__(self):
+        return u"SSLInfo(client_cert={}, client_key={}, ssl_verify={})".format(self.client_cert, self.client_key, self.ssl_verify)

--- a/sparkmagic/sparkmagic/livyclientlib/reliablehttpclient.py
+++ b/sparkmagic/sparkmagic/livyclientlib/reliablehttpclient.py
@@ -61,15 +61,37 @@ class ReliableHttpClient(object):
             try:
                 if self._endpoint.auth == constants.NO_AUTH:
                     if data is None:
-                        r = function(url, headers=self._headers, verify=self.verify_ssl)
+                        if self._endpoint.ssl_info is None:
+                            r = function(url, headers=self._headers, verify=self.verify_ssl)
+                        else:
+                            r = function(url, headers=self._headers, 
+                                        verify=self._endpoint.ssl_info.ssl_verify, 
+                                        cert=self._endpoint.ssl_info.cert)
                     else:
-                        r = function(url, headers=self._headers, data=json.dumps(data), verify=self.verify_ssl)
+                        if self._endpoint.ssl_info is None:
+                            r = function(url, headers=self._headers, data=json.dumps(data), verify=self.verify_ssl)
+                        else:
+                            r = function(url, headers=self._headers, data=json.dumps(data), 
+                                        verify=self._endpoint.ssl_info.ssl_verify, 
+                                        cert=self._endpoint.ssl_info.cert)
                 else:
                     if data is None:
-                        r = function(url, headers=self._headers, auth=self._auth, verify=self.verify_ssl)
+                        if self._endpoint.ssl_info is None:
+                            r = function(url, headers=self._headers, auth=self._auth, verify=self.verify_ssl)
+                        else:
+                            r = function(url, headers=self._headers, auth=self._auth, 
+                                        verify=self._endpoint.ssl_info.ssl_verify, 
+                                        cert=self._endpoint.ssl_info.cert)
                     else:
-                        r = function(url, headers=self._headers, auth=self._auth,
-                                     data=json.dumps(data), verify=self.verify_ssl)
+                        if self._endpoint.ssl_info is None:
+                            r = function(url, headers=self._headers, auth=self._auth,
+                                        data=json.dumps(data), verify=self.verify_ssl)
+                        else:
+                            r = function(url, headers=self._headers, auth=self._auth,
+                                        data=json.dumps(data), 
+                                        verify=self._endpoint.ssl_info.ssl_verify, 
+                                        cert=self._endpoint.ssl_info.cert)
+
             except requests.exceptions.RequestException as e:
                 error = True
                 r = None

--- a/sparkmagic/sparkmagic/utils/configuration.py
+++ b/sparkmagic/sparkmagic/utils/configuration.py
@@ -255,7 +255,9 @@ def _credentials_override(f):
     If 'base64_password' is not set, it will fallback to 'password' in config.
     """
     credentials = f()
-    base64_decoded_credentials = {k: credentials.get(k) for k in ('username', 'password', 'url', 'auth')}
+    base64_decoded_credentials = {k: credentials.get(k) for k in (
+        'username', 'password', 'url', 'auth', 'ssl_client_cert', 'ssl_client_key', 'ssl_verify'
+    )}
     base64_password = credentials.get('base64_password')
     if base64_password is not None:
         try:


### PR DESCRIPTION
Our livy is deployed in such a way:
It has a whitelist of CNs and require client to present a client side certificate, only client cert whose CN match the whitelist will be allow to access livy.

I am adding 3 configs to kernel_{language}_credentials:
ssl_client_cert, ssl_client_key and ssl_verify

I have the following config:
```
{
  "kernel_python_credentials" : {
    "username": "my_username",
    "password": "mu_password",
    "url": "https://my_livy_url/",
    "auth": "Basic_Access",
    "ssl_client_cert": "/root/.sparkmagic/sso_client.crt",
    "ssl_client_key":  "/root/.sparkmagic/sso_client.key",
    "ssl_verify":      "/root/.sparkmagic/CombinedDigicertCA.cer"
  },
...
```
Tested it and the change worked for me.
