### PR TITLE
Simplify and Speed up Docker Images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * Officially drop support for Python 3.6. Sparkmagic will not guarantee Python 3.6 compatibility moving forward.
 
+### Bug Fixes
+
+* Fixed, simplified, and sped up the sparkmagic Docker images for local development and testing
+
 ## 0.19.2
 
 ### Bug Fixes

--- a/Dockerfile.jupyter
+++ b/Dockerfile.jupyter
@@ -25,9 +25,9 @@ RUN chown -R $NB_USER .
 
 USER $NB_USER
 RUN if [ "$dev_mode" = "true" ]; then \
-      cd hdijupyterutils && pip install . && cd ../ && \
-      cd autovizwidget && pip install . && cd ../ && \
-      cd sparkmagic && pip install . && cd ../ ; \
+      cd hdijupyterutils && pip install -e . && cd ../ && \
+      cd autovizwidget && pip install -e . && cd ../ && \
+      cd sparkmagic && pip install -e . && cd ../ ; \
     else pip install sparkmagic ; fi
 
 RUN mkdir /home/$NB_USER/.sparkmagic
@@ -41,9 +41,7 @@ RUN jupyter serverextension enable --py sparkmagic
 
 USER root
 RUN chown $NB_USER /home/$NB_USER/.sparkmagic/config.json
-RUN rm -rf hdijupyterutils/ autovizwidget/ sparkmagic/
 
 CMD ["start-notebook.sh", "--NotebookApp.iopub_data_rate_limit=1000000000"]
 
 USER $NB_USER
-

--- a/Dockerfile.spark
+++ b/Dockerfile.spark
@@ -1,63 +1,48 @@
-FROM debian:stretch
+# Pin to Spark 2.x for Scala 2.11 (https://issues.apache.org/jira/browse/LIVY-423) 
+FROM datamechanics/spark:2.4.7-hadoop-3.1.0-java-8-scala-2.11-python-3.7-latest
 
+# Use root user for development. This shouldn't be used in production.
+USER 0
+
+# ----------
+# Setup Python and Livy/Spark Deps
+#
+# Livy Requires:
+# - mvn (from maven package or maven3 tarball)
+# - openjdk-8-jdk (or Oracle JDK 8)
+# - Python 2.7+
+# - R 3.x
 RUN apt-get update && apt-get install -yq --no-install-recommends --force-yes \
     curl \
     git \
