### PR TITLE
Correct missing syntax in Pyspark example notebook

### DIFF
--- a/examples/Pyspark Kernel.ipynb
+++ b/examples/Pyspark Kernel.ipynb
@@ -136,7 +136,8 @@
       ]
      },
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "execute_result",
+     "execution_count": 1
     }
    ],
    "source": [
@@ -167,7 +168,8 @@
       ]
      },
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "execute_result",
+     "execution_count": 1
     },
     {
      "data": {
@@ -179,7 +181,8 @@
       ]
      },
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "execute_result",
+     "execution_count": 1
     }
    ],
    "source": [
@@ -224,7 +227,8 @@
       ]
      },
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "execute_result",
+     "execution_count": 1
     },
     {
      "data": {
@@ -236,7 +240,8 @@
       ]
      },
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "execute_result",
+     "execution_count": 1
     }
    ],
    "source": [


### PR DESCRIPTION
### Description
Fixes [examples/Pyspark Kernel.ipynb](https://github.com/jupyter-incubator/sparkmagic/blob/ac0852cbe88a41faa368cf1e1c89045a2de973bf/examples/Pyspark%20Kernel.ipynb), so that it will render in github / nbviewer. Addresses https://github.com/jupyter-incubator/sparkmagic/issues/707

### Checklist
- [x] Wrote a description of my changes above 
- [ ] Added a bullet point for my changes to the top of the `CHANGELOG.md` file
- [ ] Added or modified unit tests to reflect my changes
- [ ] Manually tested with a notebook
- [ ] If adding a feature, there is an example notebook and/or documentation in the `README.md` file
