### PR TITLE
Pin ipykernel<6.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## NEXT RELEASE
 
+### Bug Fixes
+
+* Pins `ipykernel<6.0.0` because of breaking changes
+
 ## 0.19.0
 
 ### Features

--- a/hdijupyterutils/requirements.txt
+++ b/hdijupyterutils/requirements.txt
@@ -2,7 +2,7 @@ ipython>=4.0.2
 nose
 mock
 ipywidgets>5.0.0
-ipykernel>=4.2.2
+ipykernel>=4.2.2<6.0.0
 jupyter>=1
 pandas>=0.17.1
 numpy>=1.16.5

--- a/hdijupyterutils/setup.py
+++ b/hdijupyterutils/setup.py
@@ -1,11 +1,11 @@
-DESCRIPTION         = "HdiJupyterUtils: Utils for Jupyter projects from HDInsight team"
-NAME                = "hdijupyterutils"
-PACKAGES            = ['hdijupyterutils']
-AUTHOR              = "Jupyter Development Team"
-AUTHOR_EMAIL        = "jupyter@googlegroups.org"
-URL                 = 'https://github.com/jupyter-incubator/sparkmagic/hdijupyterutils'
-DOWNLOAD_URL        = 'https://github.com/jupyter-incubator/sparkmagic/hdijupyterutils'
-LICENSE             = 'BSD 3-clause'
+DESCRIPTION = "HdiJupyterUtils: Utils for Jupyter projects from HDInsight team"
+NAME = "hdijupyterutils"
+PACKAGES = ["hdijupyterutils"]
+AUTHOR = "Jupyter Development Team"
+AUTHOR_EMAIL = "jupyter@googlegroups.org"
+URL = "https://github.com/jupyter-incubator/sparkmagic/hdijupyterutils"
+DOWNLOAD_URL = "https://github.com/jupyter-incubator/sparkmagic/hdijupyterutils"
+LICENSE = "BSD 3-clause"
 
 import io
 import os
@@ -14,7 +14,7 @@ import re
 from distutils.core import setup
 
 
-def read(path, encoding='utf-8'):
+def read(path, encoding="utf-8"):
     path = os.path.join(os.path.dirname(__file__), path)
     with io.open(path, encoding=encoding) as fp:
         return fp.read()
