### PR TITLE
Bump numpy version to 1.16.5

### DIFF
--- a/hdijupyterutils/requirements.txt
+++ b/hdijupyterutils/requirements.txt
@@ -5,7 +5,7 @@ ipywidgets>5.0.0
 ipykernel>=4.2.2
 jupyter>=1
 pandas>=0.17.1
-numpy
+numpy>=1.16.5
 notebook>=4.2
 # Work around broken-on-Python-2 pyrsistent release:
 pyrsistent < 0.17 ; python_version < '3.0'


### PR DESCRIPTION
### Description
[pandas 1.20.0 was released and bumps the minimum version for numpy](https://pandas.pydata.org/docs/whatsnew/v1.2.0.html) 

[The travis-ci virtualenv has numpy 1.16.4 already installed 
](https://travis-ci.org/github/jupyter-incubator/sparkmagic/jobs/751773838#L193)
```
Requirement already satisfied: numpy in /home/travis/virtualenv/python3.7.1/lib/python3.7/site-packages (from -r hdijupyterutils/requirements.txt (line 8)) (1.16.4)
```
See failed build: https://travis-ci.org/github/jupyter-incubator/sparkmagic/jobs/751773838
```
ERROR: pandas 1.2.0 has requirement numpy>=1.16.5, but you'll have numpy 1.16.4 which is incompatible.
```

### Checklist
- [x] Wrote a description of my changes above 
- [ ] Added a bullet point for my changes to the top of the `CHANGELOG.md` file
- [ ] Added or modified unit tests to reflect my changes
- [ ] Manually tested with a notebook
- [ ] If adding a feature, there is an example notebook and/or documentation in the `README.md` file
