### PR TITLE
Feat/kerberos auth customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,28 @@ Kerberos support is implemented via the [requests-kerberos](https://github.com/r
 
 Currently, sparkmagic does not support passing a kerberos principal/token, but we welcome pull requests.
 
+### Kerberos Configuration
+
+By default the `HTTPKerberosAuth` constructor provided by the `requests-kerberos` package will use the following configuration
+```python
+HTTPKerberosAuth(mutual_authentication=REQUIRED)
+```
+but this will not be right configuration for every context, so it is able to pass custom arguments for this constructor using the following configuration on the `~/.sparkmagic/config.json`
+```json
+{
+    "kerberos_auth_configuration": {
+        "mutual_authentication": 1,
+        "service": "HTTP",
+        "delegate": false,
+        "force_preemptive": false,
+        "principal": "principal",
+        "hostname_override": "hostname_override",
+        "sanitize_mutual_error_response": true,
+        "send_cbt": true
+    }
+}
+```
+
 ## Papermill
 
 If you want Papermill rendering to stop on a Spark error, edit the `~/.sparkmagic/config.json` with the following settings:

--- a/README.md
+++ b/README.md
@@ -77,8 +77,6 @@ Sparkmagic supports:
 
 Kerberos support is implemented via the [requests-kerberos](https://github.com/requests/requests-kerberos) package. Sparkmagic expects a kerberos ticket to be available in the system. Requests-kerberos will pick up the kerberos ticket from a cache file. For the ticket to be available, the user needs to have run [kinit](https://web.mit.edu/kerberos/krb5-1.12/doc/user/user_commands/kinit.html) to create the kerberos ticket.
 
-Currently, sparkmagic does not support passing a kerberos principal/token, but we welcome pull requests.
-
 ### Kerberos Configuration
 
 By default the `HTTPKerberosAuth` constructor provided by the `requests-kerberos` package will use the following configuration

--- a/sparkmagic/sparkmagic/livyclientlib/reliablehttpclient.py
+++ b/sparkmagic/sparkmagic/livyclientlib/reliablehttpclient.py
@@ -3,7 +3,7 @@
 import json
 from time import sleep
 import requests
-from requests_kerberos import HTTPKerberosAuth, REQUIRED
+from requests_kerberos import HTTPKerberosAuth
 
 import sparkmagic.utils.configuration as conf
 from sparkmagic.utils.sparklogger import SparkLog
@@ -21,7 +21,7 @@ class ReliableHttpClient(object):
         self._headers = headers
         self._retry_policy = retry_policy
         if self._endpoint.auth == constants.AUTH_KERBEROS:
-            self._auth = HTTPKerberosAuth(mutual_authentication=REQUIRED)
+            self._auth = HTTPKerberosAuth(**conf.kerberos_auth_configuration())
         elif self._endpoint.auth == constants.AUTH_BASIC:
             self._auth = (self._endpoint.username, self._endpoint.password)
         elif self._endpoint.auth != constants.NO_AUTH:

--- a/sparkmagic/sparkmagic/livyclientlib/reliablehttpclient.py
+++ b/sparkmagic/sparkmagic/livyclientlib/reliablehttpclient.py
@@ -26,6 +26,7 @@ class ReliableHttpClient(object):
             self._auth = (self._endpoint.username, self._endpoint.password)
         elif self._endpoint.auth != constants.NO_AUTH:
             raise BadUserConfigurationException(u"Unsupported auth %s" %self._endpoint.auth)
+        self._session = requests.Session()
 
         self.logger = SparkLog(u"ReliableHttpClient")
 
@@ -43,15 +44,15 @@ class ReliableHttpClient(object):
 
     def get(self, relative_url, accepted_status_codes):
         """Sends a get request. Returns a response."""
-        return self._send_request(relative_url, accepted_status_codes, requests.get)
+        return self._send_request(relative_url, accepted_status_codes, self._session.get)
 
     def post(self, relative_url, accepted_status_codes, data):
         """Sends a post request. Returns a response."""
-        return self._send_request(relative_url, accepted_status_codes, requests.post, data)
+        return self._send_request(relative_url, accepted_status_codes, self._session.post, data)
 
     def delete(self, relative_url, accepted_status_codes):
         """Sends a delete request. Returns a response."""
-        return self._send_request(relative_url, accepted_status_codes, requests.delete)
+        return self._send_request(relative_url, accepted_status_codes, self._session.delete)
 
     def _send_request(self, relative_url, accepted_status_codes, function, data=None):
         return self._send_request_helper(self.compose_url(relative_url), accepted_status_codes, function, data, 0)

--- a/sparkmagic/sparkmagic/livyclientlib/sparkcontroller.py
+++ b/sparkmagic/sparkmagic/livyclientlib/sparkcontroller.py
@@ -10,6 +10,10 @@ from sparkmagic.utils.constants import MAGICS_LOGGER_NAME
 
 
 class SparkController(object):
+    # this is to reuse the already created http clients
+    # since the reliablehttpclient uses requests session
+    _http_clients = {}
+
     def __init__(self, ipython_display):
         self.logger = SparkLog(u"SparkController")
         self.ipython_display = ipython_display
@@ -110,6 +114,7 @@ class SparkController(object):
         return LivySession(http_client, properties, ipython_display,
                            session_id, heartbeat_timeout=conf.livy_server_heartbeat_timeout_seconds())
 
-    @staticmethod
-    def _http_client(endpoint):
-        return LivyReliableHttpClient.from_endpoint(endpoint)
+    def _http_client(self, endpoint):
+        if endpoint not in self._http_clients[endpoint]:
+            self._http_clients[endpoint] = LivyReliableHttpClient.from_endpoint(endpoint)
+        return self._http_clients[endpoint]

--- a/sparkmagic/sparkmagic/livyclientlib/sparkcontroller.py
+++ b/sparkmagic/sparkmagic/livyclientlib/sparkcontroller.py
@@ -115,6 +115,6 @@ class SparkController(object):
                            session_id, heartbeat_timeout=conf.livy_server_heartbeat_timeout_seconds())
 
     def _http_client(self, endpoint):
-        if endpoint not in self._http_clients[endpoint]:
+        if endpoint not in self._http_clients:
             self._http_clients[endpoint] = LivyReliableHttpClient.from_endpoint(endpoint)
         return self._http_clients[endpoint]

--- a/sparkmagic/sparkmagic/livyclientlib/sparkcontroller.py
+++ b/sparkmagic/sparkmagic/livyclientlib/sparkcontroller.py
@@ -10,14 +10,14 @@ from sparkmagic.utils.constants import MAGICS_LOGGER_NAME
 
 
 class SparkController(object):
-    # this is to reuse the already created http clients
-    # since the reliablehttpclient uses requests session
-    _http_clients = {}
 
     def __init__(self, ipython_display):
         self.logger = SparkLog(u"SparkController")
         self.ipython_display = ipython_display
         self.session_manager = SessionManager(ipython_display)
+        # this is to reuse the already created http clients
+        # since the reliablehttpclient uses requests session
+        self._http_clients = {}
 
     def get_app_id(self, client_name=None):
         session_to_use = self.get_session_by_name_or_default(client_name)

--- a/sparkmagic/sparkmagic/utils/configuration.py
+++ b/sparkmagic/sparkmagic/utils/configuration.py
@@ -14,6 +14,8 @@ from .constants import HOME_PATH, CONFIG_FILE, MAGICS_LOGGER_NAME, LIVY_KIND_PAR
 from sparkmagic.livyclientlib.exceptions import BadUserConfigurationException
 import sparkmagic.utils.constants as constants
 
+from requests_kerberos import REQUIRED
+
 
 d = {}
 path = join_paths(HOME_PATH, CONFIG_FILE)
@@ -252,6 +254,13 @@ def all_errors_are_fatal():
 def cleanup_all_sessions_on_exit():
     # If set to true, all registered livy sessions will be attempted to be cleaned up before exiting
     return False
+
+
+@_with_override
+def kerberos_auth_configuration():
+    return {
+        "mutual_authentication": REQUIRED
+    }
 
 
 def _credentials_override(f):


### PR DESCRIPTION
As addressed in issue #614 this PR proposes the following changes
- Using http clients maps on the `SparkController` class to reuse clients since it is not needed a new client per cell
- Using `requests.Session` instead of plain `requests` to ensure we store the generated Kerberos ticket cookie instead of negotiating the ticket in every request
- Add a configuration option to override the default `HTTPKerberosAuth` constructor