-    openjdk-8-jdk \
-    maven \
-    python2.7 python2.7-setuptools \
-    python3 python3-setuptools \
+    python3 python3-setuptools python3-venv python3-pip \
     r-base \
     r-base-core && \
     rm -rf /var/lib/apt/lists/*
-
-# Install pip for Python3
-RUN easy_install3 pip py4j
-RUN pip install --upgrade setuptools
 
 ENV PYTHONHASHSEED 0
 ENV PYTHONIOENCODING UTF-8
 ENV PIP_DISABLE_PIP_VERSION_CHECK 1
 
-ENV SPARK_BUILD_VERSION 2.3.3
-ENV SPARK_HOME /apps/spark-$SPARK_BUILD_VERSION
-ENV SPARK_BUILD_PATH /apps/build/spark
-RUN mkdir -p /apps/build && \
-  cd /apps/build && \
-  git clone https://github.com/apache/spark.git spark && \
-  cd $SPARK_BUILD_PATH && \
-  git checkout v$SPARK_BUILD_VERSION && \
-  dev/make-distribution.sh --name spark-$SPARK_BUILD_VERSION -Phive -Phive-thriftserver -Pyarn && \
-  cp -r /apps/build/spark/dist $SPARK_HOME && \
-  rm -rf $SPARK_BUILD_PATH
-
 # ----------
 # Build Livy
 # ----------
-ENV LIVY_BUILD_VERSION 0.6.0-incubating
-ENV LIVY_APP_PATH /apps/apache-livy-$LIVY_BUILD_VERSION-bin
-ENV LIVY_BUILD_PATH /apps/build/livy
+ARG LIVY_VERSION=0.7.1-incubating
+ENV LIVY_HOME /usr/livy
+ENV LIVY_CONF_DIR "${LIVY_HOME}/conf"
+ENV LIVY_PORT 8998
 
-# Install setuptools for Python 2.7 for Livy
-RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
-    python get-pip.py --user && \
-    rm get-pip.py && \
-    python -m pip install --upgrade setuptools
-
-RUN cd /apps/build && \
-	git clone https://github.com/apache/incubator-livy.git livy && \
-	cd $LIVY_BUILD_PATH && \
-  git checkout v$LIVY_BUILD_VERSION-rc2 && \
-    mvn -DskipTests -Dspark.version=$SPARK_BUILD_VERSION clean package && \
-    ls -al $LIVY_BUILD_PATH && ls -al $LIVY_BUILD_PATH/assembly && ls -al $LIVY_BUILD_PATH/assembly/target && \
-    unzip $LIVY_BUILD_PATH/assembly/target/apache-livy-${LIVY_BUILD_VERSION}-bin.zip -d /apps && \
-    rm -rf $LIVY_BUILD_PATH && \
-	mkdir -p $LIVY_APP_PATH/upload && \
-  mkdir -p $LIVY_APP_PATH/logs
-
-RUN pip install matplotlib
-RUN pip install pandas
+RUN curl --progress-bar -L --retry 3 \
+    "http://archive.apache.org/dist/incubator/livy/${LIVY_VERSION}/apache-livy-${LIVY_VERSION}-bin.zip" \
+    -o "./apache-livy-${LIVY_VERSION}-bin.zip" \
+  && unzip -qq "./apache-livy-${LIVY_VERSION}-bin.zip" -d /usr \
+  && mv "/usr/apache-livy-${LIVY_VERSION}-bin" "${LIVY_HOME}" \
+  && rm -rf "./apache-livy-${LIVY_VERSION}-bin.zip" \
+  && mkdir "${LIVY_HOME}/logs" \
+  && chown -R root:root "${LIVY_HOME}"
 
 EXPOSE 8998
 
-CMD $LIVY_APP_PATH/bin/livy-server
+HEALTHCHECK CMD curl -f "http://host.docker.internal:${LIVY_PORT}/" || exit 1
+
+CMD ${LIVY_HOME}/bin/livy-server

--- a/README.md
+++ b/README.md
@@ -204,8 +204,8 @@ In order to use it, make sure you have [Docker](https://docker.com) and
 [Docker Compose](https://docs.docker.com/compose/) both installed, and
 then simply run:
 
-    docker-compose build
-    docker-compose up
+    docker compose build
+    docker compose up
 
 You will then be able to access the Jupyter notebook in your browser at
 http://localhost:8888. Inside this notebook, you can configure a
@@ -213,16 +213,15 @@ sparkmagic endpoint at http://spark:8998. This endpoint is able to
 launch both Scala and Python sessions. You can also choose to start a
 wrapper kernel for Scala, Python, or R from the list of kernels.
 
-To shut down the containers, you can interrupt `docker-compose` with
-`Ctrl-C`, and optionally remove the containers with `docker-compose
+To shut down the containers, you can interrupt `docker compose` with
+`Ctrl-C`, and optionally remove the containers with `docker compose
 down`.
 
 If you are developing sparkmagic and want to test out your changes in
 the Docker container without needing to push a version to PyPI, you can
 set the `dev_mode` build arg in `docker-compose.yml` to `true`, and then
 re-build the container. This will cause the container to install your
-local version of autovizwidget, hdijupyterutils, and sparkmagic. Make
-sure to re-run `docker-compose build` before each test run.
+local version of autovizwidget, hdijupyterutils, and sparkmagic. The local packages are installed with the editable flag, meaning you can make edits directly to the libraries within the Jupyterlab docker service to debug issues in realtime. To make local changes available in Jupyterlab, make  sure to re-run `docker compose build` before spinning up the services.
 
 ## Server extension API
 


### PR DESCRIPTION
### Description
<!-- FILL IN -->
Simplifies `Docker.spark` to use an upstream pre-built image from [Data Mechanics](https://hub.docker.com/r/datamechanics/spark). It also uses a pre-built distribution of Apache Livy `0.7.1` rather than building it from scratch within the image. 

Hopefully this improves the development experience for contributors in the future. 

Thanks @jpugliesi for the help.

### Checklist
- [x] Wrote a description of my changes above 
- [x] Added a bullet point for my changes to the top of the `CHANGELOG.md` file
- [ ] Added or modified unit tests to reflect my changes
- [x] Manually tested with a notebook
- [x] If adding a feature, there is an example notebook and/or documentation in the `README.md` file
