### PR TITLE
Use JSON true instead of Python True in README Papermill Section

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,8 @@ If you want Papermill rendering to stop on a Spark error, edit the `~/.sparkmagi
 
 ```json
 {
-    "spark_statement_errors_are_fatal": True,
-    "shutdown_session_on_spark_statement_errors": True
+    "spark_statement_errors_are_fatal": true,
+    "shutdown_session_on_spark_statement_errors": true
 }
 ```
 


### PR DESCRIPTION
Please correct me if I am wrong, but the README says to use Python's `True` in a JSON file, which is invalid, so I updated it to use the valid JSON `true`.