### PR TITLE
Fix Info Subcommand in RemoteSparkMagic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Bug fixes
 
 * Fix ContextualVersionConflict in Dockerfile.spark. Thanks Linan Zheng, @LinanZheng
+* Fix Info Subcommand in RemoteSparkMagic. Thanks Linan Zheng, @LinanZheng
 
 ## 0.15.0
 

--- a/sparkmagic/sparkmagic/magics/remotesparkmagics.py
+++ b/sparkmagic/sparkmagic/magics/remotesparkmagics.py
@@ -119,10 +119,10 @@ class RemoteSparkMagics(SparkMagicBase):
 
         # info
         if subcommand == "info":
-            if args.url is not None:
+            if args.url is not None and args.id is not None:
                 endpoint = Endpoint(args.url, args.auth, args.user, args.password)
                 info_sessions = self.spark_controller.get_all_sessions_endpoint_info(endpoint)
-                self._print_endpoint_info(info_sessions)
+                self._print_endpoint_info(info_sessions, args.id)
             else:
                 self._print_local_info()
         # config

--- a/sparkmagic/sparkmagic/tests/test_remotesparkmagics.py
+++ b/sparkmagic/sparkmagic/tests/test_remotesparkmagics.py
@@ -50,7 +50,7 @@ def test_info_endpoint_command_parses():
 
     magic.spark(command)
 
-    print_info_mock.assert_called_once_with(url="http://microsoft.com", id="1234")
+    print_info_mock.assert_called_once_with(None,1234)
 
 
 @with_setup(_setup, _teardown)

--- a/sparkmagic/sparkmagic/tests/test_remotesparkmagics.py
+++ b/sparkmagic/sparkmagic/tests/test_remotesparkmagics.py
@@ -45,12 +45,12 @@ def test_info_command_parses():
 def test_info_endpoint_command_parses():
     print_info_mock = MagicMock()
     magic._print_endpoint_info = print_info_mock
-    command = "info -u http://microsoft.com"
+    command = "info -u http://microsoft.com -i 1234"
     spark_controller.get_all_sessions_endpoint_info = MagicMock(return_value=None)
 
     magic.spark(command)
 
-    print_info_mock.assert_called_once_with(None)
+    print_info_mock.assert_called_once_with(url="http://microsoft.com", id="1234")
 
 
 @with_setup(_setup, _teardown)


### PR DESCRIPTION
This PR will address the issue mentioned in https://github.com/jupyter-incubator/sparkmagic/issues/627 by enforcing both id and url arguments.