### PR TITLE
Add a cell magic to cancel statement execution

### DIFF
--- a/sparkmagic/sparkmagic/kernels/wrapperkernel/usercodeparser.py
+++ b/sparkmagic/sparkmagic/kernels/wrapperkernel/usercodeparser.py
@@ -11,7 +11,8 @@ class UserCodeParser(object):
     #    some_input
     _magics_with_no_cell_body = [i.__name__ for i in [KernelMagics.info, KernelMagics.logs, KernelMagics.cleanup,
                                                       KernelMagics.delete, KernelMagics.help, KernelMagics.spark,
-                                                      KernelMagics.send_to_spark]]
+                                                      KernelMagics.send_to_spark,
+                                                      KernelMagics.cancel]]
 
     def get_code_to_run(self, code):
         try:

--- a/sparkmagic/sparkmagic/livyclientlib/livyreliablehttpclient.py
+++ b/sparkmagic/sparkmagic/livyclientlib/livyreliablehttpclient.py
@@ -29,6 +29,12 @@ class LivyReliableHttpClient(object):
     def get_statement(self, session_id, statement_id):
         return self._http_client.get(self._statement_url(session_id, statement_id), [200]).json()
 
+    def cancel_statement(self, session_id, statement_id):
+        return self._http_client.post("{}/cancel".format(self._statement_url(session_id, statement_id)), [200], {}).json()
+
+    def get_statements(self, session_id):
+        return self._http_client.get(self._statements_url(session_id), [200]).json()
+
     def get_sessions(self):
         return self._http_client.get("/sessions", [200]).json()
 


### PR DESCRIPTION
SparkMagic currently does not have the ability to cancel the execution of certain statement and therefore it is quite problematic if the user accidentally wrote runaway code or undesirable long running Spark operations. In this PR, a new cell magic is introduced to cancel either all running/waiting statements from a session (Like SIGINT) or cancel one specific statement from a session.

This is the first draft of what I proposed above and at this moment, the PR is a working prototype stage that you can try out yourself but here are things I would love to get some suggestions/helps/reviews on:
 
1. Cell magic arguments. Are there additional user cases that I haven't thought about? Is the force argument necessary?
2. I implemented the new magic command in KernelMagics but I can see this being ported over to remotesparkmagic as a subcommand. Would you like to see this being migrated over? 

Let me know how do you think of this magic and its design. Thanks!

TODO:
- [ ] Help HTML in KernelMagic
- [ ] Unit Tests
- [ ] RemoteSparkMagic Implementation?
- [ ] Usage in example notebook
- [ ] New issue to track SIGINT callback