### PR TITLE
New conf option 'cleanup_all_sessions_on_exit'

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,35 @@ If you want Papermill rendering to stop on a Spark error, edit the `~/.sparkmagi
 }
 ```
 
+If you want any registered livy sessions to be cleaned up on exit regardless of whether the process exits gracefully or not, you can set:
+ 
+```json
+{
+    "cleanup_all_sessions_on_exit": true,
+    "all_errors_are_fatal": true
+}
+```
+
+### Conf overrides in code
+
+In addition to the conf at `~/.sparkmagic/config.json`, sparkmagic conf can be overridden programmatically in a notebook.
+
+For example:
+```python
+import sparkmagic.utils.configuration as conf
+conf.override('cleanup_all_sessions_on_exit', True)
+```
+
+Same thing, but referencing the conf member: 
+
+```python
+conf.override(conf.cleanup_all_sessions_on_exit.__name__, True)
+```
+
+NOTE: override for `cleanup_all_sessions_on_exit` must be set _before_ initializing sparkmagic ie. before this:
+
+    %load_ext sparkmagic.magics
+
 ## Docker
 
 The included `docker-compose.yml` file will let you spin up a full

--- a/sparkmagic/sparkmagic/livyclientlib/sessionmanager.py
+++ b/sparkmagic/sparkmagic/livyclientlib/sessionmanager.py
@@ -84,7 +84,8 @@ class SessionManager(object):
             def cleanup_spark_sessions():
                 try:
                     self.clean_up_all()
-                except Exception:
+                except Exception as e:
+                    self.logger.error(u"Error cleaning up sessions on exit: {}".format(e))
                     pass
             atexit.register(cleanup_spark_sessions)
             self.ipython_display.writeln(u"Cleaning up livy sessions on exit is enabled")

--- a/sparkmagic/sparkmagic/livyclientlib/sparkcontroller.py
+++ b/sparkmagic/sparkmagic/livyclientlib/sparkcontroller.py
@@ -13,7 +13,7 @@ class SparkController(object):
     def __init__(self, ipython_display):
         self.logger = SparkLog(u"SparkController")
         self.ipython_display = ipython_display
-        self.session_manager = SessionManager()
+        self.session_manager = SessionManager(ipython_display)
 
     def get_app_id(self, client_name=None):
         session_to_use = self.get_session_by_name_or_default(client_name)

--- a/sparkmagic/sparkmagic/utils/configuration.py
+++ b/sparkmagic/sparkmagic/utils/configuration.py
@@ -248,6 +248,12 @@ def all_errors_are_fatal():
     return False
 
 
+@_with_override
+def cleanup_all_sessions_on_exit():
+    # If set to true, all registered livy sessions will be attempted to be cleaned up before exiting
+    return False
+
+
 def _credentials_override(f):
     """Provides special handling for credentials. It still calls _override().
     If 'base64_password' in config is set, it will base64 decode it and returned in return value's 'password' field.


### PR DESCRIPTION
New conf option `cleanup_all_sessions_on_exit` (boolean)
- Default: `False`

The existing `shutdown_session_on_spark_statement_errors` conf allows ensuring that livy sessions are shut down only in case of a Spark error.

This new option helps ensuring that livy sessions are not left behind also when there's a non-Spark error, or if the notebook exits gracefully but user forgot to do cleanup.

----

Also added docs to README on how to set conf overrides programmatically.

----

Tested this manually with a minimal Notebook

<img width="1029" alt="Näyttökuva 2019-11-29 kello 0 12 38" src="https://user-images.githubusercontent.com/4446608/69833526-06866f00-123d-11ea-8697-21b2e781c107.png">

I also tested starting a session with `%spark add -s smoke -l python -u http://my-host:8998` and shutting down the notebook caused Livy session to be stopped, as desired.