### PR TITLE
Fix ContextualVersionConflict in Dockerfile.spark

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### Bug fixes
+
+* Fix ContextualVersionConflict in Dockerfile.spark. Thanks Linan Zheng, @LinanZheng
+
 ## 0.15.0
 
 ### Features

--- a/Dockerfile.spark
+++ b/Dockerfile.spark
@@ -11,12 +11,9 @@ RUN apt-get update && apt-get install -yq --no-install-recommends --force-yes \
     r-base-core && \
     rm -rf /var/lib/apt/lists/*
 
+# Install pip for Python3
 RUN easy_install3 pip py4j
-RUN pip install --upgrade setuptools && \
-    curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
-    python get-pip.py --user && \
-    rm get-pip.py && \
-    python -m pip install --upgrade setuptools
+RUN pip install --upgrade setuptools
 
 ENV PYTHONHASHSEED 0
 ENV PYTHONIOENCODING UTF-8
@@ -34,9 +31,19 @@ RUN mkdir -p /apps/build && \
   cp -r /apps/build/spark/dist $SPARK_HOME && \
   rm -rf $SPARK_BUILD_PATH
 
+# ----------
+# Build Livy
+# ----------
 ENV LIVY_BUILD_VERSION 0.6.0-incubating
 ENV LIVY_APP_PATH /apps/apache-livy-$LIVY_BUILD_VERSION-bin
 ENV LIVY_BUILD_PATH /apps/build/livy
+
+# Install setuptools for Python 2.7 for Livy
+RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
+    python get-pip.py --user && \
+    rm get-pip.py && \
+    python -m pip install --upgrade setuptools
+
 RUN cd /apps/build && \
 	git clone https://github.com/apache/incubator-livy.git livy && \
 	cd $LIVY_BUILD_PATH && \

--- a/Dockerfile.spark
+++ b/Dockerfile.spark
@@ -36,6 +36,10 @@ ENV LIVY_BUILD_PATH /apps/build/livy
 RUN cd /apps/build && \
 	git clone https://github.com/apache/incubator-livy.git livy && \
 	cd $LIVY_BUILD_PATH && \
+  curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
+  python get-pip.py --user && \
+  rm get-pip.py && \
+  python -m pip install --upgrade setuptools && \
   git checkout v$LIVY_BUILD_VERSION-rc2 && \
     mvn -DskipTests -Dspark.version=$SPARK_BUILD_VERSION clean package && \
     ls -al $LIVY_BUILD_PATH && ls -al $LIVY_BUILD_PATH/assembly && ls -al $LIVY_BUILD_PATH/assembly/target && \

--- a/Dockerfile.spark
+++ b/Dockerfile.spark
@@ -12,7 +12,11 @@ RUN apt-get update && apt-get install -yq --no-install-recommends --force-yes \
     rm -rf /var/lib/apt/lists/*
 
 RUN easy_install3 pip py4j
-RUN pip install --upgrade setuptools
+RUN pip install --upgrade setuptools && \
+    curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
+    python get-pip.py --user && \
+    rm get-pip.py && \
+    python -m pip install --upgrade setuptools
 
 ENV PYTHONHASHSEED 0
 ENV PYTHONIOENCODING UTF-8
@@ -36,10 +40,6 @@ ENV LIVY_BUILD_PATH /apps/build/livy
 RUN cd /apps/build && \
 	git clone https://github.com/apache/incubator-livy.git livy && \
 	cd $LIVY_BUILD_PATH && \
-  curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
-  python get-pip.py --user && \
-  rm get-pip.py && \
-  python -m pip install --upgrade setuptools && \
   git checkout v$LIVY_BUILD_VERSION-rc2 && \
     mvn -DskipTests -Dspark.version=$SPARK_BUILD_VERSION clean package && \
     ls -al $LIVY_BUILD_PATH && ls -al $LIVY_BUILD_PATH/assembly && ls -al $LIVY_BUILD_PATH/assembly/target && \


### PR DESCRIPTION
Docker can't build Spark image right now since a change in version control has been introduced in the dependent library `ConfigParser`. The solution is to upgrade the setuptools in Python 2.7 used by Livy so that the correct version can be picked up and compared against. 

Error Log:
```
Traceback (most recent call last):
  File "setup.py", line 57, in <module>
    tests_require=['pytest']
  File "/usr/lib/python2.7/distutils/core.py", line 111, in setup
    _setup_distribution = dist = klass(attrs)
  File "/usr/lib/python2.7/dist-packages/setuptools/dist.py", line 317, in __init__
    self.fetch_build_eggs(attrs['setup_requires'])
  File "/usr/lib/python2.7/dist-packages/setuptools/dist.py", line 372, in fetch_build_eggs
    replace_conflicting=True,
  File "/usr/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 854, in resolve
    raise VersionConflict(dist, req).with_context(dependent_req)
pkg_resources.ContextualVersionConflict: (configparser 0.0.0 (/apps/build/livy/python-api/.eggs/configparser-0.0.0-py2.7.egg), Requirement.parse('configparser>=3.5'), set(['entrypoints']))
```

Source:
https://github.com/jaraco/configparser/issues/45