### PR TITLE
Use Password Type Field For Passwords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## NEXT RELEASE
 
+* Update Endpoint widget to shield passwords when entering them in the ipywidget. Thanks @J0rg3M3nd3z @jodom961
+
 ## 0.18.0
 
 ### Updates

--- a/hdijupyterutils/hdijupyterutils/ipywidgetfactory.py
+++ b/hdijupyterutils/hdijupyterutils/ipywidgetfactory.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2015  aggftw@gmail.com
 # Distributed under the terms of the Modified BSD License.
 
-from ipywidgets import VBox, Output, Button, HTML, HBox, Dropdown, Checkbox, ToggleButtons, Text, Textarea, Tab
+from ipywidgets import VBox, Output, Button, HTML, HBox, Dropdown, Checkbox, ToggleButtons, Text, Textarea, Tab, Password
 
 
 class IpyWidgetFactory(object):
@@ -42,6 +42,10 @@ class IpyWidgetFactory(object):
     @staticmethod
     def get_text(**kwargs):
         return Text(**kwargs)
+
+    @staticmethod
+    def get_password(**kwargs):
+        return Password(**kwargs)
 
     @staticmethod
     def get_text_area(**kwargs):

--- a/sparkmagic/sparkmagic/auth/basic.py
+++ b/sparkmagic/sparkmagic/auth/basic.py
@@ -47,7 +47,7 @@ class Basic(HTTPBasicAuth, Authenticator):
             width=widget_width
         )
 
-        self.password_widget = ipywidget_factory.get_text(
+        self.password_widget = ipywidget_factory.get_password(
             description='Password:',
             value=self.password,
             width=widget_width


### PR DESCRIPTION
### Description
Allowing for the creation of a Password `ipywidget` in `ipywidgetfactory.py`, and using that in the Basic authentication type to not have plain text passwords.

### Checklist
- [x] Wrote a description of my changes above 
- [ ] Added a bullet point for my changes to the top of the `CHANGELOG.md` file
- [ ] Added or modified unit tests to reflect my changes
- [x] Manually tested with a notebook
- [ ] If adding a feature, there is an example notebook and/or documentation in the `README.md` file