### PR TITLE
Executing cell in specific language

### DIFF
--- a/sparkmagic/sparkmagic/kernels/kernelmagics.py
+++ b/sparkmagic/sparkmagic/kernels/kernelmagics.py
@@ -248,7 +248,6 @@ class KernelMagics(SparkMagicBase):
     @needs_local_scope
     @argument("-o", "--output", type=str, default=None, help="If present, indicated variable will be stored in variable"
                                                              "of this name in user's local context.")
-    @argument("-s", "--session", type=str, default=None, help="The name of the Livy session to use.")
     @argument("-l", "--language", type=str, default=None,
               help="Language for command; one of {}".format(', '.join([LANG_PYTHON, LANG_SCALA, LANG_R])))
     @argument("-m", "--samplemethod", type=str, default=None, help="Sample method for dataframe: either take or sample")
@@ -265,7 +264,7 @@ class KernelMagics(SparkMagicBase):
 
             coerce = get_coerce_value(args.coerce)
 
-            self.execute_spark(cell, args.language, args.output, args.samplemethod, args.maxrows, args.samplefraction, args.session, coerce)
+            self.execute_spark(cell, args.language, args.output, args.samplemethod, args.maxrows, args.samplefraction, None, coerce)
         else:
             return
 

--- a/sparkmagic/sparkmagic/kernels/kernelmagics.py
+++ b/sparkmagic/sparkmagic/kernels/kernelmagics.py
@@ -262,7 +262,7 @@ class KernelMagics(SparkMagicBase):
 
             coerce = get_coerce_value(args.coerce)
 
-            self.execute_spark(cell, args.output, args.samplemethod, args.maxrows, args.samplefraction, None, coerce)
+            self.execute_spark(cell, None, args.output, args.samplemethod, args.maxrows, args.samplefraction, None, coerce)
         else:
             return
 

--- a/sparkmagic/sparkmagic/kernels/kernelmagics.py
+++ b/sparkmagic/sparkmagic/kernels/kernelmagics.py
@@ -16,7 +16,7 @@ from sparkmagic.utils.configuration import get_livy_kind
 from sparkmagic.utils import constants
 from sparkmagic.utils.utils import parse_argstring_or_throw, get_coerce_value
 from sparkmagic.utils.sparkevents import SparkEvents
-from sparkmagic.utils.constants import LANGS_SUPPORTED
+from sparkmagic.utils.constants import LANGS_SUPPORTED, LANG_PYTHON, LANG_R, LANG_SCALA
 from sparkmagic.livyclientlib.command import Command
 from sparkmagic.livyclientlib.endpoint import Endpoint
 from sparkmagic.magics.sparkmagicsbase import SparkMagicBase
@@ -248,6 +248,8 @@ class KernelMagics(SparkMagicBase):
     @needs_local_scope
     @argument("-o", "--output", type=str, default=None, help="If present, indicated variable will be stored in variable"
                                                              "of this name in user's local context.")
+    @argument("-l", "--language", type=str, default=None,
+              help="Language for command; one of {}".format(', '.join([LANG_PYTHON, LANG_SCALA, LANG_R])))
     @argument("-m", "--samplemethod", type=str, default=None, help="Sample method for dataframe: either take or sample")
     @argument("-n", "--maxrows", type=int, default=None, help="Maximum number of rows that will be pulled back "
                                                                         "from the dataframe on the server for storing")
@@ -262,7 +264,7 @@ class KernelMagics(SparkMagicBase):
 
             coerce = get_coerce_value(args.coerce)
 
-            self.execute_spark(cell, None, args.output, args.samplemethod, args.maxrows, args.samplefraction, None, coerce)
+            self.execute_spark(cell, args.language, args.output, args.samplemethod, args.maxrows, args.samplefraction, None, coerce)
         else:
             return
 

--- a/sparkmagic/sparkmagic/kernels/kernelmagics.py
+++ b/sparkmagic/sparkmagic/kernels/kernelmagics.py
@@ -248,6 +248,7 @@ class KernelMagics(SparkMagicBase):
     @needs_local_scope
     @argument("-o", "--output", type=str, default=None, help="If present, indicated variable will be stored in variable"
                                                              "of this name in user's local context.")
