### PR TITLE
WIP: Add Connection Info Line Magic

### DIFF
--- a/sparkmagic/sparkmagic/magics/sparkmagicsbase.py
+++ b/sparkmagic/sparkmagic/magics/sparkmagicsbase.py
@@ -15,7 +15,7 @@ from collections import namedtuple
 import sparkmagic.utils.configuration as conf
 from sparkmagic.utils.sparklogger import SparkLog
 from sparkmagic.utils.sparkevents import SparkEvents
-from sparkmagic.utils.utils import get_sessions_info_html
+from sparkmagic.utils.utils import get_connection_info_html, get_sessions_info_html
 from sparkmagic.utils.constants import MIMETYPE_TEXT_HTML 
 from sparkmagic.livyclientlib.sparkcontroller import SparkController
 from sparkmagic.livyclientlib.sqlquery import SQLQuery
@@ -128,6 +128,13 @@ class SparkMagicBase(Magics):
         if info_sessions:
             info_sessions = sorted(info_sessions, key=lambda s: s.id)
             html = get_sessions_info_html(info_sessions, current_session_id)
+            self.ipython_display.html(html)
+        else:
+            self.ipython_display.html(u'No active sessions.')
+
+    def _print_current_connection_info(self, connection_info):
+        if connection_info.get("endpoint"):
+            html = get_connection_info_html(connection_info)
             self.ipython_display.html(html)
         else:
             self.ipython_display.html(u'No active sessions.')

--- a/sparkmagic/sparkmagic/utils/utils.py
+++ b/sparkmagic/sparkmagic/utils/utils.py
@@ -94,6 +94,15 @@ def get_sessions_info_html(info_sessions, current_session_id):
 
     return html
 
+
+def get_connection_info_html(connection_info):
+    html = u"""<table>
+<tr><th>endpoint</th><th>session</th></tr>""" + \
+    u"""<tr><td>{0}</td><td>{1}</td></tr>""".format(connection_info["endpoint"], connection_info["session"]) + \
+    u"</table>"
+
+    return html
+
 def initialize_auth(args):
     """Creates an authenticatior class instance for the given auth type
 


### PR DESCRIPTION
### Description
This PR is WIP -- unit tests coming shortly, wanted to sanity check the general approach and see if this makes sense at all. The motivation is this issue: https://github.com/jupyter-incubator/sparkmagic/issues/468

It adds a `%connection_info` line magic that prints the current endpoint and session id, or (more importantly) returns them as a dict when the -o option is used:

```
{
	"endpoint": "http://<ip>:8998",
	"session": "<session_id>"
}
```

The idea here is enabling users to use the livy API with the current session. There are some livy endpoints, like the one to upload code packages, that aren't part of sparkmagic (as far as I can tell) and there could always be more in the future. It could be useful to make the connection info available in code so users can make calls to them.

While `%%info` nicely formats and prints a lot of this information I can't get the information in code, which means I couldn't use it programmatically and have to copy paste from the `%%info` output.

### Checklist
- [ ] Wrote a description of my changes above 
- [ ] Added a bullet point for my changes to the top of the `CHANGELOG.md` file
- [ ] Added or modified unit tests to reflect my changes
- [ ] Manually tested with a notebook
- [ ] If adding a feature, there is an example notebook and/or documentation in the `README.md` file
