### PR TITLE
Fix iteration over the sessions in /reconnectsparkmagic

### DIFF
--- a/sparkmagic/sparkmagic/serverextension/handlers.py
+++ b/sparkmagic/sparkmagic/serverextension/handlers.py
@@ -99,7 +99,7 @@ class ReconnectHandler(IPythonHandler):
         sessions = self.session_manager.list_sessions()
 
         kernel_id = None
-        for session in sessions:
+        for session in sessions.result():
             if session['notebook']['path'] == path:
                 session_id = session['id']
                 kernel_id = session['kernel']['id']


### PR DESCRIPTION
Hi!

I noticed that the `/reconnectsparkmagic` endpoint was broken (with sparkmagic 0.15.0, iPython 7.16.1 and notebook 6.0.3).
I did an investigation and I found out that it was always recreating a new kernel because it could not correctly iterate over the different sessions to find to right kernel to restart. 

So here is a small fix I made to make it work.