+    @argument("-s", "--session", type=str, default=None, help="The name of the Livy session to use.")
     @argument("-l", "--language", type=str, default=None,
               help="Language for command; one of {}".format(', '.join([LANG_PYTHON, LANG_SCALA, LANG_R])))
     @argument("-m", "--samplemethod", type=str, default=None, help="Sample method for dataframe: either take or sample")
@@ -264,7 +265,7 @@ class KernelMagics(SparkMagicBase):
 
             coerce = get_coerce_value(args.coerce)
 
-            self.execute_spark(cell, args.language, args.output, args.samplemethod, args.maxrows, args.samplefraction, None, coerce)
+            self.execute_spark(cell, args.language, args.output, args.samplemethod, args.maxrows, args.samplefraction, args.session, coerce)
         else:
             return
 

--- a/sparkmagic/sparkmagic/magics/remotesparkmagics.py
+++ b/sparkmagic/sparkmagic/magics/remotesparkmagics.py
@@ -169,7 +169,7 @@ class RemoteSparkMagics(SparkMagicBase):
         elif len(subcommand) == 0:
             coerce = get_coerce_value(args.coerce)
             if args.context == CONTEXT_NAME_SPARK:
-                return self.execute_spark(cell, None, args.output, args.samplemethod,
+                return self.execute_spark(cell, args.language, args.output, args.samplemethod,
                                           args.maxrows, args.samplefraction, args.session, coerce)
             elif args.context == CONTEXT_NAME_SQL:
                 return self.execute_sqlquery(cell, args.samplemethod, args.maxrows, args.samplefraction,

--- a/sparkmagic/sparkmagic/magics/remotesparkmagics.py
+++ b/sparkmagic/sparkmagic/magics/remotesparkmagics.py
@@ -169,7 +169,7 @@ class RemoteSparkMagics(SparkMagicBase):
         elif len(subcommand) == 0:
             coerce = get_coerce_value(args.coerce)
             if args.context == CONTEXT_NAME_SPARK:
-                return self.execute_spark(cell, args.output, args.samplemethod,
+                return self.execute_spark(cell, None, args.output, args.samplemethod,
                                           args.maxrows, args.samplefraction, args.session, coerce)
             elif args.context == CONTEXT_NAME_SQL:
                 return self.execute_sqlquery(cell, args.samplemethod, args.maxrows, args.samplefraction,

--- a/sparkmagic/sparkmagic/magics/sparkmagicsbase.py
+++ b/sparkmagic/sparkmagic/magics/sparkmagicsbase.py
@@ -78,7 +78,7 @@ class SparkMagicBase(Magics):
                                        u' kernel'.format(input_variable_name, output_variable_name))
 
     def execute_spark(self, cell, language, output_var, samplemethod, maxrows, samplefraction, session_name, coerce):
-        (success, out, mimetype) = self.spark_controller.run_command(Command(cell, language), session_name)
+        (success, out, mimetype) = self.spark_controller.run_command(Command(cell, language=language), session_name)
         if not success:
             if conf.shutdown_session_on_spark_statement_errors():
                 self.spark_controller.cleanup()

--- a/sparkmagic/sparkmagic/magics/sparkmagicsbase.py
+++ b/sparkmagic/sparkmagic/magics/sparkmagicsbase.py
@@ -77,8 +77,8 @@ class SparkMagicBase(Magics):
             self.ipython_display.write(u'Successfully passed \'{}\' as \'{}\' to Spark'
                                        u' kernel'.format(input_variable_name, output_variable_name))
 
-    def execute_spark(self, cell, output_var, samplemethod, maxrows, samplefraction, session_name, coerce):
-        (success, out, mimetype) = self.spark_controller.run_command(Command(cell), session_name)
+    def execute_spark(self, cell, language, output_var, samplemethod, maxrows, samplefraction, session_name, coerce):
+        (success, out, mimetype) = self.spark_controller.run_command(Command(cell, language), session_name)
         if not success:
             if conf.shutdown_session_on_spark_statement_errors():
                 self.spark_controller.cleanup()

--- a/sparkmagic/sparkmagic/tests/test_command.py
+++ b/sparkmagic/sparkmagic/tests/test_command.py
@@ -42,7 +42,7 @@ def test_execute():
 
     result = command.execute(session)
 
-    http_client.post_statement.assert_called_with(0, {"code": command.code})
+    http_client.post_statement.assert_called_with(0, {"code": command.code, "kind": kind})
     http_client.get_statement.assert_called_with(0, 0)
     assert result[0]
     assert_equals(tls.TestLivySession.pi_result, result[1])
@@ -84,7 +84,7 @@ def test_execute_waiting():
 
     result = command.execute(session)
 
-    http_client.post_statement.assert_called_with(0, {"code": command.code})
+    http_client.post_statement.assert_called_with(0, {"code": command.code, "kind": kind})
     http_client.get_statement.assert_called_with(0, 0)
     assert result[0]
     assert_equals(tls.TestLivySession.pi_result, result[1])
@@ -111,7 +111,7 @@ def test_execute_null_ouput():
 
     result = command.execute(session)
 
-    http_client.post_statement.assert_called_with(0, {"code": command.code})
+    http_client.post_statement.assert_called_with(0, {"code": command.code, "kind": kind})
     http_client.get_statement.assert_called_with(0, 0)
     assert result[0]
     assert_equals(u"", result[1])

--- a/sparkmagic/sparkmagic/tests/test_kernel_magics.py
+++ b/sparkmagic/sparkmagic/tests/test_kernel_magics.py
@@ -595,7 +595,7 @@ def test_spark_sample_options():
     magic.execute_spark = MagicMock()
     ret = magic.spark(line, cell)
 
-    magic.execute_spark.assert_called_once_with(cell, "var_name", "sample", 142, 0.3, None, True)
+    magic.execute_spark.assert_called_once_with(cell, None, "var_name", "sample", 142, 0.3, None, True)
 
 
 @with_setup(_setup, _teardown)
@@ -605,7 +605,7 @@ def test_spark_false_coerce():
     magic.execute_spark = MagicMock()
     ret = magic.spark(line, cell)
 
-    magic.execute_spark.assert_called_once_with(cell, "var_name", "sample", 142, 0.3, None, False)
+    magic.execute_spark.assert_called_once_with(cell, None, "var_name", "sample", 142, 0.3, None, False)
 
 
 @with_setup(_setup, _teardown)

--- a/sparkmagic/sparkmagic/tests/test_remotesparkmagics.py
+++ b/sparkmagic/sparkmagic/tests/test_remotesparkmagics.py
@@ -284,7 +284,7 @@ def test_run_spark_command_parses():
     result = magic.spark(line, cell)
 
     magic.execute_spark.assert_called_once_with("cell code",
-                                                None, "sample", None, None, "sessions_name", None)
+                                                None, None, "sample", None, None, "sessions_name", None)
 
 
 @with_setup(_setup, _teardown)
@@ -305,7 +305,7 @@ def test_run_spark_command_parses_with_coerce():
     result = magic.spark(line, cell)
 
     magic.execute_spark.assert_called_once_with("cell code",
-                                                None, "sample", None, None, "sessions_name", True)
+                                                None, None, "sample", None, None, "sessions_name", True)
 
 
 @with_setup(_setup, _teardown)
@@ -326,7 +326,7 @@ def test_run_spark_command_parses_with_coerce_false():
     result = magic.spark(line, cell)
 
     magic.execute_spark.assert_called_once_with("cell code",
-                                                None, "sample", None, None, "sessions_name", False)
+                                                None, None, "sample", None, None, "sessions_name", False)
 
 
 @with_setup(_setup, _teardown)