@@ -26,45 +26,45 @@ def version(path):
     See <https://packaging.python.org/en/latest/single_source_version.html>.
     """
     version_file = read(path)
-    version_match = re.search(r"""^__version__ = ['"]([^'"]*)['"]""",
-                              version_file, re.M)
+    version_match = re.search(
+        r"""^__version__ = ['"]([^'"]*)['"]""", version_file, re.M
+    )
     if version_match:
         return version_match.group(1)
     raise RuntimeError("Unable to find version string.")
 
 
-VERSION = version('hdijupyterutils/__init__.py')
+VERSION = version("hdijupyterutils/__init__.py")
 
 
-
-setup(name=NAME,
-      version=VERSION,
-      description=DESCRIPTION,
-      author=AUTHOR,
-      author_email=AUTHOR_EMAIL,
-      url=URL,
-      download_url=DOWNLOAD_URL,
-      license=LICENSE,
-      packages=PACKAGES,
-      classifiers=[
-        'Development Status :: 4 - Beta',
-        'Environment :: Console',
-        'Intended Audience :: Science/Research',
-        'License :: OSI Approved :: BSD License',
-        'Natural Language :: English',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7'],
-      install_requires=[
-          'ipython>=4.0.2',
-          'nose',
-          'mock',
-          'ipywidgets>5.0.0',
-          'ipykernel>=4.2.2',
-          'jupyter>=1',
-          'pandas>=0.17.1',
-          'numpy',
-          'notebook>=4.2',
-          # Work around broken-on-Python-2 pyrsistent release:
-          "pyrsistent < 0.17 ; python_version < '3.0'",
-      ])
+setup(
+    name=NAME,
+    version=VERSION,
+    description=DESCRIPTION,
+    author=AUTHOR,
+    author_email=AUTHOR_EMAIL,
+    url=URL,
+    download_url=DOWNLOAD_URL,
+    license=LICENSE,
+    packages=PACKAGES,
+    classifiers=[
+        "Development Status :: 4 - Beta",
+        "Environment :: Console",
+        "Intended Audience :: Science/Research",
+        "License :: OSI Approved :: BSD License",
+        "Natural Language :: English",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+    ],
+    install_requires=[
+        "ipython>=4.0.2",
+        "nose",
+        "mock",
+        "ipywidgets>5.0.0",
+        "ipykernel>=4.2.2<6.0.0",
+        "jupyter>=1",
+        "pandas>=0.17.1",
+        "numpy",
+        "notebook>=4.2",
+    ],
+)

--- a/sparkmagic/requirements.txt
+++ b/sparkmagic/requirements.txt
@@ -6,7 +6,7 @@ mock
 pandas>=0.17.1
 numpy
 requests
-ipykernel>=4.2.2
+ipykernel>=4.2.2<6.0.0
 ipywidgets>5.0.0
 notebook>=4.2
 tornado>=4

--- a/sparkmagic/setup.py
+++ b/sparkmagic/setup.py
@@ -1,22 +1,24 @@
-DESCRIPTION         = "SparkMagic: Spark execution via Livy"
-NAME                = "sparkmagic"
-PACKAGES            = ['sparkmagic',
-                       'sparkmagic/controllerwidget',
-                       'sparkmagic/kernels',
-                       'sparkmagic/livyclientlib',
-                       'sparkmagic/auth',
-                       'sparkmagic/magics',
-                       'sparkmagic/kernels/pysparkkernel',
-                       'sparkmagic/kernels/sparkkernel',
-                       'sparkmagic/kernels/sparkrkernel',
-                       'sparkmagic/kernels/wrapperkernel',
-                       'sparkmagic/utils',
-                       'sparkmagic/serverextension']
-AUTHOR              = "Jupyter Development Team"
-AUTHOR_EMAIL        = "jupyter@googlegroups.org"
-URL                 = 'https://github.com/jupyter-incubator/sparkmagic'
-DOWNLOAD_URL        = 'https://github.com/jupyter-incubator/sparkmagic'
-LICENSE             = 'BSD 3-clause'
+DESCRIPTION = "SparkMagic: Spark execution via Livy"
+NAME = "sparkmagic"
+PACKAGES = [
+    "sparkmagic",
+    "sparkmagic/controllerwidget",
+    "sparkmagic/kernels",
+    "sparkmagic/livyclientlib",
+    "sparkmagic/auth",
+    "sparkmagic/magics",
+    "sparkmagic/kernels/pysparkkernel",
+    "sparkmagic/kernels/sparkkernel",
+    "sparkmagic/kernels/sparkrkernel",
+    "sparkmagic/kernels/wrapperkernel",
+    "sparkmagic/utils",
+    "sparkmagic/serverextension",
+]
+AUTHOR = "Jupyter Development Team"
+AUTHOR_EMAIL = "jupyter@googlegroups.org"
+URL = "https://github.com/jupyter-incubator/sparkmagic"
+DOWNLOAD_URL = "https://github.com/jupyter-incubator/sparkmagic"
+LICENSE = "BSD 3-clause"
 
 import io
 import os
@@ -25,7 +27,7 @@ import re
 from distutils.core import setup
 
 
-def read(path, encoding='utf-8'):
+def read(path, encoding="utf-8"):
     path = os.path.join(os.path.dirname(__file__), path)
     with io.open(path, encoding=encoding) as fp:
         return fp.read()
@@ -37,55 +39,60 @@ def version(path):
     See <https://packaging.python.org/en/latest/single_source_version.html>.
     """
     version_file = read(path)
