### PR TITLE
Added one internal magic to enable retry of session creation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## NEXT RELEASE
+### Features
+Added one internal magic to enable retry of session creation. 
 
 ## 0.18.0
 

--- a/sparkmagic/sparkmagic/kernels/kernelmagics.py
+++ b/sparkmagic/sparkmagic/kernels/kernelmagics.py
@@ -57,6 +57,7 @@ class KernelMagics(SparkMagicBase):
         self.language = u""
         self.endpoint = None
         self.fatal_error = False
+        self.allow_retry_fatal = False
         self.fatal_error_message = u""
         if spark_events is None:
             spark_events = SparkEvents()
@@ -347,17 +348,19 @@ class KernelMagics(SparkMagicBase):
         # No need to add the handle_expected_exceptions decorator to this since we manually catch all
         # exceptions when starting the session.
 
-        if self.fatal_error:
+        if self.fatal_error and not self.allow_retry_fatal:
             self.ipython_display.send_error(self.fatal_error_message)
             return False
 
         if not self.session_started:
             skip = False
             properties = conf.get_session_properties(self.language)
-            self.session_started = True
 
             try:
                 self.spark_controller.add_session(self.session_name, self.endpoint, skip, properties)
+                self.session_started = True
+                self.fatal_error = False
+                self.fatal_error_message = u""
             except Exception as e:
                 self.fatal_error = True
                 self.fatal_error_message = conf.fatal_error_suggestion().format(e)
@@ -370,6 +373,11 @@ class KernelMagics(SparkMagicBase):
                 return False
 
         return self.session_started
+
+    @cell_magic
+    def _do_not_call_allow_retry_fatal(self, line, cell="", local_ns=None):
+        # enable the flag to retry session creation
+        self.allow_retry_fatal = True
 
     @cell_magic
     @handle_expected_exceptions

--- a/sparkmagic/sparkmagic/livyclientlib/sparkcontroller.py
+++ b/sparkmagic/sparkmagic/livyclientlib/sparkcontroller.py
@@ -87,8 +87,8 @@ class SparkController(object):
             return
         http_client = self._http_client(endpoint)
         session = self._livy_session(http_client, properties, self.ipython_display)
-        self.session_manager.add_session(name, session)
         session.start()
+        self.session_manager.add_session(name, session)
 
     def get_session_id_for_client(self, name):
         return self.session_manager.get_session_id_for_client(name)

--- a/sparkmagic/sparkmagic/tests/test_kernel_magics.py
+++ b/sparkmagic/sparkmagic/tests/test_kernel_magics.py
@@ -84,7 +84,7 @@ def test_start_session_times_out():
     ret = magic._do_not_call_start_session(line)
 
     assert not ret
-    assert magic.session_started
+    assert not magic.session_started
     assert magic.fatal_error
     assert_equals(ipython_display.send_error.call_count, 1)
 
@@ -92,7 +92,7 @@ def test_start_session_times_out():
     ipython_display.send_error.reset_mock()
     ret = magic._do_not_call_start_session(line)
     assert not ret
-    assert magic.session_started
+    assert not magic.session_started
     assert_equals(ipython_display.send_error.call_count, 1)
 
 @with_setup(_setup, _teardown)
@@ -923,12 +923,70 @@ def test_start_session_displays_fatal_error_when_session_throws():
     magic.ipython_display = ipython_display
     magic.ipython_display.send_error = MagicMock()
 
-    magic._do_not_call_start_session("Test Line")
+    magic._do_not_call_start_session("")
 
     magic.spark_controller.add_session.assert_called_once_with(magic.session_name, magic.endpoint, False,
                                                                {"kind": constants.SESSION_KIND_SPARK})
     assert magic.fatal_error
     assert magic.fatal_error_message == conf.fatal_error_suggestion().format(str(e))
