### PR TITLE
SQLQuery default print error instead of throwing error stack

### DIFF
--- a/sparkmagic/sparkmagic/livyclientlib/sqlquery.py
+++ b/sparkmagic/sparkmagic/livyclientlib/sqlquery.py
@@ -5,7 +5,7 @@ import sparkmagic.utils.configuration as conf
 import sparkmagic.utils.constants as constants
 from sparkmagic.utils.sparkevents import SparkEvents
 from .command import Command
-from .exceptions import DataFrameParseException, BadUserDataException
+from .exceptions import DataFrameParseException, BadUserDataException, SparkStatementException
 
 
 class SQLQuery(ObjectWithGuid):
@@ -49,13 +49,19 @@ class SQLQuery(ObjectWithGuid):
         self._spark_events.emit_sql_execution_start_event(session.guid, session.kind, session.id, self.guid,
                                                           self.samplemethod, self.maxrows, self.samplefraction)
         command_guid = ''
+        result = None
         try:
             command = self.to_command(session.kind, session.sql_context_variable_name)
             command_guid = command.guid
             (success, records_text, mimetype) = command.execute(session)
             if not success:
-                raise BadUserDataException(records_text)
-            result = records_to_dataframe(records_text, session.kind, self._coerce)
+                if conf.spark_statement_errors_are_fatal():
+                    if conf.shutdown_session_on_spark_statement_errors():
+                        self.spark_controller.cleanup()
+                    raise SparkStatementException(records_text)
+                self.ipython_display.send_error(records_text)
+            else:
+                result = records_to_dataframe(records_text, session.kind, self._coerce)
         except Exception as e:
             self._spark_events.emit_sql_execution_end_event(session.guid, session.kind, session.id, self.guid,
                                                             command_guid, False, e.__class__.__name__, str(e))


### PR DESCRIPTION
The default result of the Spark failure is the error message, no exception throwing until user sets spark_statement_errors_are_fatal. The result of running SQL needs this, too. For most users, the error message is sufficient.