-    version_match = re.search(r"""^__version__ = ['"]([^'"]*)['"]""",
-                              version_file, re.M)
+    version_match = re.search(
+        r"""^__version__ = ['"]([^'"]*)['"]""", version_file, re.M
+    )
     if version_match:
         return version_match.group(1)
     raise RuntimeError("Unable to find version string.")
 
 
-VERSION = version('sparkmagic/__init__.py')
+VERSION = version("sparkmagic/__init__.py")
 
 
-
-setup(name=NAME,
-      version=VERSION,
-      description=DESCRIPTION,
-      author=AUTHOR,
-      author_email=AUTHOR_EMAIL,
-      url=URL,
-      download_url=DOWNLOAD_URL,
-      license=LICENSE,
-      packages=PACKAGES,
-      include_package_data=True,
-      package_data={'sparkmagic': ['kernels/pysparkkernel/kernel.js',
-				   'kernels/sparkkernel/kernel.js',
-				   'kernels/sparkrkernel/kernel.js',
-                                   'kernels/pysparkkernel/kernel.json',
-				   'kernels/sparkkernel/kernel.json',
-				   'kernels/sparkrkernel/kernel.json']},
-      classifiers=[
-        'Development Status :: 4 - Beta',
-        'Environment :: Console',
-        'Intended Audience :: Science/Research',
-        'License :: OSI Approved :: BSD License',
-        'Natural Language :: English',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7'],
-      install_requires=[
-          'hdijupyterutils>=0.6',
-          'autovizwidget>=0.6',
-          'ipython>=4.0.2',
-          'nose',
-          'mock',
-          'pandas>=0.17.1',
-          'numpy',
-          'requests',
-          'ipykernel',  # Python 2 will automatically get 4.10
-          'ipywidgets>5.0.0',
-          'notebook>=4.2',
-          'tornado>=4',
-          'requests_kerberos>=0.8.0'
-      ])
-
+setup(
+    name=NAME,
+    version=VERSION,
+    description=DESCRIPTION,
+    author=AUTHOR,
+    author_email=AUTHOR_EMAIL,
+    url=URL,
+    download_url=DOWNLOAD_URL,
+    license=LICENSE,
+    packages=PACKAGES,
+    include_package_data=True,
+    package_data={
+        "sparkmagic": [
+            "kernels/pysparkkernel/kernel.js",
+            "kernels/sparkkernel/kernel.js",
+            "kernels/sparkrkernel/kernel.js",
+            "kernels/pysparkkernel/kernel.json",
+            "kernels/sparkkernel/kernel.json",
+            "kernels/sparkrkernel/kernel.json",
+        ]
+    },
+    classifiers=[
+        "Development Status :: 4 - Beta",
+        "Environment :: Console",
+        "Intended Audience :: Science/Research",
+        "License :: OSI Approved :: BSD License",
+        "Natural Language :: English",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+    ],
+    install_requires=[
+        "hdijupyterutils>=0.6",
+        "autovizwidget>=0.6",
+        "ipython>=4.0.2",
+        "nose",
+        "mock",
+        "pandas>=0.17.1",
+        "numpy",
+        "requests",
+        "ipykernel<6.0.0",
+        "ipywidgets>5.0.0",
+        "notebook>=4.2",
+        "tornado>=4",
+        "requests_kerberos>=0.8.0",
+    ],
+)


### PR DESCRIPTION
Closes #492 

### Description
<!-- FILL IN -->

Changes to the async behavior in [IPykernel >=6.0.0](https://github.com/ipython/ipykernel/releases) causes connection issues with the Sparkmagic (Py)Spark kernels. This pins the dependency while I find the root cause of the breaking change. 

- Pins `ipykernel<6.0.0`
- Removes more references to Python 2
- Runs `black` formatter

### Checklist
- [x] Wrote a description of my changes above 
- [x] Added a bullet point for my changes to the top of the `CHANGELOG.md` file
- [x] Manually tested with a notebook
