### PR TITLE
Add comma to setup file

### DIFF
--- a/hdijupyterutils/requirements.txt
+++ b/hdijupyterutils/requirements.txt
@@ -2,7 +2,7 @@ ipython>=4.0.2
 nose
 mock
 ipywidgets>5.0.0
-ipykernel>=4.2.2<6.0.0
+ipykernel>=4.2.2, <6.0.0
 jupyter>=1
 pandas>=0.17.1
 numpy>=1.16.5

--- a/hdijupyterutils/setup.py
+++ b/hdijupyterutils/setup.py
@@ -61,7 +61,7 @@ setup(
         "nose",
         "mock",
         "ipywidgets>5.0.0",
-        "ipykernel>=4.2.2<6.0.0",
+        "ipykernel>=4.2.2,<6.0.0",
         "jupyter>=1",
         "pandas>=0.17.1",
         "numpy",

--- a/sparkmagic/requirements.txt
+++ b/sparkmagic/requirements.txt
@@ -6,7 +6,7 @@ mock
 pandas>=0.17.1
 numpy
 requests
-ipykernel>=4.2.2<6.0.0
+ipykernel>=4.2.2, <6.0.0
 ipywidgets>5.0.0
 notebook>=4.2
 tornado>=4


### PR DESCRIPTION
### Description
Following this [documentation](https://docs.python.org/3/distutils/setupscript.html#relationships-between-distributions-and-packages) a comma is required to have the expected requirement. Fixes #733

### Checklist
- [x] Wrote a description of my changes above 
- [ ] Added a bullet point for my changes to the top of the `CHANGELOG.md` file
- [ ] Added or modified unit tests to reflect my changes
- [ ] Manually tested with a notebook
- [ ] If adding a feature, there is an example notebook and/or documentation in the `README.md` file
