### PR TITLE
Drop Support for Python 3.6

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
 
     steps:
       - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## NEXT RELEASE
 
+### Updates
+
+* Officially drop support for Python 3.6. Sparkmagic will not guarantee Python 3.6 compatibility moving forward.
+
 ## 0.19.2
 
 ### Bug Fixes

--- a/autovizwidget/setup.py
+++ b/autovizwidget/setup.py
@@ -26,7 +26,7 @@ def read(path, encoding="utf-8"):
 
 
 def version(path):
-    """Obtain the package version from a python file e.g. pkg/__init__.py
+    """Obtain the package version from a python file e.g. pkg/__init__.py.
 
     See <https://packaging.python.org/en/latest/single_source_version.html>.
     """
@@ -58,8 +58,6 @@ setup(
         "Intended Audience :: Science/Research",
         "License :: OSI Approved :: BSD License",
         "Natural Language :: English",
-        "Programming Language :: Python :: 2.7",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
     ],
     install_requires=[

--- a/hdijupyterutils/requirements.txt
+++ b/hdijupyterutils/requirements.txt
@@ -7,5 +7,3 @@ jupyter>=1
 pandas>=0.17.1
 numpy>=1.16.5
 notebook>=4.2
-# Work around broken-on-Python-2 pyrsistent release:
-pyrsistent < 0.17 ; python_version < '3.0'

--- a/hdijupyterutils/setup.py
+++ b/hdijupyterutils/setup.py
@@ -53,7 +53,6 @@ setup(
         "Intended Audience :: Science/Research",
         "License :: OSI Approved :: BSD License",
         "Natural Language :: English",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
     ],
     install_requires=[

--- a/sparkmagic/setup.py
+++ b/sparkmagic/setup.py
@@ -34,7 +34,7 @@ def read(path, encoding="utf-8"):
 
 
 def version(path):
-    """Obtain the package version from a python file e.g. pkg/__init__.py
+    """Obtain the package version from a python file e.g. pkg/__init__.py.
 
     See <https://packaging.python.org/en/latest/single_source_version.html>.
     """
@@ -77,7 +77,6 @@ setup(
         "Intended Audience :: Science/Research",
         "License :: OSI Approved :: BSD License",
         "Natural Language :: English",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
     ],
     install_requires=[


### PR DESCRIPTION
### Description
As of December 17, 2021 - Python 3.6 is no longer being supported. I'll add CI support for 3.10 in a follow up PR.

### Checklist
- [x] Wrote a description of my changes above 
- [x] Added a bullet point for my changes to the top of the `CHANGELOG.md` file
- [x] Added or modified unit tests to reflect my changes
