### PR TITLE
refactor: use requirements.txt for install_requires

### DIFF
--- a/autovizwidget/setup.py
+++ b/autovizwidget/setup.py
@@ -25,6 +25,14 @@ def read(path, encoding="utf-8"):
         return fp.read()
 
 
+# read requirements.txt and convert to install_requires format
+def requirements(path):
+    lines = read(path).splitlines()
+    # remove comments and empty lines
+    lines = [line for line in lines if not line.startswith("#") and line]
+    return lines
+
+
 def version(path):
     """Obtain the package version from a python file e.g. pkg/__init__.py.
 
@@ -60,11 +68,5 @@ setup(
         "Natural Language :: English",
         "Programming Language :: Python :: 3.7",
     ],
-    install_requires=[
-        "plotly>=3",
-        "ipywidgets>5.0.0",
-        "hdijupyterutils>=0.6",
-        "notebook>=4.2",
-        "pandas>=0.20.1",
-    ],
+    install_requires=requirements("requirements.txt"),
 )

--- a/hdijupyterutils/setup.py
+++ b/hdijupyterutils/setup.py
@@ -20,6 +20,14 @@ def read(path, encoding="utf-8"):
         return fp.read()
 
 
+# read requirements.txt and convert to install_requires format
+def requirements(path):
+    lines = read(path).splitlines()
+    # remove comments and empty lines
+    lines = [line for line in lines if not line.startswith("#") and line]
+    return lines
+
+
 def version(path):
     """Obtain the package version from a python file e.g. pkg/__init__.py.
 
@@ -35,7 +43,6 @@ def version(path):
 
 
 VERSION = version("hdijupyterutils/__init__.py")
-
 
 setup(
     name=NAME,
@@ -55,15 +62,5 @@ setup(
         "Natural Language :: English",
         "Programming Language :: Python :: 3.7",
     ],
-    install_requires=[
-        "ipython>=5",
-        "nose",
-        "mock",
-        "ipywidgets>5.0.0",
-        "ipykernel>=4.2.2",
-        "jupyter>=1",
-        "pandas>=0.17.1",
-        "numpy",
-        "notebook>=4.2",
-    ],
+    install_requires=requirements("requirements.txt"),
 )

--- a/sparkmagic/setup.py
+++ b/sparkmagic/setup.py
@@ -33,6 +33,14 @@ def read(path, encoding="utf-8"):
         return fp.read()
 
 
+# read requirements.txt and convert to install_requires format
+def requirements(path):
+    lines = read(path).splitlines()
+    # remove comments and empty lines
+    lines = [line for line in lines if not line.startswith("#") and line]
+    return lines
+
+
 def version(path):
     """Obtain the package version from a python file e.g. pkg/__init__.py.
 
@@ -79,20 +87,5 @@ setup(
         "Natural Language :: English",
         "Programming Language :: Python :: 3.7",
     ],
-    install_requires=[
-        "hdijupyterutils>=0.6",
-        "autovizwidget>=0.6",
-        "ipython>=5",
-        "nose",
-        "mock",
-        "pandas>=0.17.1",
-        "numpy",
-        "requests",
-        "ipykernel>=4.2.2",
-        "ipywidgets>5.0.0",
-        "notebook>=4.2",
-        "tornado>=4",
-        "requests_kerberos>=0.8.0",
-        "nest_asyncio==1.5.5",
-    ],
+    install_requires=requirements("requirements.txt"),
 )


### PR DESCRIPTION
### Description
Not sure when this duplication was introduced, but this makes `requirements.txt` the source of truth for package `install_requires`

### Checklist
- [x] Wrote a description of my changes above 
- [x] Formatted my code with [`black`](https://black.readthedocs.io/en/stable/index.html)
- [ ] Added a bullet point for my changes to the top of the `CHANGELOG.md` file
- [ ] Added or modified unit tests to reflect my changes
- [x] Manually tested with a notebook
- [ ] If adding a feature, there is an example notebook and/or documentation in the `README.md` file
