### PR TITLE
feat: add ci to verify docker build is reliable

### DIFF
--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -1,0 +1,22 @@
+name: Build Docker Image
+
+on: [push]
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      -
+        name: Run docker compose build
+        run: |
+          docker compose build


### PR DESCRIPTION
### Description
<!-- FILL IN -->
We want new users to be able to reliably build the Sparkmagic example Docker images. Right now, we have no integration tests using the Docker images, so the only failures are reported by users. 

This adds CI to ensure the Docker image always builds. In the future, we can add CI to actually run the images and run integration tests against it. 

Relates to #789 and #791 

### Checklist
- [x] Wrote a description of my changes above 
- [x] Formatted my code with [`black`](https://black.readthedocs.io/en/stable/index.html)
- [ ] Added a bullet point for my changes to the top of the `CHANGELOG.md` file
- [ ] Added or modified unit tests to reflect my changes
- [ ] Manually tested with a notebook
- [ ] If adding a feature, there is an example notebook and/or documentation in the `README.md` file