@@ -367,7 +367,7 @@ def test_run_spark_with_store_command_parses():
 
     result = magic.spark(line, cell)
     magic.execute_spark.assert_called_once_with("cell code",
-                                                "var_name", "sample", None, None, "sessions_name", None)
+                                                None, "var_name", "sample", None, None, "sessions_name", None)
     
 
 @with_setup(_setup, _teardown)

--- a/sparkmagic/sparkmagic/tests/test_sparkmagicsbase.py
+++ b/sparkmagic/sparkmagic/tests/test_sparkmagicsbase.py
@@ -229,12 +229,12 @@ def test_spark_execution_without_output_var():
     output_var = None
     
     magic.spark_controller.run_command.return_value = (True,'out',MIMETYPE_TEXT_PLAIN)
-    magic.execute_spark("", output_var, None, None, None, session, None)
+    magic.execute_spark("", None, output_var, None, None, None, session, None)
     magic.ipython_display.write.assert_called_once_with('out')
     assert not magic.spark_controller._spark_store_command.called
 
     magic.spark_controller.run_command.return_value = (False,'out',MIMETYPE_TEXT_PLAIN)
-    assert_raises(SparkStatementException, magic.execute_spark,"", output_var, None, None, None, session, True)
+    assert_raises(SparkStatementException, magic.execute_spark,"", None, output_var, None, None, None, session, True)
     assert not magic.spark_controller._spark_store_command.called
 
 @with_setup(_setup, _teardown)
