### PR TITLE
Adding language info and file extension for the spark kernel

### DIFF
--- a/sparkmagic/sparkmagic/kernels/pysparkkernel/kernel.json
+++ b/sparkmagic/sparkmagic/kernels/pysparkkernel/kernel.json
@@ -1,4 +1,11 @@
-{"argv":["python","-m","sparkmagic.kernels.pysparkkernel.pysparkkernel", "-f", "{connection_file}"],
- "display_name":"PySpark",
- "language":"python"
+{
+  "argv": [
+    "python",
+    "-m",
+    "sparkmagic.kernels.pysparkkernel.pysparkkernel",
+    "-f",
+    "{connection_file}"
+  ],
+  "display_name": "PySpark",
+  "language": "python"
 }

--- a/sparkmagic/sparkmagic/kernels/pysparkkernel/kernel.json
+++ b/sparkmagic/sparkmagic/kernels/pysparkkernel/kernel.json
@@ -1,3 +1,4 @@
 {"argv":["python","-m","sparkmagic.kernels.pysparkkernel.pysparkkernel", "-f", "{connection_file}"],
- "display_name":"PySpark"
+ "display_name":"PySpark",
+ "language":"python"
 }

--- a/sparkmagic/sparkmagic/kernels/pysparkkernel/pysparkkernel.py
+++ b/sparkmagic/sparkmagic/kernels/pysparkkernel/pysparkkernel.py
@@ -14,6 +14,7 @@ class PySparkKernel(SparkKernelBase):
             'name': 'pyspark',
             'mimetype': 'text/x-python',
             'codemirror_mode': {'name': 'python', 'version': 3},
+            'file_extension': '.py'
             'pygments_lexer': 'python3'
         }
 

--- a/sparkmagic/sparkmagic/kernels/pysparkkernel/pysparkkernel.py
+++ b/sparkmagic/sparkmagic/kernels/pysparkkernel/pysparkkernel.py
@@ -13,15 +13,20 @@ class PySparkKernel(SparkKernelBase):
         language_info = {
             'name': 'pyspark',
             'mimetype': 'text/x-python',
-            'codemirror_mode': {'name': 'python', 'version': 3},
-            'file_extension': '.py'
+            'codemirror_mode': {
+                'name': 'python',
+                'version': 3
+            },
+            'file_extension': '.py',
             'pygments_lexer': 'python3'
         }
 
         session_language = LANG_PYTHON
 
-        super(PySparkKernel, self).__init__(implementation, implementation_version, language, language_version,
-                                            language_info, session_language, **kwargs)
+        super(PySparkKernel,
+              self).__init__(implementation, implementation_version, language,
+                             language_version, language_info, session_language,
+                             **kwargs)
 
 
 if __name__ == '__main__':

--- a/sparkmagic/sparkmagic/kernels/pysparkkernel/pysparkkernel.py
+++ b/sparkmagic/sparkmagic/kernels/pysparkkernel/pysparkkernel.py
@@ -8,7 +8,7 @@ class PySparkKernel(SparkKernelBase):
     def __init__(self, **kwargs):
         implementation = 'PySpark'
         implementation_version = '1.0'
