### PR TITLE
Issue-714: refactor get_text for base auth to get_pass in order to shield passwords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## NEXT RELEASE
 
+* Update Endpoint widget to shield passwords when entering them in the ipywidget 
+
 ## 0.18.0
 
 ### Updates

--- a/hdijupyterutils/hdijupyterutils/ipywidgetfactory.py
+++ b/hdijupyterutils/hdijupyterutils/ipywidgetfactory.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2015  aggftw@gmail.com
 # Distributed under the terms of the Modified BSD License.
 
-from ipywidgets import VBox, Output, Button, HTML, HBox, Dropdown, Checkbox, ToggleButtons, Text, Textarea, Tab
+from ipywidgets import VBox, Output, Button, HTML, HBox, Dropdown, Checkbox, Password, ToggleButtons, Text, Textarea, Tab
 
 
 class IpyWidgetFactory(object):
@@ -42,6 +42,10 @@ class IpyWidgetFactory(object):
     @staticmethod
     def get_text(**kwargs):
         return Text(**kwargs)
+    
+    @staticmethod
+    def get_pass(**kwargs):
+        return Password(**kwargs)
 
     @staticmethod
     def get_text_area(**kwargs):

--- a/sparkmagic/sparkmagic/auth/basic.py
+++ b/sparkmagic/sparkmagic/auth/basic.py
@@ -47,7 +47,7 @@ class Basic(HTTPBasicAuth, Authenticator):
             width=widget_width
         )
 
-        self.password_widget = ipywidget_factory.get_text(
+        self.password_widget = ipywidget_factory.get_pass(
             description='Password:',
             value=self.password,
             width=widget_width


### PR DESCRIPTION
### Description
Updates `get_text` to `get_password` for the basic auth connector for the endpoint widget. 
The update allows passwords to be shielded. 

https://github.com/jupyter-incubator/sparkmagic/issues/714

Updated Test of Password:
![image](https://user-images.githubusercontent.com/13648529/120524921-31570380-c39d-11eb-89e6-bab77a465399.png)

### Checklist
- [x] Wrote a description of my changes above 
- [x] Added a bullet point for my changes to the top of the `CHANGELOG.md` file
- [ ] Added or modified unit tests to reflect my changes
- [x] Manually tested with a notebook
- [x] If adding a feature, there is an example notebook and/or documentation in the `README.md` file
	- [x] Not applicable 	
