### PR TITLE
Fix missing url passing when using a custom authenticator

### DIFF
--- a/sparkmagic/sparkmagic/controllerwidget/magicscontrollerwidget.py
+++ b/sparkmagic/sparkmagic/controllerwidget/magicscontrollerwidget.py
@@ -33,7 +33,7 @@ class MagicsControllerWidget(AbstractMenuWidget):
             if all([p in endpoint_config for p in ["url", "password", "username"]]) and endpoint_config["url"] != "":
                 user = endpoint_config["username"]
                 passwd = endpoint_config["password"]
-                args = Namespace(user=user, password=passwd, auth=endpoint_config.get("auth", None))
+                args = Namespace(user=user, password=passwd, auth=endpoint_config.get("auth", None), url=endpoint_config.get("url", None))
                 auth_instance = initialize_auth(args)
 
                 default_endpoints.add(Endpoint(

--- a/sparkmagic/sparkmagic/kernels/kernelmagics.py
+++ b/sparkmagic/sparkmagic/kernels/kernelmagics.py
@@ -429,7 +429,7 @@ class KernelMagics(SparkMagicBase):
     def refresh_configuration(self):
         credentials = getattr(conf, 'base64_kernel_' + self.language + '_credentials')()
         (username, password, auth, url) = (credentials['username'], credentials['password'], credentials['auth'], credentials['url'])
-        args = Namespace(auth=auth, user=username, password=password)
+        args = Namespace(auth=auth, user=username, password=password, url=url)
         auth_instance = initialize_auth(args)
         self.endpoint = Endpoint(url, auth_instance)
 


### PR DESCRIPTION
### Description
Fixes a bug with passing the url from the configuration when using a Custom Authenticator. Fixes https://github.com/jupyter-incubator/sparkmagic/issues/683 - see this issue for more details.

### Checklist
- [x] Wrote a description of my changes above 
- [ ] Added a bullet point for my changes to the top of the `CHANGELOG.md` file
- [ ] Added or modified unit tests to reflect my changes
- [x] Manually tested with a notebook
- [ ] If adding a feature, there is an example notebook and/or documentation in the `README.md` file