-        language = 'no-op'
+        language = LANG_PYTHON
         language_version = '0.1'
         language_info = {
             'name': 'pyspark',

--- a/sparkmagic/sparkmagic/kernels/sparkkernel/kernel.js
+++ b/sparkmagic/sparkmagic/kernels/sparkkernel/kernel.js
@@ -1,8 +1,12 @@
-define(['base/js/namespace'], function(IPython){
-        var onload = function() {
-            IPython.CodeCell.config_defaults.highlight_modes['magic_text/x-sql'] = {'reg':[/^%%sql/]};
-            IPython.CodeCell.config_defaults.highlight_modes['magic_text/x-python'] = {'reg':[/^%%local/]};
-        }
+define(["base/js/namespace"], function(IPython) {
+  var onload = function() {
+    IPython.CodeCell.config_defaults.highlight_modes["magic_text/x-sql"] = {
+      reg: [/^%%sql/]
+    };
+    IPython.CodeCell.config_defaults.highlight_modes["magic_text/x-python"] = {
+      reg: [/^%%local/]
+    };
+  };
 
-        return { onload: onload }
-    })
+  return { onload: onload };
+});

--- a/sparkmagic/sparkmagic/kernels/sparkkernel/kernel.json
+++ b/sparkmagic/sparkmagic/kernels/sparkkernel/kernel.json
@@ -1,3 +1,4 @@
 {"argv":["python","-m","sparkmagic.kernels.sparkkernel.sparkkernel", "-f", "{connection_file}"],
- "display_name":"Spark"
+ "display_name":"Spark",
+ "language": "scala"
 }

--- a/sparkmagic/sparkmagic/kernels/sparkkernel/kernel.json
+++ b/sparkmagic/sparkmagic/kernels/sparkkernel/kernel.json
@@ -1,4 +1,11 @@
-{"argv":["python","-m","sparkmagic.kernels.sparkkernel.sparkkernel", "-f", "{connection_file}"],
- "display_name":"Spark",
- "language": "scala"
+{
+  "argv": [
+    "python",
+    "-m",
+    "sparkmagic.kernels.sparkkernel.sparkkernel",
+    "-f",
+    "{connection_file}"
+  ],
+  "display_name": "Spark",
+  "language": "scala"
 }

--- a/sparkmagic/sparkmagic/kernels/sparkkernel/sparkkernel.py
+++ b/sparkmagic/sparkmagic/kernels/sparkkernel/sparkkernel.py
@@ -8,7 +8,7 @@ class SparkKernel(SparkKernelBase):
     def __init__(self, **kwargs):
         implementation = 'Spark'
         implementation_version = '1.0'
-        language = 'no-op'
+        language = LANG_SCALA
         language_version = '0.1'
         language_info = {
             'name': 'scala',

--- a/sparkmagic/sparkmagic/kernels/sparkkernel/sparkkernel.py
+++ b/sparkmagic/sparkmagic/kernels/sparkkernel/sparkkernel.py
@@ -14,6 +14,7 @@ class SparkKernel(SparkKernelBase):
             'name': 'scala',
             'mimetype': 'text/x-scala',
             'codemirror_mode': 'text/x-scala',
+            'file_extension': '.sc',
             'pygments_lexer': 'scala'
         }
 

--- a/sparkmagic/sparkmagic/kernels/sparkkernel/sparkkernel.py
+++ b/sparkmagic/sparkmagic/kernels/sparkkernel/sparkkernel.py
@@ -20,8 +20,10 @@ class SparkKernel(SparkKernelBase):
 
         session_language = LANG_SCALA
 
-        super(SparkKernel, self).__init__(implementation, implementation_version, language, language_version,
-                                          language_info, session_language, **kwargs)
+        super(SparkKernel,
+              self).__init__(implementation, implementation_version, language,
+                             language_version, language_info, session_language,
+                             **kwargs)
 
 
 if __name__ == '__main__':

--- a/sparkmagic/sparkmagic/kernels/sparkrkernel/kernel.js
+++ b/sparkmagic/sparkmagic/kernels/sparkrkernel/kernel.js
@@ -1,7 +1,9 @@
-define(['base/js/namespace'], function(IPython){
-        var onload = function() {
-            IPython.CodeCell.config_defaults.highlight_modes['magic_text/x-sql'] = {'reg':[/^%%sql/]};
-        }
+define(["base/js/namespace"], function(IPython) {
+  var onload = function() {
+    IPython.CodeCell.config_defaults.highlight_modes["magic_text/x-sql"] = {
+      reg: [/^%%sql/]
+    };
+  };
 
-        return { onload: onload }
-    })
+  return { onload: onload };
+});

--- a/sparkmagic/sparkmagic/kernels/sparkrkernel/kernel.json
+++ b/sparkmagic/sparkmagic/kernels/sparkrkernel/kernel.json
@@ -1,4 +1,11 @@
-{"argv":["python","-m","sparkmagic.kernels.sparkrkernel.sparkrkernel", "-f", "{connection_file}"],
- "display_name":"SparkR",
- "language":"r"
+{
+  "argv": [
+    "python",
+    "-m",
+    "sparkmagic.kernels.sparkrkernel.sparkrkernel",
+    "-f",
+    "{connection_file}"
+  ],
+  "display_name": "SparkR",
+  "language": "r"
 }

--- a/sparkmagic/sparkmagic/kernels/sparkrkernel/kernel.json
+++ b/sparkmagic/sparkmagic/kernels/sparkrkernel/kernel.json
@@ -1,3 +1,4 @@
 {"argv":["python","-m","sparkmagic.kernels.sparkrkernel.sparkrkernel", "-f", "{connection_file}"],
- "display_name":"SparkR"
+ "display_name":"SparkR",
+ "language":"r"
 }

--- a/sparkmagic/sparkmagic/kernels/sparkrkernel/sparkrkernel.py
+++ b/sparkmagic/sparkmagic/kernels/sparkrkernel/sparkrkernel.py
@@ -20,8 +20,10 @@ class SparkRKernel(SparkKernelBase):
 
         session_language = LANG_R
 
-        super(SparkRKernel, self).__init__(implementation, implementation_version, language, language_version,
-                                          language_info, session_language, **kwargs)
+        super(SparkRKernel,
+              self).__init__(implementation, implementation_version, language,
+                             language_version, language_info, session_language,
+                             **kwargs)
 
 
 if __name__ == '__main__':

--- a/sparkmagic/sparkmagic/kernels/sparkrkernel/sparkrkernel.py
+++ b/sparkmagic/sparkmagic/kernels/sparkrkernel/sparkrkernel.py
@@ -8,7 +8,7 @@ class SparkRKernel(SparkKernelBase):
     def __init__(self, **kwargs):
         implementation = 'SparkR'
         implementation_version = '1.0'
-        language = 'no-op'
+        language = LANG_R
         language_version = '0.1'
         language_info = {
             'name': 'sparkR',

--- a/sparkmagic/sparkmagic/kernels/sparkrkernel/sparkrkernel.py
+++ b/sparkmagic/sparkmagic/kernels/sparkrkernel/sparkrkernel.py
@@ -14,6 +14,7 @@ class SparkRKernel(SparkKernelBase):
             'name': 'sparkR',
             'mimetype': 'text/x-rsrc',
             'codemirror_mode': 'text/x-rsrc',
+            'file_extension': '.r',
             'pygments_lexer': 'r'
         }
 

--- a/sparkmagic/sparkmagic/tests/test_kernels.py
+++ b/sparkmagic/sparkmagic/tests/test_kernels.py
@@ -27,13 +27,17 @@ def test_pyspark_kernel_configs():
     assert kernel.session_language == LANG_PYTHON
 
     assert kernel.implementation == 'PySpark'
-    assert kernel.language == 'no-op'
+    assert kernel.language == 'python'
     assert kernel.language_version == '0.1'
     assert kernel.language_info == {
         'name': 'pyspark',
         'mimetype': 'text/x-python',
-        'codemirror_mode': {'name': 'python', 'version': 3},
-        'pygments_lexer': 'python3'
+        'codemirror_mode': {
+            'name': 'python',
+            'version': 3
+        },
+        'file_extension': '.py',
+        'pygments_lexer': 'python3',
     }
 
 
@@ -43,14 +47,16 @@ def test_spark_kernel_configs():
     assert kernel.session_language == LANG_SCALA
 
     assert kernel.implementation == 'Spark'
-    assert kernel.language == 'no-op'
+    assert kernel.language == 'scala'
     assert kernel.language_version == '0.1'
     assert kernel.language_info == {
         'name': 'scala',
         'mimetype': 'text/x-scala',
         'pygments_lexer': 'scala',
-        'codemirror_mode': 'text/x-scala'
+        'file_extension': '.sc',
+        'codemirror_mode': 'text/x-scala',
     }
+
 
 def test_sparkr_kernel_configs():
     kernel = TestSparkRKernel()
@@ -58,12 +64,12 @@ def test_sparkr_kernel_configs():
     assert kernel.session_language == LANG_R
 
     assert kernel.implementation == 'SparkR'
-    assert kernel.language == 'no-op'
+    assert kernel.language == 'r'
     assert kernel.language_version == '0.1'
     assert kernel.language_info == {
         'name': 'sparkR',
         'mimetype': 'text/x-rsrc',
         'pygments_lexer': 'r',
+        'file_extension': '.r',
         'codemirror_mode': 'text/x-rsrc'
     }
-

--- a/sparkmagic/sparkmagic/tests/test_kernels.py
+++ b/sparkmagic/sparkmagic/tests/test_kernels.py
@@ -27,7 +27,7 @@ def test_pyspark_kernel_configs():
     assert kernel.session_language == LANG_PYTHON
 
     assert kernel.implementation == 'PySpark'
-    assert kernel.language == 'python'
+    assert kernel.language == LANG_PYTHON
     assert kernel.language_version == '0.1'
     assert kernel.language_info == {
         'name': 'pyspark',
@@ -47,7 +47,7 @@ def test_spark_kernel_configs():
     assert kernel.session_language == LANG_SCALA
 
     assert kernel.implementation == 'Spark'
-    assert kernel.language == 'scala'
+    assert kernel.language == LANG_SCALA
     assert kernel.language_version == '0.1'
     assert kernel.language_info == {
         'name': 'scala',
@@ -64,7 +64,7 @@ def test_sparkr_kernel_configs():
     assert kernel.session_language == LANG_R
 
     assert kernel.implementation == 'SparkR'
-    assert kernel.language == 'r'
+    assert kernel.language == LANG_R
     assert kernel.language_version == '0.1'
     assert kernel.language_info == {
         'name': 'sparkR',


### PR DESCRIPTION
### Description
The language and file_extension are missing from the spark magic kernel, because of which it has trouble integrating with other features like jupyterlab-lsp. Hence updating the same. 

Closes #691 

### Checklist
- [x] Wrote a description of my changes above 
- [ ] Added a bullet point for my changes to the top of the `CHANGELOG.md` file
- [ ] Added or modified unit tests to reflect my changes
- [ ] Manually tested with a notebook
- [ ] If adding a feature, there is an example notebook and/or documentation in the `README.md` file
