### PR TITLE
fix typo in ipython kernel example notebook

### DIFF
--- a/examples/Magics in IPython Kernel.ipynb
+++ b/examples/Magics in IPython Kernel.ipynb
@@ -11,7 +11,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## This notebook will demonstrate how we can use the spark magic to interspere our Python code with code that is running against a Spark cluster"
+    "## This notebook will demonstrate how we can use the spark magic to intersperse our Python code with code that is running against a Spark cluster"
    ]
   },
   {


### PR DESCRIPTION
### Description
fix typo "intersperse" in ipython kernel example notebook

### Checklist
- [x ] Wrote a description of my changes above 

(The rest are not applicable, so skipping)
- [ ] Added a bullet point for my changes to the top of the `CHANGELOG.md` file
- [ ] Added or modified unit tests to reflect my changes
- [ ] Manually tested with a notebook
- [ ] If adding a feature, there is an example notebook and/or documentation in the `README.md` file
