### PR TITLE
Add ipython<8 to hdijupyterutils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## NEXT RELEASE
 
+### Bug Fixes
+
+* Pins `ipython<8.0.0` because of breaking changes. Thanks @utkarshgupta137
+
 ## 0.19.1
 
 ### Bug Fixes

--- a/hdijupyterutils/setup.py
+++ b/hdijupyterutils/setup.py
@@ -57,7 +57,7 @@ setup(
         "Programming Language :: Python :: 3.7",
     ],
     install_requires=[
-        "ipython>=4.0.2",
+        "ipython>=4.0.2,<8",
         "nose",
         "mock",
         "ipywidgets>5.0.0",


### PR DESCRIPTION
### Description
Add ipython<8 to hdijupyterutils. See https://github.com/jupyter-incubator/sparkmagic/issues/747

### Checklist
- [x] Wrote a description of my changes above 
- [ ] Added a bullet point for my changes to the top of the `CHANGELOG.md` file
- [ ] Added or modified unit tests to reflect my changes
- [x] Manually tested with a notebook
- [ ] If adding a feature, there is an example notebook and/or documentation in the `README.md` file
