### PR TITLE
#647 non supported session kinds should not break jupyter startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Fix ContextualVersionConflict in Dockerfile.spark. Thanks Linan Zheng, @LinanZheng
 * Fix Info Subcommand in RemoteSparkMagic. Thanks Linan Zheng, @LinanZheng
+* Fix to ignore unsupported spark session types whilst fetching the session list.
 
 ## 0.15.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Fix ContextualVersionConflict in Dockerfile.spark. Thanks Linan Zheng, @LinanZheng
 * Fix Info Subcommand in RemoteSparkMagic. Thanks Linan Zheng, @LinanZheng
-* Fix to ignore unsupported spark session types whilst fetching the session list.
+* Fix to ignore unsupported spark session types whilst fetching the session list. Thanks, Murat Burak Migdisoglu, @mmigdiso
 
 ## 0.15.0
 

--- a/sparkmagic/sparkmagic/livyclientlib/sparkcontroller.py
+++ b/sparkmagic/sparkmagic/livyclientlib/sparkcontroller.py
@@ -46,9 +46,10 @@ class SparkController(object):
     def get_all_sessions_endpoint(self, endpoint):
         http_client = self._http_client(endpoint)
         sessions = http_client.get_sessions()[u"sessions"]
+        supported_sessions = filter(lambda s: (s[constants.LIVY_KIND_PARAM] in constants.SESSION_KINDS_SUPPORTED), sessions)
         session_list = [self._livy_session(http_client, {constants.LIVY_KIND_PARAM: s[constants.LIVY_KIND_PARAM]},
                                            self.ipython_display, s[u"id"])
-                        for s in sessions]
+                        for s in supported_sessions]
         for s in session_list:
             s.refresh_status_and_info()
         return session_list

--- a/sparkmagic/sparkmagic/tests/test_sparkcontroller.py
+++ b/sparkmagic/sparkmagic/tests/test_sparkcontroller.py
@@ -132,8 +132,9 @@ def test_get_client_keys():
 @with_setup(_setup, _teardown)
 def test_get_all_sessions():
     http_client = MagicMock()
-    http_client.get_sessions.return_value = json.loads('{"from":0,"total":2,"sessions":[{"id":0,"state":"idle","kind":'
+    http_client.get_sessions.return_value = json.loads('{"from":0,"total":3,"sessions":[{"id":0,"state":"idle","kind":'
                                                        '"spark","log":[""]}, {"id":1,"state":"busy","kind":"spark","log"'
+                                                       ':[""]},{"id":2,"state":"busy","kind":"sql","log"'
                                                        ':[""]}]}')
     controller._http_client = MagicMock(return_value=http_client)
     controller._livy_session = MagicMock()


### PR DESCRIPTION
### Description
When there is a Livy session with type 'sql' created outside of the jupyter, sparkmagic fails to start as it cannot match the type sql in supported 'kind's. 

### Checklist
- [x] Wrote a description of my changes above 
- [x] Added a bullet point for my changes to the top of the `CHANGELOG.md` file
- [x] Added or modified unit tests to reflect my changes
- [x] Manually tested with a notebook
- [x] If adding a feature, there is an example notebook and/or documentation in the `README.md` file