### PR TITLE
Add the owner of the session in the %%info magic table

### DIFF
--- a/sparkmagic/sparkmagic/livyclientlib/livysession.py
+++ b/sparkmagic/sparkmagic/livyclientlib/livysession.py
@@ -108,6 +108,7 @@ class LivySession(ObjectWithGuid):
                                        .format(kind, ", ".join(constants.SESSION_KINDS_SUPPORTED)))
 
         self._app_id = None
+        self._owner = None
         self._logs = u""
         self._http_client = http_client
         self._wait_for_idle_timeout_seconds = wait_for_idle_timeout_seconds
@@ -182,6 +183,11 @@ class LivySession(ObjectWithGuid):
         if self._app_id is None:
             self._app_id = self._http_client.get_session(self.id).get("appId")
         return self._app_id
+
+    def get_owner(self):
+        if self._owner is None:
+            self._owner = self._http_client.get_session(self.id).get("owner")
+        return self._owner
 
     def get_app_info(self):
         appInfo = self._http_client.get_session(self.id).get("appInfo")
@@ -313,8 +319,8 @@ class LivySession(ObjectWithGuid):
             self._heartbeat_thread = None
 
     def get_row_html(self, current_session_id):
-        return u"""<tr><td>{0}</td><td>{1}</td><td>{2}</td><td>{3}</td><td>{4}</td><td>{5}</td><td>{6}</td></tr>""".format(
-            self.id, self.get_app_id(), self.kind, self.status,
+        return u"""<tr><td>{0}</td><td>{1}</td><td>{2}</td><td>{3}</td><td>{4}</td><td>{5}</td><td>{6}</td><td>{7}</td></tr>""".format(
+            self.id, self.get_app_id(), self.kind, self.status, self.get_owner(),
             self.get_html_link(u'Link', self.get_spark_ui_url()), self.get_html_link(u'Link', self.get_driver_log_url()),
             u"" if current_session_id is None or current_session_id != self.id else u"\u2714"
         )

--- a/sparkmagic/sparkmagic/tests/test_sparkmagicsbase.py
+++ b/sparkmagic/sparkmagic/tests/test_sparkmagicsbase.py
@@ -125,7 +125,7 @@ def test_print_endpoint_info():
     session2.get_row_html.return_value = u"""<tr><td>row2</td></tr>"""
     magic._print_endpoint_info([session2, session1], current_session_id)
     magic.ipython_display.html.assert_called_once_with(u"""<table>
-<tr><th>ID</th><th>YARN Application ID</th><th>Kind</th><th>State</th><th>Spark UI</th><th>Driver log</th><th>Current session?</th></tr>\
+<tr><th>ID</th><th>YARN Application ID</th><th>Kind</th><th>State</th><th>Owner</th><th>Spark UI</th><th>Driver log</th><th>Current session?</th></tr>\
 <tr><td>row1</td></tr><tr><td>row2</td></tr>\
 </table>""")
 

--- a/sparkmagic/sparkmagic/utils/utils.py
+++ b/sparkmagic/sparkmagic/utils/utils.py
@@ -27,12 +27,12 @@ def parse_argstring_or_throw(magic_func, argstring, parse_argstring=parse_argstr
         return parse_argstring(magic_func, argstring)
     except UsageError as e:
         raise BadUserDataException(str(e))
-        
-        
+
+
 def coerce_pandas_df_to_numeric_datetime(df):
     for column_name in df.columns:
         coerced = False
-        
+
         if df[column_name].isnull().all():
             continue
 
@@ -64,7 +64,7 @@ def records_to_dataframe(records_text, kind, coerce=None):
 
         df = pd.DataFrame(data_array)
 
-        if len(data_array) > 0:    
+        if len(data_array) > 0:
             # This will assign the columns in the right order. If we simply did
             # df = pd.DataFrame(data_array, columns=data_array[0].keys())
             # in the code defining df, above, we could get an issue where the first element
@@ -75,7 +75,7 @@ def records_to_dataframe(records_text, kind, coerce=None):
                 if len(data.keys()) == len(df.columns):
                     df = df[list(data.keys())]
                     break
-                    
+
         if coerce is None:
             coerce = conf.coerce_dataframe()
         if coerce:
@@ -88,7 +88,7 @@ def records_to_dataframe(records_text, kind, coerce=None):
 
 def get_sessions_info_html(info_sessions, current_session_id):
     html = u"""<table>
-<tr><th>ID</th><th>YARN Application ID</th><th>Kind</th><th>State</th><th>Spark UI</th><th>Driver log</th><th>Current session?</th></tr>""" + \
+<tr><th>ID</th><th>YARN Application ID</th><th>Kind</th><th>State</th><th>Owner</th><th>Spark UI</th><th>Driver log</th><th>Current session?</th></tr>""" + \
     u"".join([session.get_row_html(current_session_id) for session in info_sessions]) + \
     u"</table>"
 
@@ -103,10 +103,10 @@ def initialize_auth(args):
 
     Returns:
         An instance of a valid Authenticator or None if args.auth is 'None'
-    
+
     Raises:
         sparkmagic.livyclientlib.BadUserConfigurationException: if args.auth is not a valid
-        authenticator class. 
+        authenticator class.
     """
     if args.auth is None:
         auth = conf.get_auth_value(args.user, args.password)
@@ -114,7 +114,7 @@ def initialize_auth(args):
         auth = args.auth
     if auth == constants.NO_AUTH:
         return None
-    else: 
+    else:
         full_class = conf.authenticators().get(auth)
         if full_class is None:
             raise BadUserConfigurationException(u"Auth '{}' not supported".format(auth))


### PR DESCRIPTION
### Description
For our usage, multiple users are grouped by teams and a user can view all the sessions of his team.
The `%%info` magic lists the active sessions returned by the livy server.
To facilitate the usage of sparkmagic, we added a new column in the `%%info` to display the owner of each session. 

### Checklist
- [X] Wrote a description of my changes above 
- [ ] Added a bullet point for my changes to the top of the `CHANGELOG.md` file
- [X] Added or modified unit tests to reflect my changes
- [X] Manually tested with a notebook
- [ ] If adding a feature, there is an example notebook and/or documentation in the `README.md` file
