### PR TITLE
Change import paths for dataerror

### DIFF
--- a/autovizwidget/autovizwidget/plotlygraphs/graphbase.py
+++ b/autovizwidget/autovizwidget/plotlygraphs/graphbase.py
@@ -4,7 +4,13 @@
 from plotly.graph_objs import Figure, Layout
 from plotly.offline import iplot
 
-from pandas.errors import DataError
+try:
+    from pandas.core.base import DataError
+except ImportError:
+    try:
+        from pandas.core.groupby import DataError
+    except ImportError:
+        from pandas.errors import DataError
 
 
 from ..widget.encoding import Encoding

--- a/autovizwidget/autovizwidget/plotlygraphs/graphbase.py
+++ b/autovizwidget/autovizwidget/plotlygraphs/graphbase.py
@@ -4,10 +4,8 @@
 from plotly.graph_objs import Figure, Layout
 from plotly.offline import iplot
 
-try:
-    from pandas.core.base import DataError
-except:
-    from pandas.core.groupby import DataError
+from pandas.errors import DataError
+
 
 from ..widget.encoding import Encoding
 from ..widget.invalidencodingerror import InvalidEncodingError

--- a/autovizwidget/autovizwidget/plotlygraphs/piegraph.py
+++ b/autovizwidget/autovizwidget/plotlygraphs/piegraph.py
@@ -4,7 +4,13 @@
 from plotly.graph_objs import Pie, Figure
 from plotly.offline import iplot
 
-from pandas.errors import DataError
+try:
+    from pandas.core.base import DataError
+except ImportError:
+    try:
+        from pandas.core.groupby import DataError
+    except ImportError:
+        from pandas.errors import DataError
 
 import autovizwidget.utils.configuration as conf
 from .graphbase import GraphBase

--- a/autovizwidget/autovizwidget/plotlygraphs/piegraph.py
+++ b/autovizwidget/autovizwidget/plotlygraphs/piegraph.py
@@ -4,10 +4,7 @@
 from plotly.graph_objs import Pie, Figure
 from plotly.offline import iplot
 
-try:
-    from pandas.core.base import DataError
-except:
-    from pandas.core.groupby import DataError
+from pandas.errors import DataError
 
 import autovizwidget.utils.configuration as conf
 from .graphbase import GraphBase


### PR DESCRIPTION
### Description
Fixes import paths after pandas latest release (1.5.0)
DataError is now in `pandas.errors` change [here](https://github.com/pandas-dev/pandas/pull/47047/files)
### Checklist
- [x] Wrote a description of my changes above 
- [x] Formatted my code with [`black`](https://black.readthedocs.io/en/stable/index.html)
- [ ] Added a bullet point for my changes to the top of the `CHANGELOG.md` file
- [ ] Added or modified unit tests to reflect my changes
- [x] Manually tested with a notebook
- [ ] If adding a feature, there is an example notebook and/or documentation in the `README.md` file
