### PR TITLE
Enhance configure magic to support endpoint overriding for issue 709

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## NEXT RELEASE
 
+* Enhance configure magic to support endpoint overriding.
+
 ## 0.18.0
 
 ### Updates


### PR DESCRIPTION
**Description**
Introduce an override type parameter for configure magic to
support changing the configuration at runtime. To avoid breaking
the default type is session_configs to ensure no behavior change.
Configure type could be kernel_python_credentials, kernel_scala_credentials,
authenticators etc. Also, after overriding the configuration,
refresh_configuration is called to reflect the configuration
changes.

**Motivation**

This change is to address the request:
https://github.com/jupyter-incubator/sparkmagic/issues/709

**Testing Done**

Added unit test cases and also manually test the endpoint
overriding in a notebook using following magic.

%%configure -f -t kernel_python_credentials
{"username": "billy", "base64_password": "d2VsY29tZTEyMw==", "url": "http://abc:8998", "auth": "Basic_Access"}

%%configure -f -t kernel_python_credentials
{"username": "", "password": "", "url": "http://abc:8998", "auth": "None"}

### Checklist
- [x] Wrote a description of my changes above 
- [x] Added a bullet point for my changes to the top of the `CHANGELOG.md` file
- [x] Added or modified unit tests to reflect my changes
- [x] Manually tested with a notebook
- [] If adding a feature, there is an example notebook and/or documentation in the `README.md` file (NA as not adding new feature)