@@ -245,14 +245,14 @@ def test_spark_execution_with_output_var():
     df = 'df'
 
     magic.spark_controller.run_command.side_effect = [(True,'out',MIMETYPE_TEXT_PLAIN), df]
-    magic.execute_spark("", output_var, None, None, None, session, True)
+    magic.execute_spark("", None, output_var, None, None, None, session, True)
     magic.ipython_display.write.assert_called_once_with('out')
     magic._spark_store_command.assert_called_once_with(output_var, None, None, None, True)
     assert shell.user_ns[output_var] == df
 
     magic.spark_controller.run_command.side_effect = None
     magic.spark_controller.run_command.return_value = (False,'out',MIMETYPE_TEXT_PLAIN)
-    assert_raises(SparkStatementException, magic.execute_spark,"", output_var, None, None, None, session, True)
+    assert_raises(SparkStatementException, magic.execute_spark,"", None, output_var, None, None, None, session, True)
 
 
 @with_setup(_setup, _teardown)
@@ -264,7 +264,7 @@ def test_spark_exception_with_output_var():
     df = 'df'
 
     magic.spark_controller.run_command.side_effect = [(True,'out',MIMETYPE_TEXT_PLAIN), exception]
-    assert_raises(BadUserDataException, magic.execute_spark,"", output_var, None, None, None, session, True)
+    assert_raises(BadUserDataException, magic.execute_spark,"", None, output_var, None, None, None, session, True)
     magic.ipython_display.write.assert_called_once_with('out')
     magic._spark_store_command.assert_called_once_with(output_var, None, None, None, True)
     assert shell.user_ns == {}
@@ -276,7 +276,7 @@ def test_spark_statement_exception():
     exception = BadUserDataException("Ka-boom!")
 
     magic.spark_controller.run_command.side_effect = [(False, 'out', "text/plain"), exception]
-    assert_raises(SparkStatementException, magic.execute_spark,"", None, None, None, None, session, True)
+    assert_raises(SparkStatementException, magic.execute_spark,"", None, None, None, None, None, session, True)
     magic.spark_controller.cleanup.assert_not_called()
 
 @with_setup(_setup, _teardown)
@@ -290,5 +290,5 @@ def test_spark_statement_exception_shutdowns_livy_session():
     exception = BadUserDataException("Ka-boom!")
 
     magic.spark_controller.run_command.side_effect = [(False, 'out', "text/plain"), exception]
-    assert_raises(SparkStatementException, magic.execute_spark,"", None, None, None, None, session, True)
+    assert_raises(SparkStatementException, magic.execute_spark,"", None, None, None, None, None, session, True)
     magic.spark_controller.cleanup.assert_called_once()


### PR DESCRIPTION
As mentioned in #509, #507, and #450, it is now possible in Livy to execute Spark code in Python, Scala, R for any Livy session. That would be great if you want to write polyglot notebooks and, as it turns out, it is quite a low-hanging fruit.

A few notes:

- It uses an existing command line argument: `%%spark run -l [language]` for IPython kernels, or `%%spark -l [language]` for Sparkmagic kernels.
- All unit tests pass. I did not write any additional tests, though.
- I did not modify the documentation — or the example notebooks.

Here is a (slightly doctored for the sake of simplicity) [working example](https://gist.github.com/lemeb/cc7468d5537758918d18d8b60b3aaf4c). The json file is from [here](https://github.com/apache/spark/blob/master/examples/src/main/resources/people.json).

That was simple enough; now, for further, hard questions:
- Can you get proper syntax highlighting for each cell?
- How could we refactor the code such as you could have one Scala notebook and one Pyspark notebook working on the same session? (That is definitely doable.)

Anyway, thanks for all your hard work! Peace ✌️ 