### PR TITLE
Raise on Failed Session Start if all_errors_are_fatal

### DIFF
--- a/sparkmagic/sparkmagic/kernels/kernelmagics.py
+++ b/sparkmagic/sparkmagic/kernels/kernelmagics.py
@@ -362,6 +362,10 @@ class KernelMagics(SparkMagicBase):
                 self.fatal_error_message = conf.fatal_error_suggestion().format(e)
                 self.logger.error(u"Error creating session: {}".format(e))
                 self.ipython_display.send_error(self.fatal_error_message)
+
+                if conf.all_errors_are_fatal():
+                    raise e
+
                 return False
 
         return self.session_started

--- a/sparkmagic/sparkmagic/tests/test_kernel_magics.py
+++ b/sparkmagic/sparkmagic/tests/test_kernel_magics.py
@@ -93,6 +93,19 @@ def test_start_session_times_out():
     assert magic.session_started
     assert_equals(ipython_display.send_error.call_count, 1)
 
+@with_setup(_setup, _teardown)
+@raises(LivyClientTimeoutException)
+def test_start_session_times_out_all_errors_are_fatal():
+    conf.override_all({
+        "all_errors_are_fatal": True
+    })
+
+    line = ""
+    spark_controller.add_session = MagicMock(side_effect=LivyClientTimeoutException)
+    assert not magic.session_started
+
+    ret = magic._do_not_call_start_session(line)
+
 
 @with_setup(_setup, _teardown)
 def test_delete_session():


### PR DESCRIPTION
Currently, `all_errors_are_fatal` was not functioning as expected if the session failed to start because `_do_not_call_start_session` swallowed the exception. This adds maintains existing functionality but also raises the exception if `all_errors_are_fatal` is `True`

- Raise session start exceptions 
- Add regression test