+
+
+@with_setup(_setup, _teardown)
+def test_start_session_when_retry_fatal_error_is_not_allowed_by_default():
+    e = ValueError("Failed to create the SqlContext.\nError, '{}'".format("Exception"))
+    magic.spark_controller.add_session = MagicMock(side_effect=e)
+    magic.language = constants.LANG_SCALA
+    magic.ipython_display = ipython_display
+    magic.ipython_display.send_error = MagicMock()
+
+    # first session creation
+    magic._do_not_call_start_session("")
+    # retry session creation
+    magic._do_not_call_start_session("")
+
+    # call add_session once and call send_error twice to show the error message
+    magic.spark_controller.add_session.assert_called_once_with(magic.session_name, magic.endpoint, False,
+                                                               {"kind": constants.SESSION_KIND_SPARK})
+    assert_equals(magic.ipython_display.send_error.call_count, 2)
+
+
+@with_setup(_setup, _teardown)
+def test_retry_start_session_when_retry_fatal_error_is_allowed():
+    e = ValueError("Failed to create the SqlContext.\nError, '{}'".format("Exception"))
+    magic.spark_controller.add_session = MagicMock(side_effect=e)
+    magic.language = constants.LANG_SCALA
+    magic.ipython_display = ipython_display
+    magic.ipython_display.send_error = MagicMock()
+    magic.allow_retry_fatal = True
+
+    # first session creation - failed
+    session_created = magic._do_not_call_start_session("")
+    magic.spark_controller.add_session.assert_called_once_with(magic.session_name, magic.endpoint, False,
+                                                               {"kind": constants.SESSION_KIND_SPARK})
+    assert not session_created
+    assert magic.fatal_error
+    assert magic.fatal_error_message == conf.fatal_error_suggestion().format(str(e))
+
+    # retry session creation - successful
+    magic.spark_controller.add_session = MagicMock()
+    session_created = magic._do_not_call_start_session("")
+    magic.spark_controller.add_session.assert_called_once_with(magic.session_name, magic.endpoint, False,
+                                                               {"kind": constants.SESSION_KIND_SPARK})
+    print(session_created)
+    assert session_created
+    assert magic.session_started
+    assert not magic.fatal_error
+    assert magic.fatal_error_message == u''
+
+    # show error message only once
+    assert magic.ipython_display.send_error.call_count == 1
+
+
+@with_setup(_setup, _teardown)
+def test_allow_retry_fatal():
+    assert not magic.allow_retry_fatal
+    magic._do_not_call_allow_retry_fatal("")
+    assert magic.allow_retry_fatal
 
 
 @with_setup(_setup, _teardown)

--- a/sparkmagic/sparkmagic/tests/test_sparkcontroller.py
+++ b/sparkmagic/sparkmagic/tests/test_sparkcontroller.py
@@ -259,3 +259,4 @@ def test_add_session_throws_when_session_start_fails():
     except ValueError as ex:
         assert str(ex) == str(e)
         session.start.assert_called_once()
+        controller.session_manager.add_session.assert_not_called


### PR DESCRIPTION
**Description**
Fix two issues:
1. the self.session_started[1] is set as true too early for exceptional case.
2. the session is added too early[2] before session is actually started.

Enhanced the magic kernel by adding one internal magic to allow retry session
creation. Currently, the session creation error is treated as fatal error which
make it impossible[3] to retry after fixing the endpoint info.

[1] https://github.com/jupyter-incubator/sparkmagic/blob/bfabbb39a0249197c2c05c8efe681710fff9151b/sparkmagic/sparkmagic/kernels/kernelmagics.py#L357
[2] https://github.com/jupyter-incubator/sparkmagic/blob/bfabbb39a0249197c2c05c8efe681710fff9151b/sparkmagic/sparkmagic/livyclientlib/sparkcontroller.py#L90
[3] https://github.com/jupyter-incubator/sparkmagic/blob/bfabbb39a0249197c2c05c8efe681710fff9151b/sparkmagic/sparkmagic/kernels/kernelmagics.py#L350

Please see the movitivation for our use cases.
**Motivation**
To enable user to choose an Spark cluster and connect to it at runtime(means the
sparkmagic configuration is not generated in advance), we need to configure the endpoint
after kernel starting and enable retry session creation after fixing the incorrect endpoint.

We discussed this with Alejandro(aggFTW@) and he suggested to leverage the following _do_not_call_*
methods to configure the endpoint dynamically and create session after specifying configuration.
1.    _do_not_call_delete_session
2.    _do_not_call_change_endpoint
3.    _do_not_call_start_session

To conditionally allow the session creation retry, the changes introduced a flag
to allow retry on previous fatal of session creation. By default, the behavior
is kept unchanged and do not allow retry on fatal.

**Testing Done**
1. Added unit test.
2. Also ran the code in a notebook to verify.

**Backwards Compatibility Criteria (if any)**
The enhancement is activated conditionally and no compatibility issue is expected.

### Checklist
- [x] Wrote a description of my changes above 
- [x] Added a bullet point for my changes to the top of the `CHANGELOG.md` file
- [x] Added or modified unit tests to reflect my changes
- [x] Manually tested with a notebook
- [-] If adding a feature, there is an example notebook and/or documentation in the `README.md` file (N/A as no user visible feature added. The internal magic is added for kernel integration purpose)
