### PR TITLE
refactor(tests): migrate from nose to pytest

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install package dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pytest
+          pip install pytest mock
           pip install -r hdijupyterutils/requirements.txt -e hdijupyterutils
           pip install -r autovizwidget/requirements.txt -e autovizwidget
           pip install -r sparkmagic/requirements.txt -e sparkmagic

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,16 +26,17 @@ jobs:
       - name: Install package dependencies
         run: |
           python -m pip install --upgrade pip
+          pip install pytest
           pip install -r hdijupyterutils/requirements.txt -e hdijupyterutils
           pip install -r autovizwidget/requirements.txt -e autovizwidget
           pip install -r sparkmagic/requirements.txt -e sparkmagic
       - name: Run hdijupyterutils tests
         run: |
-          nosetests hdijupyterutils
+          pytest hdijupyterutils
       - name: Run autovizwidget tests
         run: |
-          nosetests autovizwidget
+          pytest autovizwidget
       - name: Run sparkmagic tests
         run: |
           mkdir ~/.sparkmagic
-          nosetests sparkmagic
+          pytest sparkmagic

--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ To dev install, execute the following:
 and optionally follow steps 3 and 4 above.
 
 To run unit tests, run:
-
-        nosetests hdijupyterutils autovizwidget sparkmagic
-
+```bash
+pytest
+```
 If you want to see an enhancement made but don't have time to work on it yourself, feel free to submit an [issue](https://github.com/jupyter-incubator/sparkmagic/issues) for us to deal with.

--- a/autovizwidget/autovizwidget/tests/test_autovizwidget.py
+++ b/autovizwidget/autovizwidget/tests/test_autovizwidget.py
@@ -1,5 +1,4 @@
 from mock import MagicMock, call
-from nose.tools import with_setup, assert_equals
 import pandas as pd
 from pandas.testing import assert_frame_equal, assert_series_equal
 
@@ -17,7 +16,7 @@ ipython_display = None
 spark_events = None
 
 
-def _setup():
+def setup_function():
     global renderer, df, encoding, encoding_widget, output, ipywidget_factory, ipython_display, spark_events
 
     renderer = MagicMock()
@@ -49,11 +48,10 @@ def _setup():
     spark_events = MagicMock()
 
 
-def _teardown():
+def teardown_function():
     pass
 
 
-@with_setup(_setup, _teardown)
 def test_on_render_viz():
     widget = AutoVizWidget(
         df,
@@ -69,10 +67,10 @@ def test_on_render_viz():
     # on_render_viz is called in the constructor, so no need to call it here.
     output.clear_output.assert_called_once_with()
 
-    assert_equals(len(renderer.render.mock_calls), 1)
-    assert_equals(len(renderer.render.mock_calls[0]), 3)
-    assert_equals(renderer.render.mock_calls[0][1][1], encoding)
-    assert_equals(renderer.render.mock_calls[0][1][2], output)
+    assert len(renderer.render.mock_calls) == 1
+    assert len(renderer.render.mock_calls[0]) == 3
+    assert renderer.render.mock_calls[0][1][1] == encoding
+    assert renderer.render.mock_calls[0][1][2] == output
     assert_frame_equal(renderer.render.mock_calls[0][1][0], df)
 
     encoding_widget.show_x.assert_called_once_with(True)
@@ -85,14 +83,12 @@ def test_on_render_viz():
 
     encoding._chart_type = Encoding.chart_type_scatter
     widget.on_render_viz()
-    assert_equals(len(spark_events.emit_graph_render_event.mock_calls), 2)
-    assert_equals(
-        spark_events.emit_graph_render_event.call_args,
-        call(Encoding.chart_type_scatter),
+    assert len(spark_events.emit_graph_render_event.mock_calls) == 2
+    assert spark_events.emit_graph_render_event.call_args == call(
+        Encoding.chart_type_scatter
     )
 
 
-@with_setup(_setup, _teardown)
 def test_create_viz_types_buttons():
     df_single_column = pd.DataFrame([{"buildingID": 0}])
     widget = AutoVizWidget(
@@ -163,7 +159,6 @@ def test_create_viz_types_buttons():
     )
 
 
-@with_setup(_setup, _teardown)
 def test_create_viz_empty_df():
     df = pd.DataFrame([])
     widget = AutoVizWidget(
@@ -183,7 +178,6 @@ def test_create_viz_empty_df():
     spark_events.emit_graph_render_event.assert_called_once_with(encoding.chart_type)
 
 
-@with_setup(_setup, _teardown)
 def test_convert_to_displayable_dataframe():
     bool_df = pd.DataFrame(
         [
@@ -207,8 +201,8 @@ def test_convert_to_displayable_dataframe():
     assert_frame_equal(bool_df, copy_of_df)
     assert_series_equal(bool_df["int_col"], result["int_col"])
     assert_series_equal(bool_df["float_col"], result["float_col"])
-    assert_equals(result.dtypes["bool_col"], object)
-    assert_equals(len(result["bool_col"]), 2)
-    assert_equals(result["bool_col"][0], "True")
-    assert_equals(result["bool_col"][1], "False")
+    assert result.dtypes["bool_col"] == object
+    assert len(result["bool_col"]) == 2
+    assert result["bool_col"][0] == "True"
+    assert result["bool_col"][1] == "False"
     spark_events.emit_graph_render_event.assert_called_once_with(encoding.chart_type)

--- a/autovizwidget/autovizwidget/tests/test_encodingwidget.py
+++ b/autovizwidget/autovizwidget/tests/test_encodingwidget.py
@@ -1,5 +1,4 @@
 from mock import MagicMock, call
-from nose.tools import with_setup
 from ipywidgets import Widget
 import pandas as pd
 
@@ -13,7 +12,7 @@ ipywidget_factory = None
 change_hook = None
 
 
-def _setup():
+def setup_function():
     global df, encoding, ipywidget_factory, change_hook
 
     records = [
@@ -34,11 +33,10 @@ def _setup():
     change_hook = MagicMock()
 
 
-def _teardown():
+def teardown_function():
     pass
 
 
-@with_setup(_setup, _teardown)
 def test_encoding_with_all_none_doesnt_throw():
     records = [
         {"buildingID": 0, "date": "6/1/13", "temp_diff": 12},
@@ -100,7 +98,6 @@ def test_encoding_with_all_none_doesnt_throw():
     )
 
 
-@with_setup(_setup, _teardown)
 def test_value_for_aggregation():
     widget = EncodingWidget(df, encoding, change_hook, ipywidget_factory, testing=True)
 
@@ -108,7 +105,6 @@ def test_value_for_aggregation():
     assert widget._get_value_for_aggregation("avg") == "avg"
 
 
-@with_setup(_setup, _teardown)
 def test_x_changed_callback():
     widget = EncodingWidget(df, encoding, change_hook, ipywidget_factory, testing=True)
 
@@ -118,7 +114,6 @@ def test_x_changed_callback():
     assert change_hook.call_count == 1
 
 
-@with_setup(_setup, _teardown)
 def test_y_changed_callback():
     widget = EncodingWidget(df, encoding, change_hook, ipywidget_factory, testing=True)
 
@@ -128,7 +123,6 @@ def test_y_changed_callback():
     assert change_hook.call_count == 1
 
 
-@with_setup(_setup, _teardown)
 def test_y_agg__changed_callback():
     widget = EncodingWidget(df, encoding, change_hook, ipywidget_factory, testing=True)
 
@@ -138,7 +132,6 @@ def test_y_agg__changed_callback():
     assert change_hook.call_count == 1
 
 
-@with_setup(_setup, _teardown)
 def test_log_x_changed_callback():
     widget = EncodingWidget(df, encoding, change_hook, ipywidget_factory, testing=True)
 
@@ -148,7 +141,6 @@ def test_log_x_changed_callback():
     assert change_hook.call_count == 1
 
 
-@with_setup(_setup, _teardown)
 def test_log_y_changed_callback():
     widget = EncodingWidget(df, encoding, change_hook, ipywidget_factory, testing=True)
 

--- a/autovizwidget/autovizwidget/tests/test_sparkevents.py
+++ b/autovizwidget/autovizwidget/tests/test_sparkevents.py
@@ -1,6 +1,5 @@
 from hdijupyterutils.constants import INSTANCE_ID, EVENT_NAME, TIMESTAMP
 from hdijupyterutils.utils import get_instance_id
-from nose.tools import with_setup, raises
 from mock import MagicMock
 
 from autovizwidget.utils.events import AutoVizEvents
@@ -8,7 +7,7 @@ from autovizwidget.utils.constants import GRAPH_RENDER_EVENT, GRAPH_TYPE
 import autovizwidget.utils.configuration as conf
 
 
-def _setup():
+def setup_function():
     global events, time_stamp
 
     events = AutoVizEvents()
@@ -17,11 +16,10 @@ def _setup():
     time_stamp = events.get_utc_date_time()
 
 
-def _teardown():
+def teardown_function():
     conf.override_all({})
 
 
-@with_setup(_setup, _teardown)
 def test_not_emit_graph_render_event_when_not_registered():
     event_name = GRAPH_RENDER_EVENT
     graph_type = "Bar"
@@ -39,7 +37,6 @@ def test_not_emit_graph_render_event_when_not_registered():
     assert not events.handler.handle_event.called
 
 
-@with_setup(_setup, _teardown)
 def test_emit_graph_render_event_when_registered():
     conf.override(conf.events_handler.__name__, events.handler)
     event_name = GRAPH_RENDER_EVENT

--- a/autovizwidget/autovizwidget/tests/test_utils.py
+++ b/autovizwidget/autovizwidget/tests/test_utils.py
@@ -1,4 +1,3 @@
-from nose.tools import with_setup
 import pandas as pd
 
 from ..widget import utils as utils
@@ -9,7 +8,7 @@ df = None
 encoding = None
 
 
-def _setup():
+def setup_function():
     global df, encoding
 
     records = [
@@ -61,11 +60,10 @@ def _setup():
     encoding = Encoding(chart_type="table", x="date", y="temp_diff")
 
 
-def _teardown():
+def teardown_function():
     pass
 
 
-@with_setup(_setup, _teardown)
 def test_on_render_viz():
     df["date"] = pd.to_datetime(df["date"])
     df["mystr2"] = pd.to_numeric(df["mystr2"])

--- a/codecoverage.bat
+++ b/codecoverage.bat
@@ -1,1 +1,0 @@
-nosetests --with-coverage --cover-erase --cover-package=sparkmagic

--- a/codecoverage.sh
+++ b/codecoverage.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-nosetests --with-coverage --cover-erase --cover-package=sparkmagic

--- a/hdijupyterutils/hdijupyterutils/tests/test_configuration.py
+++ b/hdijupyterutils/hdijupyterutils/tests/test_configuration.py
@@ -1,6 +1,4 @@
 from mock import MagicMock
-from nose.tools import assert_equals, assert_not_equals, raises, with_setup
-import json
 
 from hdijupyterutils.configuration import override, override_all, with_override
 
@@ -36,43 +34,39 @@ def my_config_2():
 
 
 # Test helper functions
-def _setup():
+def setup_function():
     module_override_all({})
 
 
-def _teardown():
+def teardown_function():
     module_override_all({})
 
 
 # Unit tests begin
-@with_setup(_setup, _teardown)
 def test_original_value_without_overrides():
-    assert_equals(original_value, my_config())
+    assert original_value == my_config()
 
 
-@with_setup(_setup, _teardown)
 def test_original_value_with_overrides():
     new_value = 2
     module_override(my_config.__name__, new_value)
-    assert_equals(new_value, my_config())
+    assert new_value == my_config()
 
 
-@with_setup(_setup, _teardown)
 def test_original_values_when_others_override():
     new_value = 2
     module_override(my_config.__name__, new_value)
-    assert_equals(new_value, my_config())
-    assert_equals(original_value, my_config_2())
+    assert new_value == my_config()
+    assert original_value == my_config_2()
 
 
-@with_setup(_setup, _teardown)
 def test_resetting_values_when_others_override():
     new_value = 2
     module_override(my_config.__name__, new_value)
-    assert_equals(new_value, my_config())
-    assert_equals(original_value, my_config_2())
+    assert new_value == my_config()
+    assert original_value == my_config_2()
 
     # Reset
     module_override_all({})
-    assert_equals(original_value, my_config())
-    assert_equals(original_value, my_config_2())
+    assert original_value == my_config()
+    assert original_value == my_config_2()

--- a/hdijupyterutils/hdijupyterutils/tests/test_events.py
+++ b/hdijupyterutils/hdijupyterutils/tests/test_events.py
@@ -1,4 +1,4 @@
-from nose.tools import with_setup, raises
+import pytest
 from mock import MagicMock
 
 from hdijupyterutils.events import Events
@@ -7,7 +7,7 @@ from hdijupyterutils.constants import INSTANCE_ID, TIMESTAMP
 from hdijupyterutils.utils import get_instance_id
 
 
-def _setup():
+def setup_function():
     global events, guid1, guid2, guid3, time_stamp
 
     events = Events(MagicMock())
@@ -18,11 +18,10 @@ def _setup():
     guid3 = generate_uuid()
 
 
-def _teardown():
+def teardown_function():
     pass
 
 
-@with_setup(_setup, _teardown)
 def test_send_to_handler():
     kwargs_list = [(TIMESTAMP, time_stamp)]
     expected_kwargs_list = [(INSTANCE_ID, get_instance_id())] + kwargs_list
@@ -32,25 +31,8 @@ def test_send_to_handler():
     events.handler.handle_event.assert_called_once_with(expected_kwargs_list)
 
 
-@with_setup(_setup, _teardown)
-@raises(AssertionError)
 def test_send_to_handler_asserts_less_than_12():
-    kwargs_list = [
-        (TIMESTAMP, time_stamp),
-        (TIMESTAMP, time_stamp),
-        (TIMESTAMP, time_stamp),
-        (TIMESTAMP, time_stamp),
-        (TIMESTAMP, time_stamp),
-        (TIMESTAMP, time_stamp),
-        (TIMESTAMP, time_stamp),
-        (TIMESTAMP, time_stamp),
-        (TIMESTAMP, time_stamp),
-        (TIMESTAMP, time_stamp),
-        (TIMESTAMP, time_stamp),
-        (TIMESTAMP, time_stamp),
-        (TIMESTAMP, time_stamp),
-    ]
-
-    events.send_to_handler(kwargs_list)
-
-    assert False
+    with pytest.raises(AssertionError):
+        kwargs_list = [(TIMESTAMP, time_stamp)] * 13
+        events.send_to_handler(kwargs_list)
+        assert False

--- a/hdijupyterutils/hdijupyterutils/tests/test_logger.py
+++ b/hdijupyterutils/hdijupyterutils/tests/test_logger.py
@@ -1,6 +1,5 @@
 # coding=utf-8
 import logging
-from nose.tools import assert_equals
 
 from hdijupyterutils.log import Log, logging_config
 
@@ -46,7 +45,7 @@ def test_log_returnvalue():
     mock = logger.logger
     logger.debug("word1")
     assert mock.level == "DEBUG"
-    assert_equals(mock.message, "test2\tword1")
+    assert mock.message == "test2\tword1"
     logger.error("word2")
     assert mock.level == "ERROR"
     assert mock.message == "test2\tword2"

--- a/hdijupyterutils/requirements.txt
+++ b/hdijupyterutils/requirements.txt
@@ -1,6 +1,4 @@
 ipython>=4.0.2
-nose
-mock
 ipywidgets>5.0.0
 ipykernel>=4.2.2
 jupyter>=1

--- a/sparkmagic/requirements.txt
+++ b/sparkmagic/requirements.txt
@@ -1,8 +1,6 @@
 hdijupyterutils>=0.6
 autovizwidget>=0.6
 ipython>=4.0.2
-nose
-mock
 pandas>=0.17.1
 numpy
 requests

--- a/sparkmagic/sparkmagic/tests/test_command.py
+++ b/sparkmagic/sparkmagic/tests/test_command.py
@@ -2,7 +2,7 @@ import sys
 from base64 import b64encode
 from contextlib import contextmanager
 from mock import MagicMock
-from nose.tools import assert_equals, with_setup
+import pytest
 
 from IPython.display import Image
 
@@ -29,7 +29,7 @@ else:
     assert False
 
 
-def _setup():
+def setup_function():
     conf.override_all({})
 
 
@@ -60,7 +60,6 @@ def _capture_stderr():
         sys.stderr = sys.__stderr__
 
 
-@with_setup(_setup)
 def test_execute():
     spark_events = MagicMock()
     kind = SESSION_KIND_SPARK
@@ -78,8 +77,8 @@ def test_execute():
     http_client.post_statement.assert_called_with(0, {"code": command.code})
     http_client.get_statement.assert_called_with(0, 0)
     assert result[0]
-    assert_equals(tls.TestLivySession.pi_result, result[1])
-    assert_equals(MIMETYPE_TEXT_PLAIN, result[2])
+    assert tls.TestLivySession.pi_result == result[1]
+    assert MIMETYPE_TEXT_PLAIN == result[2]
     spark_events.emit_statement_execution_start_event.assert_called_once_with(
         session.guid, session.kind, session.id, command.guid
     )
@@ -101,7 +100,7 @@ def test_execute():
     assert result[0]
     assert isinstance(result[1], Image)
     assert result[1].data == b"hello"
-    assert_equals(MIMETYPE_IMAGE_PNG, result[2])
+    assert MIMETYPE_IMAGE_PNG == result[2]
 
     # Now try with HTML result:
     http_client.get_statement.return_value = {
@@ -115,11 +114,10 @@ def test_execute():
     }
     result = command.execute(session)
     assert result[0]
-    assert_equals("<p>out</p>", result[1])
-    assert_equals(MIMETYPE_TEXT_HTML, result[2])
+    assert "<p>out</p>" == result[1]
+    assert MIMETYPE_TEXT_HTML == result[2]
 
 
-@with_setup(_setup)
 def test_execute_waiting():
     spark_events = MagicMock()
     kind = SESSION_KIND_SPARK
@@ -142,8 +140,8 @@ def test_execute_waiting():
     http_client.post_statement.assert_called_with(0, {"code": command.code})
     http_client.get_statement.assert_called_with(0, 0)
     assert result[0]
-    assert_equals(tls.TestLivySession.pi_result, result[1])
-    assert_equals(MIMETYPE_TEXT_PLAIN, result[2])
+    assert tls.TestLivySession.pi_result == result[1]
+    assert MIMETYPE_TEXT_PLAIN == result[2]
     spark_events.emit_statement_execution_start_event.assert_called_once_with(
         session.guid, session.kind, session.id, command.guid
     )
@@ -152,7 +150,6 @@ def test_execute_waiting():
     )
 
 
-@with_setup(_setup)
 def test_execute_null_ouput():
     spark_events = MagicMock()
     kind = SESSION_KIND_SPARK
@@ -172,8 +169,8 @@ def test_execute_null_ouput():
     http_client.post_statement.assert_called_with(0, {"code": command.code})
     http_client.get_statement.assert_called_with(0, 0)
     assert result[0]
-    assert_equals("", result[1])
-    assert_equals(MIMETYPE_TEXT_PLAIN, result[2])
+    assert "" == result[1]
+    assert MIMETYPE_TEXT_PLAIN == result[2]
     spark_events.emit_statement_execution_start_event.assert_called_once_with(
         session.guid, session.kind, session.id, command.guid
     )
@@ -182,7 +179,6 @@ def test_execute_null_ouput():
     )
 
 
-@with_setup(_setup)
 def test_execute_failure_wait_for_session_emits_event():
     spark_events = MagicMock()
     kind = SESSION_KIND_SPARK
@@ -213,10 +209,9 @@ def test_execute_failure_wait_for_session_emits_event():
             "ValueError",
             "yo",
         )
-        assert_equals(e, session.wait_for_idle.side_effect)
+        assert e == session.wait_for_idle.side_effect
 
 
-@with_setup(_setup)
 def test_execute_failure_post_statement_emits_event():
     spark_events = MagicMock()
     kind = SESSION_KIND_SPARK
@@ -246,10 +241,9 @@ def test_execute_failure_post_statement_emits_event():
             "KeyError",
             "Something bad happened here",
         )
-        assert_equals(e, http_client.post_statement.side_effect)
+        assert e == http_client.post_statement.side_effect
 
 
-@with_setup(_setup)
 def test_execute_failure_get_statement_output_emits_event():
     spark_events = MagicMock()
     kind = SESSION_KIND_SPARK
@@ -280,10 +274,9 @@ def test_execute_failure_get_statement_output_emits_event():
             "AttributeError",
             "OHHHH",
         )
-        assert_equals(e, command._get_statement_output.side_effect)
+        assert e == command._get_statement_output.side_effect
 
 
-@with_setup(_setup)
 def test_execute_interrupted():
     spark_events = MagicMock()
     kind = SESSION_KIND_SPARK
@@ -318,7 +311,7 @@ def test_execute_interrupted():
             "",
         )
         assert isinstance(e, SparkStatementCancelledException)
-        assert_equals(str(e), COMMAND_INTERRUPTED_MSG)
+        assert str(e) == COMMAND_INTERRUPTED_MSG
 
         # Test patching _showtraceback()
         assert mock_ipython._showtraceback is SparkStatementCancelledException._show_tb
@@ -333,7 +326,7 @@ def test_execute_interrupted():
                 SparkStatementCancelledException, COMMAND_INTERRUPTED_MSG, MagicMock()
             )
             mock_show_tb.assert_called_once()  # still once
-            assert_equals(stderr.getvalue().strip(), COMMAND_INTERRUPTED_MSG)
+            assert stderr.getvalue().strip() == COMMAND_INTERRUPTED_MSG
 
     except:
         assert False

--- a/sparkmagic/sparkmagic/tests/test_configurableretrypolicy.py
+++ b/sparkmagic/sparkmagic/tests/test_configurableretrypolicy.py
@@ -1,5 +1,3 @@
-from nose.tools import assert_equals
-
 from sparkmagic.livyclientlib.configurableretrypolicy import ConfigurableRetryPolicy
 import sparkmagic.utils.configuration as conf
 from sparkmagic.livyclientlib.exceptions import BadUserConfigurationException
@@ -10,24 +8,24 @@ def test_with_empty_list():
     max_retries = 5
     policy = ConfigurableRetryPolicy(times, max_retries)
 
-    assert_equals(5, policy.seconds_to_sleep(0))
-    assert_equals(5, policy.seconds_to_sleep(4))
-    assert_equals(5, policy.seconds_to_sleep(5))
-    assert_equals(5, policy.seconds_to_sleep(6))
+    assert 5 == policy.seconds_to_sleep(0)
+    assert 5 == policy.seconds_to_sleep(4)
+    assert 5 == policy.seconds_to_sleep(5)
+    assert 5 == policy.seconds_to_sleep(6)
 
     # Check based on retry count
-    assert_equals(True, policy.should_retry(500, False, 0))
-    assert_equals(True, policy.should_retry(500, False, 4))
-    assert_equals(True, policy.should_retry(500, False, 5))
-    assert_equals(False, policy.should_retry(500, False, 6))
+    assert True is policy.should_retry(500, False, 0)
+    assert True is policy.should_retry(500, False, 4)
+    assert True is policy.should_retry(500, False, 5)
+    assert False is policy.should_retry(500, False, 6)
 
     # Check based on status code
-    assert_equals(False, policy.should_retry(201, False, 0))
-    assert_equals(False, policy.should_retry(201, False, 6))
+    assert False is policy.should_retry(201, False, 0)
+    assert False is policy.should_retry(201, False, 6)
 
     # Check based on error
-    assert_equals(True, policy.should_retry(201, True, 0))
-    assert_equals(True, policy.should_retry(201, True, 6))
+    assert True is policy.should_retry(201, True, 0)
+    assert True is policy.should_retry(201, True, 6)
 
 
 def test_with_one_element_list():
@@ -35,24 +33,24 @@ def test_with_one_element_list():
     max_retries = 5
     policy = ConfigurableRetryPolicy(times, max_retries)
 
-    assert_equals(2, policy.seconds_to_sleep(0))
-    assert_equals(2, policy.seconds_to_sleep(4))
-    assert_equals(2, policy.seconds_to_sleep(5))
-    assert_equals(2, policy.seconds_to_sleep(6))
+    assert 2 == policy.seconds_to_sleep(0)
+    assert 2 == policy.seconds_to_sleep(4)
+    assert 2 == policy.seconds_to_sleep(5)
+    assert 2 == policy.seconds_to_sleep(6)
 
     # Check based on retry count
-    assert_equals(True, policy.should_retry(500, False, 0))
-    assert_equals(True, policy.should_retry(500, False, 4))
-    assert_equals(True, policy.should_retry(500, False, 5))
-    assert_equals(False, policy.should_retry(500, False, 6))
+    assert True is policy.should_retry(500, False, 0)
+    assert True is policy.should_retry(500, False, 4)
+    assert True is policy.should_retry(500, False, 5)
+    assert False is policy.should_retry(500, False, 6)
 
     # Check based on status code
-    assert_equals(False, policy.should_retry(201, False, 0))
-    assert_equals(False, policy.should_retry(201, False, 6))
+    assert False is policy.should_retry(201, False, 0)
+    assert False is policy.should_retry(201, False, 6)
 
     # Check based on error
-    assert_equals(True, policy.should_retry(201, True, 0))
-    assert_equals(True, policy.should_retry(201, True, 6))
+    assert True is policy.should_retry(201, True, 0)
+    assert True is policy.should_retry(201, True, 6)
 
 
 def test_with_default_values():
@@ -60,30 +58,30 @@ def test_with_default_values():
     max_retries = conf.configurable_retry_policy_max_retries()
     policy = ConfigurableRetryPolicy(times, max_retries)
 
-    assert_equals(times[0], policy.seconds_to_sleep(0))
-    assert_equals(times[0], policy.seconds_to_sleep(1))
-    assert_equals(times[1], policy.seconds_to_sleep(2))
-    assert_equals(times[2], policy.seconds_to_sleep(3))
-    assert_equals(times[3], policy.seconds_to_sleep(4))
-    assert_equals(times[4], policy.seconds_to_sleep(5))
-    assert_equals(times[4], policy.seconds_to_sleep(6))
-    assert_equals(times[4], policy.seconds_to_sleep(7))
-    assert_equals(times[4], policy.seconds_to_sleep(8))
-    assert_equals(times[4], policy.seconds_to_sleep(9))
+    assert times[0] == policy.seconds_to_sleep(0)
+    assert times[0] == policy.seconds_to_sleep(1)
+    assert times[1] == policy.seconds_to_sleep(2)
+    assert times[2] == policy.seconds_to_sleep(3)
+    assert times[3] == policy.seconds_to_sleep(4)
+    assert times[4] == policy.seconds_to_sleep(5)
+    assert times[4] == policy.seconds_to_sleep(6)
+    assert times[4] == policy.seconds_to_sleep(7)
+    assert times[4] == policy.seconds_to_sleep(8)
+    assert times[4] == policy.seconds_to_sleep(9)
 
     # Check based on retry count
-    assert_equals(True, policy.should_retry(500, False, 0))
-    assert_equals(True, policy.should_retry(500, False, 7))
-    assert_equals(True, policy.should_retry(500, False, 8))
-    assert_equals(False, policy.should_retry(500, False, 9))
+    assert True is policy.should_retry(500, False, 0)
+    assert True is policy.should_retry(500, False, 7)
+    assert True is policy.should_retry(500, False, 8)
+    assert False is policy.should_retry(500, False, 9)
 
     # Check based on status code
-    assert_equals(False, policy.should_retry(201, False, 0))
-    assert_equals(False, policy.should_retry(201, False, 9))
+    assert False is policy.should_retry(201, False, 0)
+    assert False is policy.should_retry(201, False, 9)
 
     # Check based on error
-    assert_equals(True, policy.should_retry(201, True, 0))
-    assert_equals(True, policy.should_retry(201, True, 9))
+    assert True is policy.should_retry(201, True, 0)
+    assert True is policy.should_retry(201, True, 9)
 
 
 def test_with_negative_values():

--- a/sparkmagic/sparkmagic/tests/test_configuration.py
+++ b/sparkmagic/sparkmagic/tests/test_configuration.py
@@ -1,6 +1,5 @@
+import pytest
 from mock import MagicMock
-from nose.tools import raises
-import json
 
 import sparkmagic.utils.configuration as conf
 from sparkmagic.livyclientlib.exceptions import BadUserConfigurationException
@@ -96,13 +95,13 @@ def test_configuration_override_work_with_empty_password():
     }
 
 
-@raises(BadUserConfigurationException)
 def test_configuration_raise_error_for_bad_base64_password():
-    kpc = {"username": "U", "base64_password": "P", "url": "L"}
-    overrides = {conf.kernel_python_credentials.__name__: kpc}
-    conf.override_all(overrides)
-    conf.override(conf.livy_session_startup_timeout_seconds.__name__, 1)
-    conf.base64_kernel_python_credentials()
+    with pytest.raises(BadUserConfigurationException):
+        kpc = {"username": "U", "base64_password": "P", "url": "L"}
+        overrides = {conf.kernel_python_credentials.__name__: kpc}
+        conf.override_all(overrides)
+        conf.override(conf.livy_session_startup_timeout_seconds.__name__, 1)
+        conf.base64_kernel_python_credentials()
 
 
 def test_share_config_between_pyspark_and_pyspark3():

--- a/sparkmagic/sparkmagic/tests/test_configuration.py
+++ b/sparkmagic/sparkmagic/tests/test_configuration.py
@@ -1,5 +1,5 @@
 from mock import MagicMock
-from nose.tools import assert_equals, assert_not_equals, raises, with_setup
+from nose.tools import raises
 import json
 
 import sparkmagic.utils.configuration as conf
@@ -7,11 +7,10 @@ from sparkmagic.livyclientlib.exceptions import BadUserConfigurationException
 from sparkmagic.utils.constants import AUTH_BASIC, NO_AUTH
 
 
-def _setup():
+def setup_function():
     conf.override_all({})
 
 
-@with_setup(_setup)
 def test_configuration_override_base64_password():
     kpc = {
         "username": "U",
@@ -23,60 +22,56 @@ def test_configuration_override_base64_password():
     overrides = {conf.kernel_python_credentials.__name__: kpc}
     conf.override_all(overrides)
     conf.override(conf.livy_session_startup_timeout_seconds.__name__, 1)
-    assert_equals(
-        conf.d,
-        {
-            conf.kernel_python_credentials.__name__: kpc,
-            conf.livy_session_startup_timeout_seconds.__name__: 1,
-        },
-    )
-    assert_equals(conf.livy_session_startup_timeout_seconds(), 1)
-    assert_equals(
-        conf.base64_kernel_python_credentials(),
-        {"username": "U", "password": "password", "url": "L", "auth": AUTH_BASIC},
-    )
+    assert conf.d == {
+        conf.kernel_python_credentials.__name__: kpc,
+        conf.livy_session_startup_timeout_seconds.__name__: 1,
+    }
+    assert conf.livy_session_startup_timeout_seconds() == 1
+    assert conf.base64_kernel_python_credentials() == {
+        "username": "U",
+        "password": "password",
+        "url": "L",
+        "auth": AUTH_BASIC,
+    }
 
 
-@with_setup(_setup)
 def test_configuration_auth_missing_basic_auth():
     kpc = {"username": "U", "password": "P", "url": "L"}
     overrides = {conf.kernel_python_credentials.__name__: kpc}
     conf.override_all(overrides)
-    assert_equals(
-        conf.base64_kernel_python_credentials(),
-        {"username": "U", "password": "P", "url": "L", "auth": AUTH_BASIC},
-    )
+    assert conf.base64_kernel_python_credentials() == {
+        "username": "U",
+        "password": "P",
+        "url": "L",
+        "auth": AUTH_BASIC,
+    }
 
 
-@with_setup(_setup)
 def test_configuration_auth_missing_no_auth():
     kpc = {"username": "", "password": "", "url": "L"}
     overrides = {conf.kernel_python_credentials.__name__: kpc}
     conf.override_all(overrides)
-    assert_equals(
-        conf.base64_kernel_python_credentials(),
-        {"username": "", "password": "", "url": "L", "auth": NO_AUTH},
-    )
+    assert conf.base64_kernel_python_credentials() == {
+        "username": "",
+        "password": "",
+        "url": "L",
+        "auth": NO_AUTH,
+    }
 
 
-@with_setup(_setup)
 def test_configuration_override_fallback_to_password():
     kpc = {"username": "U", "password": "P", "url": "L", "auth": NO_AUTH}
     overrides = {conf.kernel_python_credentials.__name__: kpc}
     conf.override_all(overrides)
     conf.override(conf.livy_session_startup_timeout_seconds.__name__, 1)
-    assert_equals(
-        conf.d,
-        {
-            conf.kernel_python_credentials.__name__: kpc,
-            conf.livy_session_startup_timeout_seconds.__name__: 1,
-        },
-    )
-    assert_equals(conf.livy_session_startup_timeout_seconds(), 1)
-    assert_equals(conf.base64_kernel_python_credentials(), kpc)
+    assert conf.d == {
+        conf.kernel_python_credentials.__name__: kpc,
+        conf.livy_session_startup_timeout_seconds.__name__: 1,
+    }
+    assert conf.livy_session_startup_timeout_seconds() == 1
+    assert conf.base64_kernel_python_credentials() == kpc
 
 
-@with_setup(_setup)
 def test_configuration_override_work_with_empty_password():
     kpc = {
         "username": "U",
@@ -88,22 +83,20 @@ def test_configuration_override_work_with_empty_password():
     overrides = {conf.kernel_python_credentials.__name__: kpc}
     conf.override_all(overrides)
     conf.override(conf.livy_session_startup_timeout_seconds.__name__, 1)
-    assert_equals(
-        conf.d,
-        {
-            conf.kernel_python_credentials.__name__: kpc,
-            conf.livy_session_startup_timeout_seconds.__name__: 1,
-        },
-    )
-    assert_equals(conf.livy_session_startup_timeout_seconds(), 1)
-    assert_equals(
-        conf.base64_kernel_python_credentials(),
-        {"username": "U", "password": "", "url": "", "auth": AUTH_BASIC},
-    )
+    assert conf.d == {
+        conf.kernel_python_credentials.__name__: kpc,
+        conf.livy_session_startup_timeout_seconds.__name__: 1,
+    }
+    assert conf.livy_session_startup_timeout_seconds() == 1
+    assert conf.base64_kernel_python_credentials() == {
+        "username": "U",
+        "password": "",
+        "url": "",
+        "auth": AUTH_BASIC,
+    }
 
 
 @raises(BadUserConfigurationException)
-@with_setup(_setup)
 def test_configuration_raise_error_for_bad_base64_password():
     kpc = {"username": "U", "base64_password": "P", "url": "L"}
     overrides = {conf.kernel_python_credentials.__name__: kpc}
@@ -112,7 +105,6 @@ def test_configuration_raise_error_for_bad_base64_password():
     conf.base64_kernel_python_credentials()
 
 
-@with_setup(_setup)
 def test_share_config_between_pyspark_and_pyspark3():
     kpc = {
         "username": "U",
@@ -122,7 +114,7 @@ def test_share_config_between_pyspark_and_pyspark3():
         "auth": AUTH_BASIC,
     }
     overrides = {conf.kernel_python_credentials.__name__: kpc}
-    assert_equals(
-        conf.base64_kernel_python3_credentials(),
-        conf.base64_kernel_python_credentials(),
+    assert (
+        conf.base64_kernel_python3_credentials()
+        == conf.base64_kernel_python_credentials()
     )

--- a/sparkmagic/sparkmagic/tests/test_endpoint.py
+++ b/sparkmagic/sparkmagic/tests/test_endpoint.py
@@ -1,5 +1,3 @@
-from nose.tools import assert_equals, assert_not_equal, assert_false
-
 from sparkmagic.livyclientlib.exceptions import BadUserDataException
 from sparkmagic.livyclientlib.endpoint import Endpoint
 from sparkmagic.auth.basic import Basic
@@ -11,12 +9,11 @@ def test_equality():
     basic_auth2 = Basic()
     kerberos_auth1 = Kerberos()
     kerberos_auth2 = Kerberos()
-    assert_equals(
-        Endpoint("http://url.com", basic_auth1), Endpoint("http://url.com", basic_auth2)
+    assert Endpoint("http://url.com", basic_auth1) == Endpoint(
+        "http://url.com", basic_auth2
     )
-    assert_equals(
-        Endpoint("http://url.com", kerberos_auth1),
-        Endpoint("http://url.com", kerberos_auth2),
+    assert Endpoint("http://url.com", kerberos_auth1) == Endpoint(
+        "http://url.com", kerberos_auth2
     )
 
 
@@ -25,8 +22,8 @@ def test_inequality():
     basic_auth2 = Basic()
     basic_auth1.username = "user"
     basic_auth2.username = "different_user"
-    assert_not_equal(
-        Endpoint("http://url.com", basic_auth1), Endpoint("http://url.com", basic_auth2)
+    assert Endpoint("http://url.com", basic_auth1) != Endpoint(
+        "http://url.com", basic_auth2
     )
 
 

--- a/sparkmagic/sparkmagic/tests/test_exceptions.py
+++ b/sparkmagic/sparkmagic/tests/test_exceptions.py
@@ -1,5 +1,4 @@
 from mock import MagicMock
-from nose.tools import raises
 import pytest
 
 import sparkmagic.utils.configuration as conf

--- a/sparkmagic/sparkmagic/tests/test_exceptions.py
+++ b/sparkmagic/sparkmagic/tests/test_exceptions.py
@@ -1,5 +1,6 @@
 from mock import MagicMock
-from nose.tools import with_setup, assert_equals, assert_is, raises
+from nose.tools import raises
+import pytest
 
 import sparkmagic.utils.configuration as conf
 from sparkmagic.livyclientlib.exceptions import *
@@ -10,7 +11,7 @@ ipython_display = None
 logger = None
 
 
-def _setup():
+def setup_function():
     global self, ipython_display, logger
     self = MagicMock()
     ipython_display = self.ipython_display
@@ -18,94 +19,83 @@ def _setup():
     conf.override_all({})
 
 
-@with_setup(_setup)
 def test_handle_expected_exceptions():
     mock_method = MagicMock()
     mock_method.__name__ = "MockMethod"
     decorated = handle_expected_exceptions(mock_method)
-    assert_equals(decorated.__name__, mock_method.__name__)
+    assert decorated.__name__ == mock_method.__name__
 
     result = decorated(self, 1, 2, 3)
-    assert_equals(result, mock_method.return_value)
-    assert_equals(ipython_display.send_error.call_count, 0)
+    assert result == mock_method.return_value
+    assert ipython_display.send_error.call_count == 0
     mock_method.assert_called_once_with(self, 1, 2, 3)
 
 
-@with_setup(_setup)
 def test_handle_expected_exceptions_handle():
     conf.override_all({"all_errors_are_fatal": False})
     mock_method = MagicMock(side_effect=LivyUnexpectedStatusException("ridiculous"))
     mock_method.__name__ = "MockMethod2"
     decorated = handle_expected_exceptions(mock_method)
-    assert_equals(decorated.__name__, mock_method.__name__)
+    assert decorated.__name__ == mock_method.__name__
 
     result = decorated(self, 1, kwarg="foo")
-    assert_is(result, None)
-    assert_equals(ipython_display.send_error.call_count, 1)
+    assert result is None
+    assert ipython_display.send_error.call_count == 1
     mock_method.assert_called_once_with(self, 1, kwarg="foo")
 
 
-@raises(ValueError)
-@with_setup(_setup)
 def test_handle_expected_exceptions_throw():
-    mock_method = MagicMock(side_effect=ValueError("HALP"))
-    mock_method.__name__ = "mock_meth"
-    decorated = handle_expected_exceptions(mock_method)
-    assert_equals(decorated.__name__, mock_method.__name__)
+    with pytest.raises(ValueError):
+        mock_method = MagicMock(side_effect=ValueError("HALP"))
+        mock_method.__name__ = "mock_meth"
+        decorated = handle_expected_exceptions(mock_method)
+        assert decorated.__name__ == mock_method.__name__
 
-    result = decorated(self, 1, kwarg="foo")
+        _ = decorated(self, 1, kwarg="foo")
 
 
-@raises(LivyUnexpectedStatusException)
-@with_setup(_setup)
 def test_handle_expected_exceptions_throws_if_all_errors_fatal():
-    conf.override_all({"all_errors_are_fatal": True})
-    mock_method = MagicMock(side_effect=LivyUnexpectedStatusException("Oh no!"))
-    mock_method.__name__ = "mock_meth"
-    decorated = handle_expected_exceptions(mock_method)
-    assert_equals(decorated.__name__, mock_method.__name__)
+    with pytest.raises(LivyUnexpectedStatusException):
+        conf.override_all({"all_errors_are_fatal": True})
+        mock_method = MagicMock(side_effect=LivyUnexpectedStatusException("Oh no!"))
+        mock_method.__name__ = "mock_meth"
+        decorated = handle_expected_exceptions(mock_method)
+        assert decorated.__name__ == mock_method.__name__
 
-    result = decorated(self, 1, kwarg="foo")
+        _ = decorated(self, 1, kwarg="foo")
 
 
 # test wrap with unexpected to true
-
-
-@with_setup(_setup)
 def test_wrap_unexpected_exceptions():
     mock_method = MagicMock()
     mock_method.__name__ = "tos"
     decorated = wrap_unexpected_exceptions(mock_method)
-    assert_equals(decorated.__name__, mock_method.__name__)
+    assert decorated.__name__ == mock_method.__name__
 
     result = decorated(self, 0.0)
-    assert_equals(result, mock_method.return_value)
-    assert_equals(ipython_display.send_error.call_count, 0)
+    assert result == mock_method.return_value
+    assert ipython_display.send_error.call_count == 0
     mock_method.assert_called_once_with(self, 0.0)
 
 
-@with_setup(_setup)
 def test_wrap_unexpected_exceptions_handle():
     mock_method = MagicMock(side_effect=ValueError("~~~~~~"))
     mock_method.__name__ = "tos"
     decorated = wrap_unexpected_exceptions(mock_method)
-    assert_equals(decorated.__name__, mock_method.__name__)
+    assert decorated.__name__ == mock_method.__name__
 
     result = decorated(self, "FOOBAR", FOOBAR="FOOBAR")
-    assert_is(result, None)
-    assert_equals(ipython_display.send_error.call_count, 1)
+    assert result is None
+    assert ipython_display.send_error.call_count == 1
     mock_method.assert_called_once_with(self, "FOOBAR", FOOBAR="FOOBAR")
 
 
-# test wrap with unexpected to true
-# test wrap with all to true
-@raises(ValueError)
-@with_setup(_setup)
 def test_wrap_unexpected_exceptions_throws_if_all_errors_fatal():
-    conf.override_all({"all_errors_are_fatal": True})
-    mock_method = MagicMock(side_effect=ValueError("~~~~~~"))
-    mock_method.__name__ = "tos"
-    decorated = wrap_unexpected_exceptions(mock_method)
-    assert_equals(decorated.__name__, mock_method.__name__)
+    with pytest.raises(ValueError):
+        conf.override_all({"all_errors_are_fatal": True})
+        mock_method = MagicMock(side_effect=ValueError("~~~~~~"))
+        mock_method.__name__ = "tos"
+        decorated = wrap_unexpected_exceptions(mock_method)
+        assert decorated.__name__ == mock_method.__name__
 
-    result = decorated(self, "FOOBAR", FOOBAR="FOOBAR")
+        _ = decorated(self, "FOOBAR", FOOBAR="FOOBAR")

--- a/sparkmagic/sparkmagic/tests/test_handlers.py
+++ b/sparkmagic/sparkmagic/tests/test_handlers.py
@@ -1,5 +1,4 @@
 from mock import MagicMock, patch
-from nose.tools import assert_equals
 from tornado.concurrent import Future
 from tornado.web import MissingArgumentError
 from tornado.testing import gen_test
@@ -101,18 +100,17 @@ class TestSparkMagicHandler(AsyncTestCase):
         super(TestSparkMagicHandler, self).setUp()
 
     def test_msg_status(self):
-        assert_equals(self.reconnect_handler._msg_status(self.good_msg), "ok")
-        assert_equals(self.reconnect_handler._msg_status(self.bad_msg), "error")
+        assert self.reconnect_handler._msg_status(self.good_msg) == "ok"
+        assert self.reconnect_handler._msg_status(self.bad_msg) == "error"
 
     def test_msg_successful(self):
-        assert_equals(self.reconnect_handler._msg_successful(self.good_msg), True)
-        assert_equals(self.reconnect_handler._msg_successful(self.bad_msg), False)
+        assert self.reconnect_handler._msg_successful(self.good_msg) == True
+        assert self.reconnect_handler._msg_successful(self.bad_msg) == False
 
     def test_msg_error(self):
-        assert_equals(self.reconnect_handler._msg_error(self.good_msg), None)
-        assert_equals(
-            self.reconnect_handler._msg_error(self.bad_msg),
-            "{}:\n{}".format("SyntaxError", "oh no!"),
+        assert self.reconnect_handler._msg_error(self.good_msg) == None
+        assert self.reconnect_handler._msg_error(self.bad_msg) == "{}:\n{}".format(
+            "SyntaxError", "oh no!"
         )
 
     @gen_test
@@ -120,7 +118,7 @@ class TestSparkMagicHandler(AsyncTestCase):
         self.reconnect_handler.request.body = "{{}"
 
         res = yield self.reconnect_handler.post()
-        assert_equals(res, None)
+        assert res == None
 
         msg = "Invalid JSON in request body."
         self.reconnect_handler.set_status.assert_called_once_with(400)
@@ -134,7 +132,7 @@ class TestSparkMagicHandler(AsyncTestCase):
         self.reconnect_handler.request.body = json.dumps({})
 
         res = yield self.reconnect_handler.post()
-        assert_equals(res, None)
+        assert res == None
 
         msg = "HTTP 400: Bad Request (Missing argument path)"
         self.reconnect_handler.set_status.assert_called_once_with(400)
@@ -159,7 +157,7 @@ class TestSparkMagicHandler(AsyncTestCase):
         _get_kernel_manager.return_value = kernel_manager_future
 
         res = yield self.reconnect_handler.post()
-        assert_equals(res, None)
+        assert res == None
 
         code = "%{} -s {} -u {} -p {} -t {}".format(
             KernelMagics._do_not_call_change_endpoint.__name__,
@@ -197,7 +195,7 @@ class TestSparkMagicHandler(AsyncTestCase):
         _get_kernel_manager.return_value = kernel_manager_future
 
         res = yield self.reconnect_handler.post()
-        assert_equals(res, None)
+        assert res == None
 
         code = "%{} -s {} -u {} -p {} -t {}".format(
             KernelMagics._do_not_call_change_endpoint.__name__,
@@ -225,7 +223,7 @@ class TestSparkMagicHandler(AsyncTestCase):
         _get_kernel_manager.return_value = kernel_manager_future
 
         res = yield self.reconnect_handler.post()
-        assert_equals(res, None)
+        assert res == None
 
         code = "%{} -s {} -u {} -p {} -t {}".format(
             KernelMagics._do_not_call_change_endpoint.__name__,
@@ -254,7 +252,7 @@ class TestSparkMagicHandler(AsyncTestCase):
         self.client.get_shell_msg = MagicMock(return_value=self.bad_msg)
 
         res = yield self.reconnect_handler.post()
-        assert_equals(res, None)
+        assert res == None
 
         code = "%{} -s {} -u {} -p {} -t {}".format(
             KernelMagics._do_not_call_change_endpoint.__name__,
@@ -290,7 +288,7 @@ class TestSparkMagicHandler(AsyncTestCase):
             different_path, self.kernel_name
         )
 
-        assert_equals(self.individual_kernel_manager, km)
+        assert self.individual_kernel_manager == km
         self.individual_kernel_manager.restart_kernel.assert_not_called()
         self.kernel_manager.get_kernel.assert_not_called()
         _get_kernel_manager_new_session.assert_called_once_with(
@@ -306,7 +304,7 @@ class TestSparkMagicHandler(AsyncTestCase):
             self.path, self.kernel_name
         )
 
-        assert_equals(self.individual_kernel_manager, km)
+        assert self.individual_kernel_manager == km
         self.individual_kernel_manager.restart_kernel.assert_called_once_with()
         _get_kernel_manager_new_session.assert_not_called()
 
@@ -326,7 +324,7 @@ class TestSparkMagicHandler(AsyncTestCase):
             self.path, different_kernel
         )
 
-        assert_equals(self.individual_kernel_manager, km)
+        assert self.individual_kernel_manager == km
         self.individual_kernel_manager.restart_kernel.assert_not_called()
         self.kernel_manager.get_kernel.assert_not_called()
         _get_kernel_manager_new_session.assert_called_once_with(

--- a/sparkmagic/sparkmagic/tests/test_heartbeatthread.py
+++ b/sparkmagic/sparkmagic/tests/test_heartbeatthread.py
@@ -1,5 +1,4 @@
 from mock import MagicMock
-from nose.tools import assert_equals
 from time import sleep
 
 from sparkmagic.livyclientlib.livysession import _HeartbeatThread
@@ -11,9 +10,9 @@ def test_create_thread():
     retry_seconds = 2
     heartbeat_thread = _HeartbeatThread(session, refresh_seconds, retry_seconds)
 
-    assert_equals(heartbeat_thread.livy_session, session)
-    assert_equals(heartbeat_thread.refresh_seconds, refresh_seconds)
-    assert_equals(heartbeat_thread.retry_seconds, retry_seconds)
+    assert heartbeat_thread.livy_session == session
+    assert heartbeat_thread.refresh_seconds == refresh_seconds
+    assert heartbeat_thread.retry_seconds == retry_seconds
 
 
 def test_run_once():

--- a/sparkmagic/sparkmagic/tests/test_livyreliablehttpclient.py
+++ b/sparkmagic/sparkmagic/tests/test_livyreliablehttpclient.py
@@ -1,5 +1,4 @@
 from mock import MagicMock
-from nose.tools import assert_equals
 
 from sparkmagic.livyclientlib.livyreliablehttpclient import LivyReliableHttpClient
 from sparkmagic.livyclientlib.endpoint import Endpoint
@@ -15,7 +14,7 @@ def test_post_statement():
     livy_client = LivyReliableHttpClient(http_client, None)
     data = {"adlfj": "sadflkjsdf"}
     out = livy_client.post_statement(100, data)
-    assert_equals(out, http_client.post.return_value.json.return_value)
+    assert out == http_client.post.return_value.json.return_value
     http_client.post.assert_called_once_with("/sessions/100/statements", [201], data)
 
 
@@ -23,7 +22,7 @@ def test_get_statement():
     http_client = MagicMock()
     livy_client = LivyReliableHttpClient(http_client, None)
     out = livy_client.get_statement(100, 4)
-    assert_equals(out, http_client.get.return_value.json.return_value)
+    assert out == http_client.get.return_value.json.return_value
     http_client.get.assert_called_once_with("/sessions/100/statements/4", [200])
 
 
@@ -31,7 +30,7 @@ def test_cancel_statement():
     http_client = MagicMock()
     livy_client = LivyReliableHttpClient(http_client, None)
     out = livy_client.cancel_statement(100, 104)
-    assert_equals(out, http_client.post.return_value.json.return_value)
+    assert out == http_client.post.return_value.json.return_value
     http_client.post.assert_called_once_with(
         "/sessions/100/statements/104/cancel", [200], {}
     )
@@ -41,7 +40,7 @@ def test_get_sessions():
     http_client = MagicMock()
     livy_client = LivyReliableHttpClient(http_client, None)
     out = livy_client.get_sessions()
-    assert_equals(out, http_client.get.return_value.json.return_value)
+    assert out == http_client.get.return_value.json.return_value
     http_client.get.assert_called_once_with("/sessions", [200])
 
 
@@ -50,7 +49,7 @@ def test_post_session():
     livy_client = LivyReliableHttpClient(http_client, None)
     properties = {"adlfj": "sadflkjsdf", 1: [2, 3, 4, 5]}
     out = livy_client.post_session(properties)
-    assert_equals(out, http_client.post.return_value.json.return_value)
+    assert out == http_client.post.return_value.json.return_value
     http_client.post.assert_called_once_with("/sessions", [201], properties)
 
 
@@ -58,7 +57,7 @@ def test_get_session():
     http_client = MagicMock()
     livy_client = LivyReliableHttpClient(http_client, None)
     out = livy_client.get_session(4)
-    assert_equals(out, http_client.get.return_value.json.return_value)
+    assert out == http_client.get.return_value.json.return_value
     http_client.get.assert_called_once_with("/sessions/4", [200])
 
 
@@ -73,7 +72,7 @@ def test_get_all_session_logs():
     http_client = MagicMock()
     livy_client = LivyReliableHttpClient(http_client, None)
     out = livy_client.get_all_session_logs(42)
-    assert_equals(out, http_client.get.return_value.json.return_value)
+    assert out == http_client.get.return_value.json.return_value
     http_client.get.assert_called_once_with("/sessions/42/log?from=0", [200])
 
 
@@ -84,9 +83,9 @@ def test_custom_headers():
     endpoint = Endpoint("http://url.com", None)
     client = LivyReliableHttpClient.from_endpoint(endpoint)
     headers = client.get_headers()
-    assert_equals(len(headers), 2)
-    assert_equals("Content-Type" in headers, True)
-    assert_equals("header1" in headers, True)
+    assert len(headers) == 2
+    assert ("Content-Type" in headers) == True
+    assert ("header1" in headers) == True
 
 
 def test_retry_policy():
@@ -95,15 +94,15 @@ def test_retry_policy():
     max_retries = conf.configurable_retry_policy_max_retries()
     policy = LivyReliableHttpClient._get_retry_policy()
     assert type(policy) is ConfigurableRetryPolicy
-    assert_equals(times, policy.retry_seconds_to_sleep_list)
-    assert_equals(max_retries, policy.max_retries)
+    assert times == policy.retry_seconds_to_sleep_list
+    assert max_retries == policy.max_retries
 
     # Configure to linear retry
     _override_policy(constants.LINEAR_RETRY)
     policy = LivyReliableHttpClient._get_retry_policy()
     assert type(policy) is LinearRetryPolicy
-    assert_equals(5, policy.seconds_to_sleep(1))
-    assert_equals(5, policy.max_retries)
+    assert 5 == policy.seconds_to_sleep(1)
+    assert 5 == policy.max_retries
 
     # Configure to something invalid
     _override_policy("garbage")

--- a/sparkmagic/sparkmagic/tests/test_livysession.py
+++ b/sparkmagic/sparkmagic/tests/test_livysession.py
@@ -1,6 +1,6 @@
 ﻿import json
 from mock import MagicMock, call
-from nose.tools import raises, assert_equals
+import pytest
 
 import sparkmagic.utils.constants as constants
 import sparkmagic.utils.configuration as conf
@@ -215,9 +215,9 @@ class TestLivySession(object):
         session = self._create_session(kind=kind)
         session.start()
 
-        assert_equals(kind, session.kind)
-        assert_equals("idle", session.status)
-        assert_equals(0, session.id)
+        assert kind == session.kind
+        assert "idle" == session.status
+        assert 0 == session.id
         self.http_client.post_session.assert_called_with(
             {"kind": "spark", "heartbeatTimeoutInSecond": 60}
         )
@@ -231,9 +231,9 @@ class TestLivySession(object):
         session = self._create_session(kind=kind)
         session.start()
 
-        assert_equals(kind, session.kind)
-        assert_equals("idle", session.status)
-        assert_equals(0, session.id)
+        assert kind == session.kind
+        assert "idle" == session.status
+        assert 0 == session.id
         self.http_client.post_session.assert_called_with(
             {"kind": "sparkr", "heartbeatTimeoutInSecond": 60}
         )
@@ -247,9 +247,9 @@ class TestLivySession(object):
         session = self._create_session(kind=kind)
         session.start()
 
-        assert_equals(kind, session.kind)
-        assert_equals("idle", session.status)
-        assert_equals(0, session.id)
+        assert kind == session.kind
+        assert "idle" == session.status
+        assert 0 == session.id
         self.http_client.post_session.assert_called_with(
             {"kind": "pyspark", "heartbeatTimeoutInSecond": 60}
         )
@@ -278,13 +278,12 @@ class TestLivySession(object):
         session.refresh_status_and_info()
         state = session.status
 
-        assert_equals("idle", state)
+        assert "idle" == state
         self.http_client.get_session.assert_called_with(0)
 
     def test_status_recovering(self):
-        """
-        Ensure 'recovering' state is supported: we go from recovering to idle.
-        """
+        """Ensure 'recovering' state is supported: we go from recovering to
+        idle."""
         self.http_client.post_session.return_value = self.session_create_json
 
         def get_session(i, calls=[]):
@@ -298,7 +297,7 @@ class TestLivySession(object):
         self.http_client.get_statement.return_value = self.ready_statement_json
         session = self._create_session()
         session.start()
-        assert_equals("idle", session.status)
+        assert "idle" == session.status
 
     def test_logs_gets_latest_logs(self):
         self.http_client.post_session.return_value = self.session_create_json
@@ -310,7 +309,7 @@ class TestLivySession(object):
 
         logs = session.get_logs()
 
-        assert_equals("hi\nhi", logs)
+        assert "hi\nhi" == logs
         self.http_client.get_all_session_logs.assert_called_with(0)
 
     def test_wait_for_idle_returns_when_in_state(self):
@@ -333,7 +332,7 @@ class TestLivySession(object):
         session.wait_for_idle(30)
 
         self.http_client.get_session.assert_called_with(0)
-        assert_equals(4, self.http_client.get_session.call_count)
+        assert 4 == self.http_client.get_session.call_count
 
     def test_wait_for_idle_prints_resource_limit_message(self):
         self.http_client.post_session.return_value = self.session_create_json
@@ -354,48 +353,48 @@ class TestLivySession(object):
         session.start()
 
         session.wait_for_idle(30)
-        assert_equals(session.ipython_display.send_error.call_count, 1)
+        assert session.ipython_display.send_error.call_count == 1
 
-    @raises(LivyUnexpectedStatusException)
     def test_wait_for_idle_throws_when_in_final_status(self):
-        self.http_client.post_session.return_value = self.session_create_json
-        self.get_session_responses = [
-            self.ready_sessions_json,
-            self.busy_sessions_json,
-            self.busy_sessions_json,
-            self.error_sessions_json,
-        ]
-        self.http_client.get_session.side_effect = self._next_session_response_get
-        self.http_client.get_all_session_logs.return_value = self.log_json
+        with pytest.raises(LivyUnexpectedStatusException):
+            self.http_client.post_session.return_value = self.session_create_json
+            self.get_session_responses = [
+                self.ready_sessions_json,
+                self.busy_sessions_json,
+                self.busy_sessions_json,
+                self.error_sessions_json,
+            ]
+            self.http_client.get_session.side_effect = self._next_session_response_get
+            self.http_client.get_all_session_logs.return_value = self.log_json
 
-        session = self._create_session()
-        session.get_row_html = MagicMock()
-        session.get_row_html.return_value = """<tr><td>row1</td></tr>"""
+            session = self._create_session()
+            session.get_row_html = MagicMock()
+            session.get_row_html.return_value = """<tr><td>row1</td></tr>"""
 
-        session.start()
+            session.start()
 
-        session.wait_for_idle(30)
+            session.wait_for_idle(30)
 
-    @raises(LivyClientTimeoutException)
     def test_wait_for_idle_times_out(self):
-        self.http_client.post_session.return_value = self.session_create_json
-        self.get_session_responses = [
-            self.ready_sessions_json,
-            self.ready_sessions_json,
-            self.busy_sessions_json,
-            self.busy_sessions_json,
-            self.ready_sessions_json,
-        ]
-        self.http_client.get_session.side_effect = self._next_session_response_get
-        self.http_client.get_statement.return_value = self.ready_statement_json
+        with pytest.raises(LivyClientTimeoutException):
+            self.http_client.post_session.return_value = self.session_create_json
+            self.get_session_responses = [
+                self.ready_sessions_json,
+                self.ready_sessions_json,
+                self.busy_sessions_json,
+                self.busy_sessions_json,
+                self.ready_sessions_json,
+            ]
+            self.http_client.get_session.side_effect = self._next_session_response_get
+            self.http_client.get_statement.return_value = self.ready_statement_json
 
-        session = self._create_session()
-        session.get_row_html = MagicMock()
-        session.get_row_html.return_value = """<tr><td>row1</td></tr>"""
+            session = self._create_session()
+            session.get_row_html = MagicMock()
+            session.get_row_html.return_value = """<tr><td>row1</td></tr>"""
 
-        session.start()
+            session.start()
 
-        session.wait_for_idle(0.01)
+            session.wait_for_idle(0.01)
 
     def test_delete_session_when_active(self):
         self.http_client.post_session.return_value = self.session_create_json
@@ -406,7 +405,7 @@ class TestLivySession(object):
 
         session.delete()
 
-        assert_equals("dead", session.status)
+        assert "dead" == session.status
 
     def test_delete_session_when_not_started(self):
         self.http_client.post_session.return_value = self.session_create_json
@@ -414,7 +413,7 @@ class TestLivySession(object):
 
         session.delete()
 
-        assert_equals(session.ipython_display.send_error.call_count, 1)
+        assert session.ipython_display.send_error.call_count == 1
 
     def test_delete_session_when_dead_throws(self):
         self.http_client.post.return_value = self.session_create_json
@@ -423,7 +422,7 @@ class TestLivySession(object):
 
         session.delete()
 
-        assert_equals(session.ipython_display.send_error.call_count, 0)
+        assert session.ipython_display.send_error.call_count == 0
 
     def test_start_emits_start_end_session(self):
         self.http_client.post_session.return_value = self.session_create_json
@@ -495,7 +494,7 @@ class TestLivySession(object):
 
         session.delete()
 
-        assert_equals(session.id, -1)
+        assert session.id == -1
         self.spark_events.emit_session_deletion_start_event.assert_called_once_with(
             session.guid, session.kind, end_id, end_status
         )
@@ -547,7 +546,7 @@ class TestLivySession(object):
 
         session.delete()
 
-        assert_equals(0, session.ipython_display.send_error.call_count)
+        assert 0 == session.ipython_display.send_error.call_count
         self.spark_events.emit_session_deletion_start_event.assert_called_once_with(
             session.guid, session.kind, end_id, end_status
         )
@@ -588,8 +587,8 @@ class TestLivySession(object):
 
         app_id = session.get_app_id()
 
-        assert_equals(expected_app_id, app_id)
-        assert_equals(expected_call_count, self.http_client.get_session.call_count)
+        assert expected_app_id == app_id
+        assert expected_call_count == self.http_client.get_session.call_count
 
     def _verify_get_driver_log_url(self, mock_driver_log_url, expected_url):
         mock_field = (
@@ -607,8 +606,8 @@ class TestLivySession(object):
 
         driver_log_url = session.get_driver_log_url()
 
-        assert_equals(expected_url, driver_log_url)
-        assert_equals(7, self.http_client.get_session.call_count)
+        assert expected_url == driver_log_url
+        assert 7 == self.http_client.get_session.call_count
 
     def test_get_empty_spark_ui_url(self):
         self._verify_get_spark_ui_url("null", None)
@@ -633,8 +632,8 @@ class TestLivySession(object):
 
         spark_ui_url = session.get_spark_ui_url()
 
-        assert_equals(expected_url, spark_ui_url)
-        assert_equals(7, self.http_client.get_session.call_count)
+        assert expected_url == spark_ui_url
+        assert 7 == self.http_client.get_session.call_count
 
     def test_get_row_html(self):
         session_id1 = 1
@@ -650,9 +649,9 @@ class TestLivySession(object):
         session1.get_user.return_value = "userTest"
         html1 = session1.get_row_html(1)
 
-        assert_equals(
-            html1,
-            """<tr><td>1</td><td>app1234</td><td>spark</td><td>idle</td><td><a target="_blank" href="https://microsoft.com/sparkui">Link</a></td><td><a target="_blank" href="https://microsoft.com/driverlog">Link</a></td><td>userTest</td><td>\u2714</td></tr>""",
+        assert (
+            html1
+            == """<tr><td>1</td><td>app1234</td><td>spark</td><td>idle</td><td><a target="_blank" href="https://microsoft.com/sparkui">Link</a></td><td><a target="_blank" href="https://microsoft.com/driverlog">Link</a></td><td>userTest</td><td>\u2714</td></tr>"""
         )
 
         session_id2 = 3
@@ -671,20 +670,20 @@ class TestLivySession(object):
 
         html2 = session2.get_row_html(1)
 
-        assert_equals(
-            html2,
-            """<tr><td>3</td><td>app5069</td><td>pyspark</td><td>busy</td><td></td><td></td><td>userTest2</td><td></td></tr>""",
+        assert (
+            html2
+            == """<tr><td>3</td><td>app5069</td><td>pyspark</td><td>busy</td><td></td><td></td><td>userTest2</td><td></td></tr>"""
         )
 
     def test_link(self):
         url = "https://microsoft.com"
-        assert_equals(
-            LivySession.get_html_link("Link", url),
-            """<a target="_blank" href="https://microsoft.com">Link</a>""",
+        assert (
+            LivySession.get_html_link("Link", url)
+            == """<a target="_blank" href="https://microsoft.com">Link</a>"""
         )
 
         url = None
-        assert_equals(LivySession.get_html_link("Link", url), "")
+        assert LivySession.get_html_link("Link", url) == ""
 
     def test_spark_session_available(self):
         self.http_client.post_session.return_value = self.session_create_json
@@ -692,7 +691,7 @@ class TestLivySession(object):
         self.http_client.get_statement.return_value = self.ready_statement_json
         session = self._create_session()
         session.start()
-        assert_equals(session.sql_context_variable_name, "spark")
+        assert session.sql_context_variable_name == "spark"
 
     def test_sql_context_available(self):
         self.http_client.post_session.return_value = self.session_create_json
@@ -704,15 +703,17 @@ class TestLivySession(object):
         self.http_client.get_statement.side_effect = self._next_statement_response_get
         session = self._create_session()
         session.start()
-        assert_equals(session.sql_context_variable_name, "sqlContext")
+        assert session.sql_context_variable_name == "sqlContext"
 
-    @raises(SqlContextNotFoundException)
     def test_spark_session_and_sql_context_unavailable(self):
-        self.http_client.post_session.return_value = self.session_create_json
-        self.http_client.get_session.return_value = self.ready_sessions_json
-        self.http_client.get_statement.return_value = self.ready_statement_failed_json
-        session = self._create_session()
-        session.start()
+        with pytest.raises(SqlContextNotFoundException):
+            self.http_client.post_session.return_value = self.session_create_json
+            self.http_client.get_session.return_value = self.ready_sessions_json
+            self.http_client.get_statement.return_value = (
+                self.ready_statement_failed_json
+            )
+            session = self._create_session()
+            session.start()
 
     def test_is_posted(self):
         self.http_client.post_session.return_value = self.session_create_json

--- a/sparkmagic/sparkmagic/tests/test_reliablehttpclient.py
+++ b/sparkmagic/sparkmagic/tests/test_reliablehttpclient.py
@@ -2,14 +2,7 @@
 # Distributed under the terms of the Modified BSD License.
 
 from mock import patch, PropertyMock, MagicMock
-from nose.tools import (
-    raises,
-    assert_equals,
-    with_setup,
-    assert_is_not_none,
-    assert_false,
-    assert_true,
-)
+import pytest
 import requests
 from requests_kerberos.kerberos_ import HTTPKerberosAuth, REQUIRED, OPTIONAL
 from sparkmagic.auth.basic import Basic
@@ -30,12 +23,12 @@ kerberos_auth = Kerberos()
 endpoint = Endpoint("http://url.com", basic_auth)
 
 
-def _setup():
+def setup_function():
     global retry_policy
     retry_policy = LinearRetryPolicy(0.01, 5)
 
 
-def _teardown():
+def teardown_function():
     pass
 
 
@@ -46,26 +39,24 @@ def return_sequential():
     return val
 
 
-@with_setup(_setup, _teardown)
 def test_compose_url():
     client = ReliableHttpClient(endpoint, {}, retry_policy)
 
     composed = client.compose_url("r")
-    assert_equals("http://url.com/r", composed)
+    assert "http://url.com/r" == composed
 
     composed = client.compose_url("/r")
-    assert_equals("http://url.com/r", composed)
+    assert "http://url.com/r" == composed
 
     client = ReliableHttpClient(endpoint, {}, retry_policy)
 
     composed = client.compose_url("r")
-    assert_equals("http://url.com/r", composed)
+    assert "http://url.com/r" == composed
 
     composed = client.compose_url("/r")
-    assert_equals("http://url.com/r", composed)
+    assert "http://url.com/r" == composed
 
 
-@with_setup(_setup, _teardown)
 def test_get():
     with patch("requests.Session.get") as patched_get:
         type(patched_get.return_value).status_code = 200
@@ -74,21 +65,19 @@ def test_get():
 
         result = client.get("r", [200])
 
-        assert_equals(200, result.status_code)
+        assert 200 == result.status_code
 
 
-@raises(HttpClientException)
-@with_setup(_setup, _teardown)
 def test_get_throws():
-    with patch("requests.Session.get") as patched_get:
-        type(patched_get.return_value).status_code = 500
+    with pytest.raises(HttpClientException):
+        with patch("requests.Session.get") as patched_get:
+            type(patched_get.return_value).status_code = 500
 
-        client = ReliableHttpClient(endpoint, {}, retry_policy)
+            client = ReliableHttpClient(endpoint, {}, retry_policy)
 
-        client.get("r", [200])
+            client.get("r", [200])
 
 
-@with_setup(_setup, _teardown)
 def test_get_will_retry():
     global sequential_values, retry_policy
     retry_policy = MagicMock()
@@ -106,12 +95,11 @@ def test_get_will_retry():
 
         result = client.get("r", [200])
 
-        assert_equals(200, result.status_code)
+        assert 200 == result.status_code
         retry_policy.should_retry.assert_called_once_with(500, False, 0)
         retry_policy.seconds_to_sleep.assert_called_once_with(0)
 
 
-@with_setup(_setup, _teardown)
 def test_post():
     with patch("requests.Session.post") as patched_post:
         type(patched_post.return_value).status_code = 200
@@ -120,21 +108,19 @@ def test_post():
 
         result = client.post("r", [200], {})
 
-        assert_equals(200, result.status_code)
+        assert 200 == result.status_code
 
 
-@raises(HttpClientException)
-@with_setup(_setup, _teardown)
 def test_post_throws():
-    with patch("requests.Session.post") as patched_post:
-        type(patched_post.return_value).status_code = 500
+    with pytest.raises(HttpClientException):
+        with patch("requests.Session.post") as patched_post:
+            type(patched_post.return_value).status_code = 500
 
-        client = ReliableHttpClient(endpoint, {}, retry_policy)
+            client = ReliableHttpClient(endpoint, {}, retry_policy)
 
-        client.post("r", [200], {})
+            client.post("r", [200], {})
 
 
-@with_setup(_setup, _teardown)
 def test_post_will_retry():
     global sequential_values, retry_policy
     retry_policy = MagicMock()
@@ -152,12 +138,11 @@ def test_post_will_retry():
 
         result = client.post("r", [200], {})
 
-        assert_equals(200, result.status_code)
+        assert 200 == result.status_code
         retry_policy.should_retry.assert_called_once_with(500, False, 0)
         retry_policy.seconds_to_sleep.assert_called_once_with(0)
 
 
-@with_setup(_setup, _teardown)
 def test_delete():
     with patch("requests.Session.delete") as patched_delete:
         type(patched_delete.return_value).status_code = 200
@@ -166,21 +151,19 @@ def test_delete():
 
         result = client.delete("r", [200])
 
-        assert_equals(200, result.status_code)
+        assert 200 == result.status_code
 
 
-@raises(HttpClientException)
-@with_setup(_setup, _teardown)
 def test_delete_throws():
-    with patch("requests.Session.delete") as patched_delete:
-        type(patched_delete.return_value).status_code = 500
+    with pytest.raises(HttpClientException):
+        with patch("requests.Session.delete") as patched_delete:
+            type(patched_delete.return_value).status_code = 500
 
-        client = ReliableHttpClient(endpoint, {}, retry_policy)
+            client = ReliableHttpClient(endpoint, {}, retry_policy)
 
-        client.delete("r", [200])
+            client.delete("r", [200])
 
 
-@with_setup(_setup, _teardown)
 def test_delete_will_retry():
     global sequential_values, retry_policy
     retry_policy = MagicMock()
@@ -198,12 +181,11 @@ def test_delete_will_retry():
 
         result = client.delete("r", [200])
 
-        assert_equals(200, result.status_code)
+        assert 200 == result.status_code
         retry_policy.should_retry.assert_called_once_with(500, False, 0)
         retry_policy.seconds_to_sleep.assert_called_once_with(0)
 
 
-@with_setup(_setup, _teardown)
 def test_will_retry_error_no():
     global sequential_values, retry_policy
     retry_policy = MagicMock()
@@ -221,35 +203,31 @@ def test_will_retry_error_no():
             retry_policy.should_retry.assert_called_once_with(None, True, 0)
 
 
-@with_setup(_setup, _teardown)
 def test_basic_auth_check_auth():
     endpoint = Endpoint("http://url.com", basic_auth)
     client = ReliableHttpClient(endpoint, {}, retry_policy)
     assert isinstance(client._auth, Basic)
     assert hasattr(client._auth, "username")
     assert hasattr(client._auth, "password")
-    assert_equals(client._auth.username, endpoint.auth.username)
-    assert_equals(client._auth.password, endpoint.auth.password)
+    assert client._auth.username == endpoint.auth.username
+    assert client._auth.password == endpoint.auth.password
 
 
-@with_setup(_setup, _teardown)
 def test_no_auth_check_auth():
     endpoint = Endpoint("http://url.com", None)
     client = ReliableHttpClient(endpoint, {}, retry_policy)
-    assert_equals(client._auth, None)
+    assert client._auth == None
 
 
-@with_setup(_setup, _teardown)
 def test_kerberos_auth_check_auth():
     endpoint = Endpoint("http://url.com", kerberos_auth)
     client = ReliableHttpClient(endpoint, {}, retry_policy)
-    assert_is_not_none(client._auth)
+    assert client._auth is not None
     assert isinstance(client._auth, HTTPKerberosAuth)
     assert hasattr(client._auth, "mutual_authentication")
-    assert_equals(client._auth.mutual_authentication, REQUIRED)
+    assert client._auth.mutual_authentication == REQUIRED
 
 
-@with_setup(_setup, _teardown)
 def test_kerberos_auth_custom_configuration():
     custom_kerberos_conf = {"mutual_authentication": OPTIONAL, "force_preemptive": True}
     overrides = {conf.kerberos_auth_configuration.__name__: custom_kerberos_conf}
@@ -257,9 +235,9 @@ def test_kerberos_auth_custom_configuration():
     kerberos_auth = Kerberos()
     endpoint = Endpoint("http://url.com", kerberos_auth)
     client = ReliableHttpClient(endpoint, {}, retry_policy)
-    assert_is_not_none(client._auth)
+    assert client._auth is not None
     assert isinstance(client._auth, HTTPKerberosAuth)
     assert hasattr(client._auth, "mutual_authentication")
-    assert_equals(client._auth.mutual_authentication, OPTIONAL)
+    assert client._auth.mutual_authentication == OPTIONAL
     assert hasattr(client._auth, "force_preemptive")
-    assert_equals(client._auth.force_preemptive, True)
+    assert client._auth.force_preemptive == True

--- a/sparkmagic/sparkmagic/tests/test_remotesparkmagics.py
+++ b/sparkmagic/sparkmagic/tests/test_remotesparkmagics.py
@@ -1,5 +1,4 @@
 from mock import MagicMock
-from nose.tools import with_setup, assert_equals
 
 import sparkmagic.utils.configuration as conf
 from sparkmagic.utils.utils import parse_argstring_or_throw, initialize_auth
@@ -22,7 +21,7 @@ shell = None
 ipython_display = None
 
 
-def _setup():
+def setup_function():
     global magic, spark_controller, shell, ipython_display
     conf.override_all({})
 
@@ -32,11 +31,10 @@ def _setup():
     magic.spark_controller = spark_controller = MagicMock()
 
 
-def _teardown():
+def teardown_function():
     pass
 
 
-@with_setup(_setup, _teardown)
 def test_info_command_parses():
     print_info_mock = MagicMock()
     magic._print_local_info = print_info_mock
@@ -47,7 +45,6 @@ def test_info_command_parses():
     print_info_mock.assert_called_once_with()
 
 
-@with_setup(_setup, _teardown)
 def test_info_endpoint_command_parses():
     print_info_mock = MagicMock()
     magic._print_endpoint_info = print_info_mock
@@ -59,7 +56,6 @@ def test_info_endpoint_command_parses():
     print_info_mock.assert_called_once_with(None, 1234)
 
 
-@with_setup(_setup, _teardown)
 def test_info_command_exception():
     print_info_mock = MagicMock(side_effect=LivyClientTimeoutException("OHHHHHOHOHOHO"))
     magic._print_local_info = print_info_mock
@@ -73,7 +69,6 @@ def test_info_command_exception():
     )
 
 
-@with_setup(_setup, _teardown)
 def test_add_sessions_command_parses():
     # Do not skip and python
     add_sessions_mock = MagicMock()
@@ -112,7 +107,6 @@ def test_add_sessions_command_parses():
     )
 
 
-@with_setup(_setup, _teardown)
 def test_add_sessions_command_parses_kerberos():
     # Do not skip and python
     add_sessions_mock = MagicMock()
@@ -132,10 +126,9 @@ def test_add_sessions_command_parses_kerberos():
         False,
         {"kind": "pyspark"},
     )
-    assert_equals(auth_instance.url, "http://url.com")
+    assert auth_instance.url == "http://url.com"
 
 
-@with_setup(_setup, _teardown)
 def test_add_sessions_command_exception():
     # Do not skip and python
     add_sessions_mock = MagicMock(side_effect=BadUserDataException("hehe"))
@@ -159,7 +152,6 @@ def test_add_sessions_command_exception():
     )
 
 
-@with_setup(_setup, _teardown)
 def test_add_sessions_command_extra_properties():
     conf.override_all({})
     magic.spark("config", '{"extra": "yes"}')
@@ -185,7 +177,6 @@ def test_add_sessions_command_extra_properties():
     conf.override_all({})
 
 
-@with_setup(_setup, _teardown)
 def test_delete_sessions_command_parses():
     mock_method = MagicMock()
     spark_controller.delete_session_by_name = mock_method
@@ -201,7 +192,6 @@ def test_delete_sessions_command_parses():
     mock_method.assert_called_once_with(Endpoint("URL", initialize_auth(args)), 4)
 
 
-@with_setup(_setup, _teardown)
 def test_delete_sessions_command_exception():
     mock_method = MagicMock(side_effect=LivyUnexpectedStatusException("FEEEEEELINGS"))
     spark_controller.delete_session_by_name = mock_method
@@ -213,7 +203,6 @@ def test_delete_sessions_command_exception():
     )
 
 
-@with_setup(_setup, _teardown)
 def test_cleanup_command_parses():
     mock_method = MagicMock()
     spark_controller.cleanup = mock_method
@@ -224,7 +213,6 @@ def test_cleanup_command_parses():
     mock_method.assert_called_once_with()
 
 
-@with_setup(_setup, _teardown)
 def test_cleanup_command_exception():
     mock_method = MagicMock(
         side_effect=SessionManagementException("Livy did something VERY BAD")
@@ -239,7 +227,6 @@ def test_cleanup_command_exception():
     )
 
 
-@with_setup(_setup, _teardown)
 def test_cleanup_endpoint_command_parses():
     mock_method = MagicMock()
     spark_controller.cleanup_endpoint = mock_method
@@ -256,7 +243,6 @@ def test_cleanup_endpoint_command_parses():
     mock_method.assert_called_with(Endpoint("endp", initialize_auth(args)))
 
 
-@with_setup(_setup, _teardown)
 def test_bad_command_writes_error():
     line = "bad_command"
     usage = "Please look at usage of %spark by executing `%spark?`."
@@ -268,7 +254,6 @@ def test_bad_command_writes_error():
     )
 
 
-@with_setup(_setup, _teardown)
 def test_run_cell_command_parses():
     run_cell_method = MagicMock()
     result_value = ""
@@ -287,7 +272,6 @@ def test_run_cell_command_parses():
     ipython_display.write.assert_called_once_with(result_value)
 
 
-@with_setup(_setup, _teardown)
 def test_run_cell_command_writes_to_err():
     run_cell_method = MagicMock()
     result_value = ""
@@ -308,7 +292,6 @@ def test_run_cell_command_writes_to_err():
     )
 
 
-@with_setup(_setup, _teardown)
 def test_run_cell_command_exception():
     run_cell_method = MagicMock()
     run_cell_method.side_effect = HttpClientException("meh")
@@ -328,7 +311,6 @@ def test_run_cell_command_exception():
     )
 
 
-@with_setup(_setup, _teardown)
 def test_run_spark_command_parses():
     magic.execute_spark = MagicMock()
 
@@ -348,7 +330,6 @@ def test_run_spark_command_parses():
     )
 
 
-@with_setup(_setup, _teardown)
 def test_run_spark_command_parses_with_coerce():
     magic.execute_spark = MagicMock()
 
@@ -372,7 +353,6 @@ def test_run_spark_command_parses_with_coerce():
     )
 
 
-@with_setup(_setup, _teardown)
 def test_run_spark_command_parses_with_coerce_false():
     magic.execute_spark = MagicMock()
 
@@ -396,7 +376,6 @@ def test_run_spark_command_parses_with_coerce_false():
     )
 
 
-@with_setup(_setup, _teardown)
 def test_run_sql_command_parses_with_coerce_false():
     magic.execute_sqlquery = MagicMock()
 
@@ -420,7 +399,6 @@ def test_run_sql_command_parses_with_coerce_false():
     )
 
 
-@with_setup(_setup, _teardown)
 def test_run_spark_with_store_command_parses():
     magic.execute_spark = MagicMock()
 
@@ -443,7 +421,6 @@ def test_run_spark_with_store_command_parses():
     )
 
 
-@with_setup(_setup, _teardown)
 def test_run_spark_with_store_correct_calls():
     run_cell_method = MagicMock()
     run_cell_method.return_value = (True, "", MIMETYPE_TEXT_PLAIN)
@@ -483,7 +460,6 @@ def test_run_spark_with_store_correct_calls():
     )
 
 
-@with_setup(_setup, _teardown)
 def test_run_spark_command_exception():
     run_cell_method = MagicMock()
     run_cell_method.side_effect = LivyUnexpectedStatusException("WOW")
@@ -510,7 +486,6 @@ def test_run_spark_command_exception():
     )
 
 
-@with_setup(_setup, _teardown)
 def test_run_spark_command_exception_while_storing():
     run_cell_method = MagicMock()
     exception = LivyUnexpectedStatusException("WOW")
@@ -542,7 +517,6 @@ def test_run_spark_command_exception_while_storing():
     )
 
 
-@with_setup(_setup, _teardown)
 def test_run_sql_command_parses():
     run_cell_method = MagicMock()
     run_cell_method.return_value = (True, "", MIMETYPE_TEXT_PLAIN)
@@ -565,7 +539,6 @@ def test_run_sql_command_parses():
     assert result is not None
 
 
-@with_setup(_setup, _teardown)
 def test_run_sql_command_exception():
     run_cell_method = MagicMock()
     run_cell_method.side_effect = LivyUnexpectedStatusException("WOW")
@@ -590,7 +563,6 @@ def test_run_sql_command_exception():
     )
 
 
-@with_setup(_setup, _teardown)
 def test_run_sql_command_knows_how_to_be_quiet():
     run_cell_method = MagicMock()
     run_cell_method.return_value = (True, "", MIMETYPE_TEXT_PLAIN)
@@ -614,7 +586,6 @@ def test_run_sql_command_knows_how_to_be_quiet():
     assert result is None
 
 
-@with_setup(_setup, _teardown)
 def test_logs_subcommand():
     get_logs_method = MagicMock()
     result_value = ""
@@ -633,7 +604,6 @@ def test_logs_subcommand():
     ipython_display.write.assert_called_once_with(result_value)
 
 
-@with_setup(_setup, _teardown)
 def test_logs_exception():
     get_logs_method = MagicMock(
         side_effect=LivyUnexpectedStatusException("How did this happen?")

--- a/sparkmagic/sparkmagic/tests/test_sendpandasdftosparkcommand.py
+++ b/sparkmagic/sparkmagic/tests/test_sendpandasdftosparkcommand.py
@@ -1,9 +1,11 @@
 # coding=utf-8
 
-import pandas as pd
+import pytest
 from mock import MagicMock
+
+import pandas as pd
+
 from sparkmagic.livyclientlib.exceptions import BadUserDataException
-from nose.tools import assert_raises, assert_equals
 from sparkmagic.livyclientlib.command import Command
 import sparkmagic.utils.constants as constants
 from sparkmagic.livyclientlib.sendpandasdftosparkcommand import (
@@ -86,12 +88,9 @@ def test_should_create_a_valid_scala_expression():
     sparkcommand = SendPandasDfToSparkCommand(
         input_variable_name, input_variable_value, output_variable_name, 1
     )
-    assert_equals(
-        sparkcommand._scala_command(
-            input_variable_name, input_variable_value, output_variable_name
-        ),
-        Command(expected_scala_code),
-    )
+    assert sparkcommand._scala_command(
+        input_variable_name, input_variable_value, output_variable_name
+    ) == Command(expected_scala_code)
 
 
 def test_should_create_a_valid_r_expression():
@@ -113,12 +112,9 @@ def test_should_create_a_valid_r_expression():
     sparkcommand = SendPandasDfToSparkCommand(
         input_variable_name, input_variable_value, output_variable_name, 1
     )
-    assert_equals(
-        sparkcommand._r_command(
-            input_variable_name, input_variable_value, output_variable_name
-        ),
-        Command(expected_r_code),
-    )
+    assert sparkcommand._r_command(
+        input_variable_name, input_variable_value, output_variable_name
+    ) == Command(expected_r_code)
 
 
 def test_should_create_a_valid_python3_expression():
@@ -139,12 +135,9 @@ def test_should_create_a_valid_python3_expression():
     sparkcommand = SendPandasDfToSparkCommand(
         input_variable_name, input_variable_value, output_variable_name, 1
     )
-    assert_equals(
-        sparkcommand._pyspark_command(
-            input_variable_name, input_variable_value, output_variable_name
-        ),
-        Command(expected_python3_code),
-    )
+    assert sparkcommand._pyspark_command(
+        input_variable_name, input_variable_value, output_variable_name
+    ) == Command(expected_python3_code)
 
 
 def test_should_create_a_valid_python2_expression():
@@ -165,12 +158,9 @@ def test_should_create_a_valid_python2_expression():
     sparkcommand = SendPandasDfToSparkCommand(
         input_variable_name, input_variable_value, output_variable_name, 1
     )
-    assert_equals(
-        sparkcommand._pyspark_command(
-            input_variable_name, input_variable_value, output_variable_name
-        ),
-        Command(expected_python2_code),
-    )
+    assert sparkcommand._pyspark_command(
+        input_variable_name, input_variable_value, output_variable_name
+    ) == Command(expected_python2_code)
 
 
 def test_should_properly_limit_pandas_dataframe():
@@ -191,26 +181,22 @@ def test_should_properly_limit_pandas_dataframe():
     sparkcommand = SendPandasDfToSparkCommand(
         input_variable_name, input_variable_value, output_variable_name, max_rows
     )
-    assert_equals(
-        sparkcommand._scala_command(
-            input_variable_name, input_variable_value, output_variable_name
-        ),
-        Command(expected_scala_code),
-    )
+    assert sparkcommand._scala_command(
+        input_variable_name, input_variable_value, output_variable_name
+    ) == Command(expected_scala_code)
 
 
 def test_should_raise_when_input_is_not_pandas_df():
-    input_variable_name = "input"
-    input_variable_value = "not a pandas dataframe"
-    output_variable_name = "output"
-    sparkcommand = SendPandasDfToSparkCommand(
-        input_variable_name, input_variable_value, output_variable_name, 1
-    )
-    assert_raises(
-        BadUserDataException,
-        sparkcommand.to_command,
-        "spark",
-        input_variable_name,
-        input_variable_value,
-        output_variable_name,
-    )
+    with pytest.raises(BadUserDataException):
+        input_variable_name = "input"
+        input_variable_value = "not a pandas dataframe"
+        output_variable_name = "output"
+        sparkcommand = SendPandasDfToSparkCommand(
+            input_variable_name, input_variable_value, output_variable_name, 1
+        )
+        sparkcommand.to_command(
+            "spark",
+            input_variable_name,
+            input_variable_value,
+            output_variable_name,
+        )

--- a/sparkmagic/sparkmagic/tests/test_sendstringtosparkcommand.py
+++ b/sparkmagic/sparkmagic/tests/test_sendstringtosparkcommand.py
@@ -1,8 +1,9 @@
 # coding=utf-8
-from sparkmagic.livyclientlib.sendstringtosparkcommand import SendStringToSparkCommand
+import pytest
 from mock import MagicMock
+
+from sparkmagic.livyclientlib.sendstringtosparkcommand import SendStringToSparkCommand
 from sparkmagic.livyclientlib.exceptions import BadUserDataException
-from nose.tools import assert_raises, assert_equals
 from sparkmagic.livyclientlib.command import Command
 import sparkmagic.utils.constants as constants
 
@@ -71,14 +72,15 @@ def test_to_command_invalid():
     sparkcommand = SendStringToSparkCommand(
         input_variable_name, input_variable_value, output_variable_name
     )
-    assert_raises(
+    with pytest.raises(
         BadUserDataException,
-        sparkcommand.to_command,
-        "invalid",
-        input_variable_name,
-        input_variable_value,
-        output_variable_name,
-    )
+    ):
+        sparkcommand.to_command(
+            "invalid",
+            input_variable_name,
+            input_variable_value,
+            output_variable_name,
+        )
 
 
 def test_should_raise_when_input_aint_a_string():
@@ -88,14 +90,15 @@ def test_should_raise_when_input_aint_a_string():
     sparkcommand = SendStringToSparkCommand(
         input_variable_name, input_variable_value, output_variable_name
     )
-    assert_raises(
+    with pytest.raises(
         BadUserDataException,
-        sparkcommand.to_command,
-        "spark",
-        input_variable_name,
-        input_variable_value,
-        output_variable_name,
-    )
+    ):
+        sparkcommand.to_command(
+            "spark",
+            input_variable_name,
+            input_variable_value,
+            output_variable_name,
+        )
 
 
 def test_should_create_a_valid_scala_expression():
@@ -105,12 +108,9 @@ def test_should_create_a_valid_scala_expression():
     sparkcommand = SendStringToSparkCommand(
         input_variable_name, input_variable_value, output_variable_name
     )
-    assert_equals(
-        sparkcommand._scala_command(
-            input_variable_name, input_variable_value, output_variable_name
-        ),
-        Command('var {} = """{}"""'.format(output_variable_name, input_variable_value)),
-    )
+    assert sparkcommand._scala_command(
+        input_variable_name, input_variable_value, output_variable_name
+    ) == Command('var {} = """{}"""'.format(output_variable_name, input_variable_value))
 
 
 def test_should_create_a_valid_python_expression():
@@ -120,12 +120,9 @@ def test_should_create_a_valid_python_expression():
     sparkcommand = SendStringToSparkCommand(
         input_variable_name, input_variable_value, output_variable_name
     )
-    assert_equals(
-        sparkcommand._pyspark_command(
-            input_variable_name, input_variable_value, output_variable_name
-        ),
-        Command("{} = {}".format(output_variable_name, repr(input_variable_value))),
-    )
+    assert sparkcommand._pyspark_command(
+        input_variable_name, input_variable_value, output_variable_name
+    ) == Command("{} = {}".format(output_variable_name, repr(input_variable_value)))
 
 
 def test_should_create_a_valid_r_expression():
@@ -135,11 +132,8 @@ def test_should_create_a_valid_r_expression():
     sparkcommand = SendStringToSparkCommand(
         input_variable_name, input_variable_value, output_variable_name
     )
-    assert_equals(
-        sparkcommand._r_command(
-            input_variable_name, input_variable_value, output_variable_name
-        ),
-        Command(
-            """assign("{}","{}")""".format(output_variable_name, input_variable_value)
-        ),
+    assert sparkcommand._r_command(
+        input_variable_name, input_variable_value, output_variable_name
+    ) == Command(
+        """assign("{}","{}")""".format(output_variable_name, input_variable_value)
     )

--- a/sparkmagic/sparkmagic/tests/test_sessionmanager.py
+++ b/sparkmagic/sparkmagic/tests/test_sessionmanager.py
@@ -1,17 +1,16 @@
 ﻿import atexit
+import pytest
 from mock import MagicMock, PropertyMock
-from nose.tools import raises, assert_equals
 
 import sparkmagic.utils.configuration as conf
 from sparkmagic.livyclientlib.exceptions import SessionManagementException
 from sparkmagic.livyclientlib.sessionmanager import SessionManager
 
 
-@raises(SessionManagementException)
 def test_get_client_throws_when_client_not_exists():
-    manager = get_session_manager()
-
-    manager.get_session("name")
+    with pytest.raises(SessionManagementException):
+        manager = get_session_manager()
+        manager.get_session("name")
 
 
 def test_get_client():
@@ -20,34 +19,34 @@ def test_get_client():
 
     manager.add_session("name", client)
 
-    assert_equals(client, manager.get_session("name"))
+    assert client == manager.get_session("name")
 
 
-@raises(SessionManagementException)
 def test_delete_client():
-    client = MagicMock()
-    manager = get_session_manager()
+    with pytest.raises(SessionManagementException):
+        client = MagicMock()
+        manager = get_session_manager()
 
-    manager.add_session("name", client)
-    manager.delete_client("name")
+        manager.add_session("name", client)
+        manager.delete_client("name")
 
-    manager.get_session("name")
+        manager.get_session("name")
 
 
-@raises(SessionManagementException)
 def test_delete_client_throws_when_client_not_exists():
-    manager = get_session_manager()
+    with pytest.raises(SessionManagementException):
+        manager = get_session_manager()
 
-    manager.delete_client("name")
+        manager.delete_client("name")
 
 
-@raises(SessionManagementException)
 def test_add_client_throws_when_client_exists():
-    client = MagicMock()
-    manager = get_session_manager()
+    with pytest.raises(SessionManagementException):
+        client = MagicMock()
+        manager = get_session_manager()
 
-    manager.add_session("name", client)
-    manager.add_session("name", client)
+        manager.add_session("name", client)
+        manager.add_session("name", client)
 
 
 def test_client_names_returned():
@@ -57,7 +56,7 @@ def test_client_names_returned():
     manager.add_session("name0", client)
     manager.add_session("name1", client)
 
-    assert_equals({"name0", "name1"}, set(manager.get_sessions_list()))
+    assert {"name0", "name1"} == set(manager.get_sessions_list())
 
 
 def test_get_any_client():
@@ -66,24 +65,24 @@ def test_get_any_client():
 
     manager.add_session("name", client)
 
-    assert_equals(client, manager.get_any_session())
+    assert client == manager.get_any_session()
 
 
-@raises(SessionManagementException)
 def test_get_any_client_raises_exception_with_no_client():
-    manager = get_session_manager()
+    with pytest.raises(SessionManagementException):
+        manager = get_session_manager()
 
-    manager.get_any_session()
+        manager.get_any_session()
 
 
-@raises(SessionManagementException)
 def test_get_any_client_raises_exception_with_two_clients():
-    client = MagicMock()
-    manager = get_session_manager()
-    manager.add_session("name0", client)
-    manager.add_session("name1", client)
+    with pytest.raises(SessionManagementException):
+        client = MagicMock()
+        manager = get_session_manager()
+        manager.add_session("name0", client)
+        manager.add_session("name1", client)
 
-    manager.get_any_session()
+        manager.get_any_session()
 
 
 def test_clean_up():
@@ -117,8 +116,9 @@ def test_cleanup_all_sessions_on_exit():
 
 
 def test_cleanup_all_sessions_on_exit_fails():
-    """
-    Cleanup on exit is best effort only. When cleanup fails, exception is caught and error is logged.
+    """Cleanup on exit is best effort only.
+
+    When cleanup fails, exception is caught and error is logged.
     """
     conf.override(conf.cleanup_all_sessions_on_exit.__name__, True)
     client0 = MagicMock()
@@ -151,7 +151,7 @@ def test_get_session_name_by_id_endpoint():
     name_to_search = "name"
 
     name = manager.get_session_name_by_id_endpoint(id_to_search, endpoint_to_search)
-    assert_equals(None, name)
+    assert None == name
 
     session = MagicMock()
     type(session).id = PropertyMock(return_value=int(id_to_search))
@@ -159,7 +159,7 @@ def test_get_session_name_by_id_endpoint():
 
     manager.add_session(name_to_search, session)
     name = manager.get_session_name_by_id_endpoint(id_to_search, endpoint_to_search)
-    assert_equals(name_to_search, name)
+    assert name_to_search == name
 
 
 def test_get_session_id_for_client_not_there():

--- a/sparkmagic/sparkmagic/tests/test_sparkevents.py
+++ b/sparkmagic/sparkmagic/tests/test_sparkevents.py
@@ -1,13 +1,14 @@
+import pytest
+from mock import MagicMock
+
 from hdijupyterutils.constants import INSTANCE_ID, EVENT_NAME, TIMESTAMP
 from hdijupyterutils.utils import get_instance_id, generate_uuid
-from nose.tools import with_setup, raises
-from mock import MagicMock
 
 import sparkmagic.utils.constants as constants
 from sparkmagic.utils.sparkevents import SparkEvents
 
 
-def _setup():
+def setup_function():
     global spark_events, guid1, guid2, guid3, time_stamp
 
     spark_events = SparkEvents()
@@ -20,11 +21,10 @@ def _setup():
     guid3 = generate_uuid()
 
 
-def _teardown():
+def teardown_function():
     pass
 
 
-@with_setup(_setup, _teardown)
 def test_emit_library_loaded_event():
     event_name = constants.LIBRARY_LOADED_EVENT
     kwargs_list = [
@@ -39,7 +39,6 @@ def test_emit_library_loaded_event():
     spark_events.handler.handle_event.assert_called_once_with(kwargs_list)
 
 
-@with_setup(_setup, _teardown)
 def test_emit_cluster_change_event():
     status_code = 200
 
@@ -60,7 +59,6 @@ def test_emit_cluster_change_event():
     spark_events.handler.handle_event.assert_called_once_with(kwargs_list)
 
 
-@with_setup(_setup, _teardown)
 def test_emit_session_creation_start_event():
     language = constants.SESSION_KIND_SPARK
     event_name = constants.SESSION_CREATION_START_EVENT
@@ -79,7 +77,6 @@ def test_emit_session_creation_start_event():
     spark_events.handler.handle_event.assert_called_once_with(kwargs_list)
 
 
-@with_setup(_setup, _teardown)
 def test_emit_session_creation_end_event():
     language = constants.SESSION_KIND_SPARK
     event_name = constants.SESSION_CREATION_END_EVENT
@@ -107,7 +104,6 @@ def test_emit_session_creation_end_event():
     spark_events.handler.handle_event.assert_called_once_with(kwargs_list)
 
 
-@with_setup(_setup, _teardown)
 def test_emit_session_deletion_start_event():
     language = constants.SESSION_KIND_SPARK
     event_name = constants.SESSION_DELETION_START_EVENT
@@ -130,7 +126,6 @@ def test_emit_session_deletion_start_event():
     spark_events.handler.handle_event.assert_called_once_with(kwargs_list)
 
 
-@with_setup(_setup, _teardown)
 def test_emit_session_deletion_end_event():
     language = constants.SESSION_KIND_SPARK
     event_name = constants.SESSION_DELETION_END_EVENT
@@ -158,7 +153,6 @@ def test_emit_session_deletion_end_event():
     spark_events.handler.handle_event.assert_called_once_with(kwargs_list)
 
 
-@with_setup(_setup, _teardown)
 def test_emit_statement_execution_start_event():
     language = constants.SESSION_KIND_PYSPARK
     session_id = 7
@@ -183,7 +177,6 @@ def test_emit_statement_execution_start_event():
     spark_events.handler.handle_event.assert_called_once_with(kwargs_list)
 
 
-@with_setup(_setup, _teardown)
 def test_emit_statement_execution_end_event():
     language = constants.SESSION_KIND_SPARK
     session_id = 7
@@ -223,7 +216,6 @@ def test_emit_statement_execution_end_event():
     spark_events.handler.handle_event.assert_called_once_with(kwargs_list)
 
 
-@with_setup(_setup, _teardown)
 def test_emit_sql_execution_start_event():
     event_name = constants.SQL_EXECUTION_START_EVENT
     session_id = 22
@@ -254,7 +246,6 @@ def test_emit_sql_execution_start_event():
     spark_events.handler.handle_event.assert_called_once_with(kwargs_list)
 
 
-@with_setup(_setup, _teardown)
 def test_emit_sql_execution_end_event():
     event_name = constants.SQL_EXECUTION_END_EVENT
     session_id = 17
@@ -293,7 +284,6 @@ def test_emit_sql_execution_end_event():
     spark_events.handler.handle_event.assert_called_once_with(kwargs_list)
 
 
-@with_setup(_setup, _teardown)
 def test_emit_magic_execution_start_event():
     event_name = constants.MAGIC_EXECUTION_START_EVENT
     magic_name = "sql"
@@ -315,7 +305,6 @@ def test_emit_magic_execution_start_event():
     spark_events.handler.handle_event.assert_called_once_with(kwargs_list)
 
 
-@with_setup(_setup, _teardown)
 def test_emit_magic_execution_end_event():
     event_name = constants.MAGIC_EXECUTION_END_EVENT
     magic_name = "sql"
@@ -350,6 +339,6 @@ def test_magic_verify_language_ok():
         SparkEvents()._verify_language_ok(language)
 
 
-@raises(AssertionError)
 def test_magic_verify_language_ok_error():
-    SparkEvents()._verify_language_ok("NYARGLEBARGLE")
+    with pytest.raises(AssertionError):
+        SparkEvents()._verify_language_ok("not a real language")

--- a/sparkmagic/sparkmagic/tests/test_sparkkernelbase.py
+++ b/sparkmagic/sparkmagic/tests/test_sparkkernelbase.py
@@ -1,8 +1,6 @@
 import asyncio
 
-
 from unittest.mock import MagicMock, call, patch
-from nose.tools import with_setup
 
 from sparkmagic.kernels.wrapperkernel.sparkkernelbase import SparkKernelBase
 from sparkmagic.utils.constants import LANG_PYTHON
@@ -25,7 +23,7 @@ class TestSparkKernel(SparkKernelBase):
         )
 
 
-def _setup():
+def setup_function():
     global kernel, execute_cell_mock, do_shutdown_mock, ipython_display
 
     user_code_parser = MagicMock(return_value=code)
@@ -38,11 +36,10 @@ def _setup():
     kernel.ipython_display = ipython_display = MagicMock()
 
 
-def _teardown():
+def teardown_function():
     pass
 
 
-@with_setup(_setup, _teardown)
 def test_execute_valid_code():
     # Verify that the execution flows through.
     ret = kernel.do_execute(code, False)
@@ -56,7 +53,6 @@ def test_execute_valid_code():
     assert ipython_display.send_error.call_count == 0
 
 
-@with_setup(_setup, _teardown)
 def test_execute_throws_if_fatal_error_happened():
     # Verify that if a fatal error already happened, we don't run the code and show the fatal error instead.
     fatal_error = "Error."
@@ -70,7 +66,6 @@ def test_execute_throws_if_fatal_error_happened():
     assert ipython_display.send_error.call_count == 1
 
 
-@with_setup(_setup, _teardown)
 def test_execute_alerts_user_if_an_unexpected_error_happens():
     # Verify that developer error shows developer error (the Github link).
     # Because do_execute is so minimal, we'll assume we have a bug in the _repeat_fatal_error method
@@ -83,7 +78,6 @@ def test_execute_alerts_user_if_an_unexpected_error_happens():
     assert ipython_display.send_error.call_count == 1
 
 
-@with_setup(_setup, _teardown)
 def test_execute_throws_if_fatal_error_happens_for_execution():
     # Verify that the kernel sends the error from Python execution's context to the user
     fatal_error = "Error."
@@ -103,7 +97,6 @@ def test_execute_throws_if_fatal_error_happens_for_execution():
     assert ipython_display.send_error.call_count == 1
 
 
-@with_setup(_setup, _teardown)
 def test_shutdown_cleans_up():
     # No restart
     kernel._execute_cell_for_user = ecfu_m = MagicMock()
@@ -124,7 +117,6 @@ def test_shutdown_cleans_up():
     dsi_m.assert_called_once_with(True)
 
 
-@with_setup(_setup, _teardown)
 def test_register_auto_viz():
     kernel._register_auto_viz()
 
@@ -141,7 +133,6 @@ def test_register_auto_viz():
     )
 
 
-@with_setup(_setup, _teardown)
 def test_change_language():
     kernel._change_language()
 
@@ -157,7 +148,6 @@ def test_change_language():
     )
 
 
-@with_setup(_setup, _teardown)
 def test_load_magics():
     kernel._load_magics_extension()
 
@@ -167,7 +157,6 @@ def test_load_magics():
     )
 
 
-@with_setup(_setup, _teardown)
 def test_delete_session():
     kernel._delete_session()
 
@@ -177,7 +166,6 @@ def test_delete_session():
     )
 
 
-@with_setup(_teardown)
 def test_execute_cell_for_user_ipykernel4():
     want = {"status": "OK"}
     # Can't use patch decorator because
@@ -193,7 +181,6 @@ def test_execute_cell_for_user_ipykernel4():
         assert want == got
 
 
-@with_setup(_teardown)
 def test_execute_cell_for_user_ipykernel5():
     want = {"status": "OK"}
     # Can't use patch decorator because
@@ -211,7 +198,6 @@ def test_execute_cell_for_user_ipykernel5():
         assert want == got
 
 
-@with_setup(_teardown)
 def test_execute_cell_for_user_ipykernel6():
     want = {"status": "OK"}
     # Can't use patch decorator because

--- a/sparkmagic/sparkmagic/tests/test_sparkmagicsbase.py
+++ b/sparkmagic/sparkmagic/tests/test_sparkmagicsbase.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
-import sparkmagic.utils.configuration as conf
+import pytest
 from mock import MagicMock
-from nose.tools import with_setup, assert_equals, assert_raises, raises
 
+import sparkmagic.utils.configuration as conf
 from sparkmagic.utils.configuration import get_livy_kind
 from sparkmagic.utils.constants import (
     LANGS_SUPPORTED,
@@ -23,7 +23,7 @@ from sparkmagic.livyclientlib.sqlquery import SQLQuery
 from sparkmagic.livyclientlib.sparkstorecommand import SparkStoreCommand
 
 
-def _setup():
+def setup_function():
     global magic, session, shell, ipython_display
     shell = MagicMock()
     shell.user_ns = {}
@@ -35,7 +35,7 @@ def _setup():
     conf.override_all({})
 
 
-def _teardown():
+def teardown_function():
     pass
 
 
@@ -50,7 +50,6 @@ def test_get_livy_kind_covers_all_langs():
         get_livy_kind(lang)
 
 
-@with_setup(_setup, _teardown)
 def test_sql_df_execution_without_output_var():
     df = 0
     query = SQLQuery("")
@@ -60,10 +59,9 @@ def test_sql_df_execution_without_output_var():
 
     magic.spark_controller.run_sqlquery.assert_called_once_with(query, session)
     assert res == df
-    assert_equals(list(shell.user_ns.keys()), [])
+    assert list(shell.user_ns.keys()) == []
 
 
-@with_setup(_setup, _teardown)
 def test_sql_df_execution_with_output_var():
     df = 0
     query = SQLQuery("")
@@ -79,7 +77,6 @@ def test_sql_df_execution_with_output_var():
     assert shell.user_ns[output_var] == df
 
 
-@with_setup(_setup, _teardown)
 def test_sql_df_execution_quiet_without_output_var():
     df = 0
     cell = SQLQuery("")
@@ -92,10 +89,9 @@ def test_sql_df_execution_quiet_without_output_var():
 
     magic.spark_controller.run_sqlquery.assert_called_once_with(cell, session)
     assert res is None
-    assert_equals(list(shell.user_ns.keys()), [])
+    assert list(shell.user_ns.keys()) == []
 
 
-@with_setup(_setup, _teardown)
 def test_sql_df_execution_quiet_with_output_var():
     df = 0
     cell = SQLQuery("")
@@ -111,7 +107,6 @@ def test_sql_df_execution_quiet_with_output_var():
     assert shell.user_ns[output_var] == df
 
 
-@with_setup(_setup, _teardown)
 def test_sql_df_execution_quiet_with_coerce():
     df = 0
     cell = SQLQuery("", coerce=True)
@@ -127,7 +122,6 @@ def test_sql_df_execution_quiet_with_coerce():
     assert shell.user_ns[output_var] == df
 
 
-@with_setup(_setup, _teardown)
 def test_print_endpoint_info():
     current_session_id = 1
     session1 = MagicMock()
@@ -145,43 +139,39 @@ def test_print_endpoint_info():
     )
 
 
-@with_setup(_setup, _teardown)
 def test_print_empty_endpoint_info():
     current_session_id = None
     magic._print_endpoint_info([], current_session_id)
     magic.ipython_display.html.assert_called_once_with("No active sessions.")
 
 
-@with_setup(_setup, _teardown)
-@raises(BadUserDataException)
 def test_send_to_spark_should_raise_when_variable_value_is_none():
-    input_variable_name = "x_in"
-    output_variable_name = "x_out"
-    var_type = "str"
-    max_rows = 25000
-    magic.shell.user_ns[input_variable_name] = None
+    with pytest.raises(BadUserDataException):
+        input_variable_name = "x_in"
+        output_variable_name = "x_out"
+        var_type = "str"
+        max_rows = 25000
+        magic.shell.user_ns[input_variable_name] = None
 
-    magic.do_send_to_spark(
-        "", input_variable_name, var_type, output_variable_name, max_rows, None
-    )
+        magic.do_send_to_spark(
+            "", input_variable_name, var_type, output_variable_name, max_rows, None
+        )
 
 
-@with_setup(_setup, _teardown)
-@raises(BadUserDataException)
 def test_send_to_spark_should_raise_when_type_is_incorrect():
-    input_variable_name = "x_in"
-    input_variable_value = "x_value"
-    output_variable_name = "x_out"
-    var_type = "incorrect"
-    max_rows = 25000
-    magic.shell.user_ns[input_variable_name] = input_variable_value
+    with pytest.raises(BadUserDataException):
+        input_variable_name = "x_in"
+        input_variable_value = "x_value"
+        output_variable_name = "x_out"
+        var_type = "incorrect"
+        max_rows = 25000
+        magic.shell.user_ns[input_variable_name] = input_variable_value
 
-    magic.do_send_to_spark(
-        "", input_variable_name, var_type, output_variable_name, max_rows, None
-    )
+        magic.do_send_to_spark(
+            "", input_variable_name, var_type, output_variable_name, max_rows, None
+        )
 
 
-@with_setup(_setup, _teardown)
 def test_send_to_spark_should_print_error_when_str_command_failed():
     input_variable_name = "x_in"
     input_variable_value = "x_value"
@@ -204,7 +194,6 @@ def test_send_to_spark_should_print_error_when_str_command_failed():
     assert not magic.ipython_display.write.called
 
 
-@with_setup(_setup, _teardown)
 def test_send_to_spark_should_print_error_when_df_command_failed():
     input_variable_name = "x_in"
     input_variable_value = "x_value"
@@ -227,7 +216,6 @@ def test_send_to_spark_should_print_error_when_df_command_failed():
     assert not magic.ipython_display.write.called
 
 
-@with_setup(_setup, _teardown)
 def test_send_to_spark_should_name_the_output_variable_the_same_as_input_name_when_custom_name_not_provided():
     input_variable_name = "x_in"
     input_variable_value = output_value = "x_value"
@@ -248,7 +236,6 @@ def test_send_to_spark_should_name_the_output_variable_the_same_as_input_name_wh
     assert not magic.ipython_display.send_error.called
 
 
-@with_setup(_setup, _teardown)
 def test_send_to_spark_should_write_successfully_when_everything_is_correct():
     input_variable_name = "x_in"
     input_variable_value = output_value = "x_value"
@@ -269,7 +256,6 @@ def test_send_to_spark_should_write_successfully_when_everything_is_correct():
     assert not magic.ipython_display.send_error.called
 
 
-@with_setup(_setup, _teardown)
 def test_spark_execution_without_output_var():
     output_var = None
 
@@ -283,21 +269,19 @@ def test_spark_execution_without_output_var():
         "out",
         MIMETYPE_TEXT_PLAIN,
     )
-    assert_raises(
-        SparkStatementException,
-        magic.execute_spark,
-        "",
-        output_var,
-        None,
-        None,
-        None,
-        session,
-        True,
-    )
-    assert not magic.spark_controller._spark_store_command.called
+    with pytest.raises(SparkStatementException):
+        magic.execute_spark(
+            "",
+            output_var,
+            None,
+            None,
+            None,
+            session,
+            True,
+        )
+        assert not magic.spark_controller._spark_store_command.called
 
 
-@with_setup(_setup, _teardown)
 def test_spark_execution_with_output_var():
     mockSparkCommand = MagicMock()
     magic._spark_store_command = MagicMock(return_value=mockSparkCommand)
@@ -321,20 +305,18 @@ def test_spark_execution_with_output_var():
         "out",
         MIMETYPE_TEXT_PLAIN,
     )
-    assert_raises(
-        SparkStatementException,
-        magic.execute_spark,
-        "",
-        output_var,
-        None,
-        None,
-        None,
-        session,
-        True,
-    )
+    with pytest.raises(SparkStatementException):
+        magic.execute_spark(
+            "",
+            output_var,
+            None,
+            None,
+            None,
+            session,
+            True,
+        )
 
 
-@with_setup(_setup, _teardown)
 def test_spark_exception_with_output_var():
     mockSparkCommand = MagicMock()
     magic._spark_store_command = MagicMock(return_value=mockSparkCommand)
@@ -346,17 +328,8 @@ def test_spark_exception_with_output_var():
         (True, "out", MIMETYPE_TEXT_PLAIN),
         exception,
     ]
-    assert_raises(
-        BadUserDataException,
-        magic.execute_spark,
-        "",
-        output_var,
-        None,
-        None,
-        None,
-        session,
-        True,
-    )
+    with pytest.raises(BadUserDataException):
+        magic.execute_spark("", output_var, None, None, None, session, True)
     magic.ipython_display.write.assert_called_once_with("out")
     magic._spark_store_command.assert_called_once_with(
         output_var, None, None, None, True
@@ -364,7 +337,6 @@ def test_spark_exception_with_output_var():
     assert shell.user_ns == {}
 
 
-@with_setup(_setup, _teardown)
 def test_spark_statement_exception():
     mockSparkCommand = MagicMock()
     magic._spark_store_command = MagicMock(return_value=mockSparkCommand)
@@ -374,21 +346,11 @@ def test_spark_statement_exception():
         (False, "out", "text/plain"),
         exception,
     ]
-    assert_raises(
-        SparkStatementException,
-        magic.execute_spark,
-        "",
-        None,
-        None,
-        None,
-        None,
-        session,
-        True,
-    )
+    with pytest.raises(SparkStatementException):
+        magic.execute_spark("", None, None, None, None, session, True)
     magic.spark_controller.cleanup.assert_not_called()
 
 
-@with_setup(_setup, _teardown)
 def test_spark_statement_exception_shutdowns_livy_session():
     conf.override_all({"shutdown_session_on_spark_statement_errors": True})
 
@@ -400,15 +362,6 @@ def test_spark_statement_exception_shutdowns_livy_session():
         (False, "out", "text/plain"),
         exception,
     ]
-    assert_raises(
-        SparkStatementException,
-        magic.execute_spark,
-        "",
-        None,
-        None,
-        None,
-        None,
-        session,
-        True,
-    )
+    with pytest.raises(SparkStatementException):
+        magic.execute_spark("", None, None, None, None, session, True)
     magic.spark_controller.cleanup.assert_called_once()

--- a/sparkmagic/sparkmagic/tests/test_sparkstorecommand.py
+++ b/sparkmagic/sparkmagic/tests/test_sparkstorecommand.py
@@ -79,128 +79,106 @@ def test_sparkstorecommand_loads_defaults():
     conf.override_all(defaults)
     variable_name = "var_name"
     sparkcommand = SparkStoreCommand(variable_name)
-    assert (
-        sparkcommand.samplemethod == defaults[conf.default_samplemethod.__name__])
+    assert sparkcommand.samplemethod == defaults[conf.default_samplemethod.__name__]
     assert sparkcommand.maxrows == defaults[conf.default_maxrows.__name__]
-    assert (
-        sparkcommand.samplefraction == defaults[conf.default_samplefraction.__name__])
+    assert sparkcommand.samplefraction == defaults[conf.default_samplefraction.__name__]
 
 
 def test_pyspark_livy_sampling_options():
     variable_name = "var_name"
 
     sparkcommand = SparkStoreCommand(variable_name, samplemethod="take", maxrows=120)
-    assert (
-        sparkcommand._pyspark_command(variable_name) ==
-        Command(
-            "import sys\nfor {} in {}.toJSON(use_unicode=(sys.version_info.major > 2)).take(120): print({})".format(
-                LONG_RANDOM_VARIABLE_NAME, variable_name, LONG_RANDOM_VARIABLE_NAME
-            )
-        ))
+    assert sparkcommand._pyspark_command(variable_name) == Command(
+        "import sys\nfor {} in {}.toJSON(use_unicode=(sys.version_info.major > 2)).take(120): print({})".format(
+            LONG_RANDOM_VARIABLE_NAME, variable_name, LONG_RANDOM_VARIABLE_NAME
+        )
+    )
 
     sparkcommand = SparkStoreCommand(variable_name, samplemethod="take", maxrows=-1)
-    assert (
-        sparkcommand._pyspark_command(variable_name) ==
-        Command(
-            "import sys\nfor {} in {}.toJSON(use_unicode=(sys.version_info.major > 2)).collect(): print({})".format(
-                LONG_RANDOM_VARIABLE_NAME, variable_name, LONG_RANDOM_VARIABLE_NAME
-            )
-        ))
+    assert sparkcommand._pyspark_command(variable_name) == Command(
+        "import sys\nfor {} in {}.toJSON(use_unicode=(sys.version_info.major > 2)).collect(): print({})".format(
+            LONG_RANDOM_VARIABLE_NAME, variable_name, LONG_RANDOM_VARIABLE_NAME
+        )
+    )
 
     sparkcommand = SparkStoreCommand(
         variable_name, samplemethod="sample", samplefraction=0.25, maxrows=-1
     )
-    assert (
-        sparkcommand._pyspark_command(variable_name) ==
-        Command(
-            "import sys\nfor {} in {}.toJSON(use_unicode=(sys.version_info.major > 2)).sample(False, 0.25).collect(): "
-            "print({})".format(
-                LONG_RANDOM_VARIABLE_NAME, variable_name, LONG_RANDOM_VARIABLE_NAME
-            )
-        ))
+    assert sparkcommand._pyspark_command(variable_name) == Command(
+        "import sys\nfor {} in {}.toJSON(use_unicode=(sys.version_info.major > 2)).sample(False, 0.25).collect(): "
+        "print({})".format(
+            LONG_RANDOM_VARIABLE_NAME, variable_name, LONG_RANDOM_VARIABLE_NAME
+        )
+    )
 
     sparkcommand = SparkStoreCommand(
         variable_name, samplemethod="sample", samplefraction=0.33, maxrows=3234
     )
-    assert (
-        sparkcommand._pyspark_command(variable_name) ==
-        Command(
-            "import sys\nfor {} in {}.toJSON(use_unicode=(sys.version_info.major > 2)).sample(False, 0.33).take(3234): "
-            "print({})".format(
-                LONG_RANDOM_VARIABLE_NAME, variable_name, LONG_RANDOM_VARIABLE_NAME
-            )
-        ))
+    assert sparkcommand._pyspark_command(variable_name) == Command(
+        "import sys\nfor {} in {}.toJSON(use_unicode=(sys.version_info.major > 2)).sample(False, 0.33).take(3234): "
+        "print({})".format(
+            LONG_RANDOM_VARIABLE_NAME, variable_name, LONG_RANDOM_VARIABLE_NAME
+        )
+    )
 
     sparkcommand = SparkStoreCommand(
         variable_name, samplemethod="sample", samplefraction=0.33, maxrows=3234
     )
-    assert (
-        sparkcommand._pyspark_command(variable_name) ==
-        Command(
-            "import sys\nfor {} in {}.toJSON(use_unicode=(sys.version_info.major > 2)).sample(False, 0.33).take(3234): "
-            "print({})".format(
-                LONG_RANDOM_VARIABLE_NAME, variable_name, LONG_RANDOM_VARIABLE_NAME
-            )
-        ))
+    assert sparkcommand._pyspark_command(variable_name) == Command(
+        "import sys\nfor {} in {}.toJSON(use_unicode=(sys.version_info.major > 2)).sample(False, 0.33).take(3234): "
+        "print({})".format(
+            LONG_RANDOM_VARIABLE_NAME, variable_name, LONG_RANDOM_VARIABLE_NAME
+        )
+    )
 
     sparkcommand = SparkStoreCommand(variable_name, samplemethod=None, maxrows=100)
-    assert (
-        sparkcommand._pyspark_command(variable_name) ==
-        Command(
-            "import sys\nfor {} in {}.toJSON(use_unicode=(sys.version_info.major > 2)).take(100): print({})".format(
-                LONG_RANDOM_VARIABLE_NAME, variable_name, LONG_RANDOM_VARIABLE_NAME
-            )
-        ))
+    assert sparkcommand._pyspark_command(variable_name) == Command(
+        "import sys\nfor {} in {}.toJSON(use_unicode=(sys.version_info.major > 2)).take(100): print({})".format(
+            LONG_RANDOM_VARIABLE_NAME, variable_name, LONG_RANDOM_VARIABLE_NAME
+        )
+    )
 
     sparkcommand = SparkStoreCommand(variable_name, samplemethod=None, maxrows=100)
-    assert (
-        sparkcommand._pyspark_command(variable_name) ==
-        Command(
-            "import sys\nfor {} in {}.toJSON(use_unicode=(sys.version_info.major > 2)).take(100): print({})".format(
-                LONG_RANDOM_VARIABLE_NAME, variable_name, LONG_RANDOM_VARIABLE_NAME
-            )
-        ))
+    assert sparkcommand._pyspark_command(variable_name) == Command(
+        "import sys\nfor {} in {}.toJSON(use_unicode=(sys.version_info.major > 2)).take(100): print({})".format(
+            LONG_RANDOM_VARIABLE_NAME, variable_name, LONG_RANDOM_VARIABLE_NAME
+        )
+    )
 
 
 def test_scala_livy_sampling_options():
     variable_name = "abc"
 
     sparkcommand = SparkStoreCommand(variable_name, samplemethod="take", maxrows=100)
-    assert (
-        sparkcommand._scala_command(variable_name) ==
-        Command("{}.toJSON.take(100).foreach(println)".format(variable_name)))
+    assert sparkcommand._scala_command(variable_name) == Command(
+        "{}.toJSON.take(100).foreach(println)".format(variable_name)
+    )
 
     sparkcommand = SparkStoreCommand(variable_name, samplemethod="take", maxrows=-1)
-    assert (
-        sparkcommand._scala_command(variable_name) ==
-        Command("{}.toJSON.collect.foreach(println)".format(variable_name)))
+    assert sparkcommand._scala_command(variable_name) == Command(
+        "{}.toJSON.collect.foreach(println)".format(variable_name)
+    )
 
     sparkcommand = SparkStoreCommand(
         variable_name, samplemethod="sample", samplefraction=0.25, maxrows=-1
     )
-    assert (
-        sparkcommand._scala_command(variable_name) ==
-        Command(
-            "{}.toJSON.sample(false, 0.25).collect.foreach(println)".format(
-                variable_name
-            )
-        ))
+    assert sparkcommand._scala_command(variable_name) == Command(
+        "{}.toJSON.sample(false, 0.25).collect.foreach(println)".format(variable_name)
+    )
 
     sparkcommand = SparkStoreCommand(
         variable_name, samplemethod="sample", samplefraction=0.33, maxrows=3234
     )
-    assert (
-        sparkcommand._scala_command(variable_name) ==
-        Command(
-            "{}.toJSON.sample(false, 0.33).take(3234).foreach(println)".format(
-                variable_name
-            )
-        ))
+    assert sparkcommand._scala_command(variable_name) == Command(
+        "{}.toJSON.sample(false, 0.33).take(3234).foreach(println)".format(
+            variable_name
+        )
+    )
 
     sparkcommand = SparkStoreCommand(variable_name, samplemethod=None, maxrows=100)
-    assert (
-        sparkcommand._scala_command(variable_name) ==
-        Command("{}.toJSON.take(100).foreach(println)".format(variable_name)))
+    assert sparkcommand._scala_command(variable_name) == Command(
+        "{}.toJSON.take(100).foreach(println)".format(variable_name)
+    )
 
 
 def test_r_livy_sampling_options():
@@ -208,53 +186,43 @@ def test_r_livy_sampling_options():
 
     sparkcommand = SparkStoreCommand(variable_name, samplemethod="take", maxrows=100)
 
-    assert (
-        sparkcommand._r_command(variable_name) ==
-        Command(
-            "for ({} in (jsonlite::toJSON(take({},100)))) {{cat({})}}".format(
-                LONG_RANDOM_VARIABLE_NAME, variable_name, LONG_RANDOM_VARIABLE_NAME
-            )
-        ))
+    assert sparkcommand._r_command(variable_name) == Command(
+        "for ({} in (jsonlite::toJSON(take({},100)))) {{cat({})}}".format(
+            LONG_RANDOM_VARIABLE_NAME, variable_name, LONG_RANDOM_VARIABLE_NAME
+        )
+    )
 
     sparkcommand = SparkStoreCommand(variable_name, samplemethod="take", maxrows=-1)
-    assert (
-        sparkcommand._r_command(variable_name) ==
-        Command(
-            "for ({} in (jsonlite::toJSON(collect({})))) {{cat({})}}".format(
-                LONG_RANDOM_VARIABLE_NAME, variable_name, LONG_RANDOM_VARIABLE_NAME
-            )
-        ))
+    assert sparkcommand._r_command(variable_name) == Command(
+        "for ({} in (jsonlite::toJSON(collect({})))) {{cat({})}}".format(
+            LONG_RANDOM_VARIABLE_NAME, variable_name, LONG_RANDOM_VARIABLE_NAME
+        )
+    )
 
     sparkcommand = SparkStoreCommand(
         variable_name, samplemethod="sample", samplefraction=0.25, maxrows=-1
     )
-    assert (
-        sparkcommand._r_command(variable_name) ==
-        Command(
-            "for ({} in (jsonlite::toJSON(collect(sample({}, FALSE, 0.25))))) {{cat({})}}".format(
-                LONG_RANDOM_VARIABLE_NAME, variable_name, LONG_RANDOM_VARIABLE_NAME
-            )
-        ))
+    assert sparkcommand._r_command(variable_name) == Command(
+        "for ({} in (jsonlite::toJSON(collect(sample({}, FALSE, 0.25))))) {{cat({})}}".format(
+            LONG_RANDOM_VARIABLE_NAME, variable_name, LONG_RANDOM_VARIABLE_NAME
+        )
+    )
 
     sparkcommand = SparkStoreCommand(
         variable_name, samplemethod="sample", samplefraction=0.33, maxrows=3234
     )
-    assert (
-        sparkcommand._r_command(variable_name) ==
-        Command(
-            "for ({} in (jsonlite::toJSON(take(sample({}, FALSE, 0.33),3234)))) {{cat({})}}".format(
-                LONG_RANDOM_VARIABLE_NAME, variable_name, LONG_RANDOM_VARIABLE_NAME
-            )
-        ))
+    assert sparkcommand._r_command(variable_name) == Command(
+        "for ({} in (jsonlite::toJSON(take(sample({}, FALSE, 0.33),3234)))) {{cat({})}}".format(
+            LONG_RANDOM_VARIABLE_NAME, variable_name, LONG_RANDOM_VARIABLE_NAME
+        )
+    )
 
     sparkcommand = SparkStoreCommand(variable_name, samplemethod=None, maxrows=100)
-    assert (
-        sparkcommand._r_command(variable_name) ==
-        Command(
-            "for ({} in (jsonlite::toJSON(take({},100)))) {{cat({})}}".format(
-                LONG_RANDOM_VARIABLE_NAME, variable_name, LONG_RANDOM_VARIABLE_NAME
-            )
-        ))
+    assert sparkcommand._r_command(variable_name) == Command(
+        "for ({} in (jsonlite::toJSON(take({},100)))) {{cat({})}}".format(
+            LONG_RANDOM_VARIABLE_NAME, variable_name, LONG_RANDOM_VARIABLE_NAME
+        )
+    )
 
 
 def test_execute_code():
@@ -282,13 +250,11 @@ def test_unicode():
     variable_name = "collect 'è'"
 
     sparkcommand = SparkStoreCommand(variable_name, samplemethod="take", maxrows=120)
-    assert (
-        sparkcommand._pyspark_command(variable_name) ==
-        Command(
-            "import sys\nfor {} in {}.toJSON(use_unicode=(sys.version_info.major > 2)).take(120): print({})".format(
-                LONG_RANDOM_VARIABLE_NAME, variable_name, LONG_RANDOM_VARIABLE_NAME
-            )
-        ))
-    assert (
-        sparkcommand._scala_command(variable_name) ==
-        Command("{}.toJSON.take(120).foreach(println)".format(variable_name)))
+    assert sparkcommand._pyspark_command(variable_name) == Command(
+        "import sys\nfor {} in {}.toJSON(use_unicode=(sys.version_info.major > 2)).take(120): print({})".format(
+            LONG_RANDOM_VARIABLE_NAME, variable_name, LONG_RANDOM_VARIABLE_NAME
+        )
+    )
+    assert sparkcommand._scala_command(variable_name) == Command(
+        "{}.toJSON.take(120).foreach(println)".format(variable_name)
+    )

--- a/sparkmagic/sparkmagic/tests/test_sqlquery.py
+++ b/sparkmagic/sparkmagic/tests/test_sqlquery.py
@@ -1,6 +1,6 @@
 ﻿# coding=utf-8
+import pytest
 from mock import MagicMock, call
-from nose.tools import with_setup, assert_equals, assert_false, raises
 import pandas as pd
 from pandas.testing import assert_frame_equal
 
@@ -11,15 +11,6 @@ from sparkmagic.livyclientlib.command import Command
 from sparkmagic.livyclientlib.exceptions import BadUserDataException
 
 
-def _setup():
-    pass
-
-
-def _teardown():
-    pass
-
-
-@with_setup(_setup, _teardown)
 def test_to_command_pyspark():
     variable_name = "var_name"
     sqlquery = SQLQuery("Query")
@@ -28,20 +19,18 @@ def test_to_command_pyspark():
     sqlquery._pyspark_command.assert_called_with(variable_name)
 
 
-@with_setup(_setup, _teardown)
 def test_sqlquery_initializes():
     query = "HERE IS MY SQL QUERY SELECT * FROM CREATE DROP TABLE"
     samplemethod = "take"
     maxrows = 120
     samplefraction = 0.6
     sqlquery = SQLQuery(query, samplemethod, maxrows, samplefraction)
-    assert_equals(sqlquery.query, query)
-    assert_equals(sqlquery.samplemethod, samplemethod)
-    assert_equals(sqlquery.maxrows, maxrows)
-    assert_equals(sqlquery.samplefraction, samplefraction)
+    assert sqlquery.query == query
+    assert sqlquery.samplemethod == samplemethod
+    assert sqlquery.maxrows == maxrows
+    assert sqlquery.samplefraction == samplefraction
 
 
-@with_setup(_setup, _teardown)
 def test_sqlquery_loads_defaults():
     defaults = {
         conf.default_samplemethod.__name__: "sample",
@@ -51,168 +40,116 @@ def test_sqlquery_loads_defaults():
     conf.override_all(defaults)
     query = "DROP TABLE USERS;"
     sqlquery = SQLQuery(query)
-    assert_equals(sqlquery.query, query)
-    assert_equals(sqlquery.samplemethod, defaults[conf.default_samplemethod.__name__])
-    assert_equals(sqlquery.maxrows, defaults[conf.default_maxrows.__name__])
-    assert_equals(
-        sqlquery.samplefraction, defaults[conf.default_samplefraction.__name__]
-    )
+    assert sqlquery.query == query
+    assert sqlquery.samplemethod == defaults[conf.default_samplemethod.__name__]
+    assert sqlquery.maxrows == defaults[conf.default_maxrows.__name__]
+    assert sqlquery.samplefraction == defaults[conf.default_samplefraction.__name__]
 
 
-@with_setup(_setup, _teardown)
-@raises(BadUserDataException)
 def test_sqlquery_rejects_bad_data():
-    query = "HERE IS MY SQL QUERY SELECT * FROM CREATE DROP TABLE"
-    samplemethod = "foo"
-    _ = SQLQuery(query, samplemethod)
+    with pytest.raises(BadUserDataException):
+        query = "HERE IS MY SQL QUERY SELECT * FROM CREATE DROP TABLE"
+        samplemethod = "foo"
+        _ = SQLQuery(query, samplemethod)
 
 
-@with_setup(_setup, _teardown)
 def test_pyspark_livy_sql_options():
     query = "abc"
 
     sqlquery = SQLQuery(query, samplemethod="take", maxrows=120)
-    assert_equals(
-        sqlquery._pyspark_command("sqlContext"),
-        Command(
-            'import sys\nfor {} in sqlContext.sql(u"""{} """).toJSON(use_unicode=(sys.version_info.major > 2)).take(120): print({})'.format(
-                LONG_RANDOM_VARIABLE_NAME, query, LONG_RANDOM_VARIABLE_NAME
-            )
-        ),
+    assert sqlquery._pyspark_command("sqlContext") == Command(
+        'import sys\nfor {} in sqlContext.sql(u"""{} """).toJSON(use_unicode=(sys.version_info.major > 2)).take(120): print({})'.format(
+            LONG_RANDOM_VARIABLE_NAME, query, LONG_RANDOM_VARIABLE_NAME
+        )
     )
 
     sqlquery = SQLQuery(query, samplemethod="take", maxrows=-1)
-    assert_equals(
-        sqlquery._pyspark_command("sqlContext"),
-        Command(
-            'import sys\nfor {} in sqlContext.sql(u"""{} """).toJSON(use_unicode=(sys.version_info.major > 2)).collect(): print({})'.format(
-                LONG_RANDOM_VARIABLE_NAME, query, LONG_RANDOM_VARIABLE_NAME
-            )
-        ),
+    assert sqlquery._pyspark_command("sqlContext") == Command(
+        'import sys\nfor {} in sqlContext.sql(u"""{} """).toJSON(use_unicode=(sys.version_info.major > 2)).collect(): print({})'.format(
+            LONG_RANDOM_VARIABLE_NAME, query, LONG_RANDOM_VARIABLE_NAME
+        )
     )
 
     sqlquery = SQLQuery(query, samplemethod="sample", samplefraction=0.25, maxrows=-1)
-    assert_equals(
-        sqlquery._pyspark_command("sqlContext"),
-        Command(
-            'import sys\nfor {} in sqlContext.sql(u"""{} """).toJSON(use_unicode=(sys.version_info.major > 2)).sample(False, 0.25).collect(): '
-            "print({})".format(
-                LONG_RANDOM_VARIABLE_NAME, query, LONG_RANDOM_VARIABLE_NAME
-            )
-        ),
+    assert sqlquery._pyspark_command("sqlContext") == Command(
+        'import sys\nfor {} in sqlContext.sql(u"""{} """).toJSON(use_unicode=(sys.version_info.major > 2)).sample(False, 0.25).collect(): '
+        "print({})".format(LONG_RANDOM_VARIABLE_NAME, query, LONG_RANDOM_VARIABLE_NAME)
     )
 
     sqlquery = SQLQuery(query, samplemethod="sample", samplefraction=0.33, maxrows=3234)
-    assert_equals(
-        sqlquery._pyspark_command("sqlContext"),
-        Command(
-            'import sys\nfor {} in sqlContext.sql(u"""{} """).toJSON(use_unicode=(sys.version_info.major > 2)).sample(False, 0.33).take(3234): '
-            "print({})".format(
-                LONG_RANDOM_VARIABLE_NAME, query, LONG_RANDOM_VARIABLE_NAME
-            )
-        ),
+    assert sqlquery._pyspark_command("sqlContext") == Command(
+        'import sys\nfor {} in sqlContext.sql(u"""{} """).toJSON(use_unicode=(sys.version_info.major > 2)).sample(False, 0.33).take(3234): '
+        "print({})".format(LONG_RANDOM_VARIABLE_NAME, query, LONG_RANDOM_VARIABLE_NAME)
     )
 
     sqlquery = SQLQuery(query, samplemethod="sample", samplefraction=0.33, maxrows=3234)
-    assert_equals(
-        sqlquery._pyspark_command("spark"),
-        Command(
-            'import sys\nfor {} in spark.sql(u"""{} """).toJSON(use_unicode=(sys.version_info.major > 2)).sample(False, 0.33).take(3234): '
-            "print({})".format(
-                LONG_RANDOM_VARIABLE_NAME, query, LONG_RANDOM_VARIABLE_NAME
-            )
-        ),
+    assert sqlquery._pyspark_command("spark") == Command(
+        'import sys\nfor {} in spark.sql(u"""{} """).toJSON(use_unicode=(sys.version_info.major > 2)).sample(False, 0.33).take(3234): '
+        "print({})".format(LONG_RANDOM_VARIABLE_NAME, query, LONG_RANDOM_VARIABLE_NAME)
     )
 
 
-@with_setup(_setup, _teardown)
 def test_scala_livy_sql_options():
     query = "abc"
 
     sqlquery = SQLQuery(query, samplemethod="take", maxrows=100)
-    assert_equals(
-        sqlquery._scala_command("sqlContext"),
-        Command(
-            'sqlContext.sql("""{}""").toJSON.take(100).foreach(println)'.format(query)
-        ),
+    assert sqlquery._scala_command("sqlContext") == Command(
+        'sqlContext.sql("""{}""").toJSON.take(100).foreach(println)'.format(query)
     )
 
     sqlquery = SQLQuery(query, samplemethod="take", maxrows=-1)
-    assert_equals(
-        sqlquery._scala_command("sqlContext"),
-        Command(
-            'sqlContext.sql("""{}""").toJSON.collect.foreach(println)'.format(query)
-        ),
+    assert sqlquery._scala_command("sqlContext") == Command(
+        'sqlContext.sql("""{}""").toJSON.collect.foreach(println)'.format(query)
     )
 
     sqlquery = SQLQuery(query, samplemethod="sample", samplefraction=0.25, maxrows=-1)
-    assert_equals(
-        sqlquery._scala_command("sqlContext"),
-        Command(
-            'sqlContext.sql("""{}""").toJSON.sample(false, 0.25).collect.foreach(println)'.format(
-                query
-            )
-        ),
+    assert sqlquery._scala_command("sqlContext") == Command(
+        'sqlContext.sql("""{}""").toJSON.sample(false, 0.25).collect.foreach(println)'.format(
+            query
+        )
     )
 
     sqlquery = SQLQuery(query, samplemethod="sample", samplefraction=0.33, maxrows=3234)
-    assert_equals(
-        sqlquery._scala_command("sqlContext"),
-        Command(
-            'sqlContext.sql("""{}""").toJSON.sample(false, 0.33).take(3234).foreach(println)'.format(
-                query
-            )
-        ),
+    assert sqlquery._scala_command("sqlContext") == Command(
+        'sqlContext.sql("""{}""").toJSON.sample(false, 0.33).take(3234).foreach(println)'.format(
+            query
+        )
     )
 
 
-@with_setup(_setup, _teardown)
 def test_r_livy_sql_options_spark():
     query = "abc"
     sqlquery = SQLQuery(query, samplemethod="take", maxrows=100)
     sqlContext = "sqlContext"
 
-    assert_equals(
-        sqlquery._r_command(sqlContext),
-        Command(
-            'for ({} in (jsonlite:::toJSON(take(sql({}, "{}"),100)))) {{cat({})}}'.format(
-                LONG_RANDOM_VARIABLE_NAME, sqlContext, query, LONG_RANDOM_VARIABLE_NAME
-            )
-        ),
+    assert sqlquery._r_command(sqlContext) == Command(
+        'for ({} in (jsonlite:::toJSON(take(sql({}, "{}"),100)))) {{cat({})}}'.format(
+            LONG_RANDOM_VARIABLE_NAME, sqlContext, query, LONG_RANDOM_VARIABLE_NAME
+        )
     )
 
     sqlquery = SQLQuery(query, samplemethod="take", maxrows=-1)
-    assert_equals(
-        sqlquery._r_command(sqlContext),
-        Command(
-            'for ({} in (jsonlite:::toJSON(collect(sql({}, "{}"))))) {{cat({})}}'.format(
-                LONG_RANDOM_VARIABLE_NAME, sqlContext, query, LONG_RANDOM_VARIABLE_NAME
-            )
-        ),
+    assert sqlquery._r_command(sqlContext) == Command(
+        'for ({} in (jsonlite:::toJSON(collect(sql({}, "{}"))))) {{cat({})}}'.format(
+            LONG_RANDOM_VARIABLE_NAME, sqlContext, query, LONG_RANDOM_VARIABLE_NAME
+        )
     )
 
     sqlquery = SQLQuery(query, samplemethod="sample", samplefraction=0.25, maxrows=-1)
-    assert_equals(
-        sqlquery._r_command(sqlContext),
-        Command(
-            'for ({} in (jsonlite:::toJSON(collect(sample(sql({}, "{}"), FALSE, 0.25))))) {{cat({})}}'.format(
-                LONG_RANDOM_VARIABLE_NAME, sqlContext, query, LONG_RANDOM_VARIABLE_NAME
-            )
-        ),
+    assert sqlquery._r_command(sqlContext) == Command(
+        'for ({} in (jsonlite:::toJSON(collect(sample(sql({}, "{}"), FALSE, 0.25))))) {{cat({})}}'.format(
+            LONG_RANDOM_VARIABLE_NAME, sqlContext, query, LONG_RANDOM_VARIABLE_NAME
+        )
     )
 
     sqlquery = SQLQuery(query, samplemethod="sample", samplefraction=0.33, maxrows=3234)
-    assert_equals(
-        sqlquery._r_command(sqlContext),
-        Command(
-            'for ({} in (jsonlite:::toJSON(take(sample(sql({}, "{}"), FALSE, 0.33),3234)))) {{cat({})}}'.format(
-                LONG_RANDOM_VARIABLE_NAME, sqlContext, query, LONG_RANDOM_VARIABLE_NAME
-            )
-        ),
+    assert sqlquery._r_command(sqlContext) == Command(
+        'for ({} in (jsonlite:::toJSON(take(sample(sql({}, "{}"), FALSE, 0.33),3234)))) {{cat({})}}'.format(
+            LONG_RANDOM_VARIABLE_NAME, sqlContext, query, LONG_RANDOM_VARIABLE_NAME
+        )
     )
 
 
-@with_setup(_setup, _teardown)
 def test_execute_sql():
     spark_events = MagicMock()
     sqlquery = SQLQuery(
@@ -248,7 +185,6 @@ def test_execute_sql():
     )
 
 
-@with_setup(_setup, _teardown)
 def test_execute_sql_no_results():
     global executed_once
     executed_once = False
@@ -289,7 +225,6 @@ def test_execute_sql_no_results():
     )
 
 
-@with_setup(_setup, _teardown)
 def test_execute_sql_failure_emits_event():
     spark_events = MagicMock()
     sqlquery = SQLQuery("HERE IS THE QUERY", "take", 100, 0.2, spark_events)
@@ -314,158 +249,111 @@ def test_execute_sql_failure_emits_event():
         )
 
 
-@with_setup(_setup, _teardown)
 def test_unicode_sql():
     query = "SELECT 'è'"
     longvar = LONG_RANDOM_VARIABLE_NAME
 
     sqlquery = SQLQuery(query, samplemethod="take", maxrows=120)
-    assert_equals(
-        sqlquery._pyspark_command("spark"),
-        Command(
-            'import sys\nfor {} in spark.sql(u"""{} """).toJSON(use_unicode=(sys.version_info.major > 2)).take(120): print({})'.format(
-                longvar, query, longvar
-            )
-        ),
+    assert sqlquery._pyspark_command("spark") == Command(
+        'import sys\nfor {} in spark.sql(u"""{} """).toJSON(use_unicode=(sys.version_info.major > 2)).take(120): print({})'.format(
+            longvar, query, longvar
+        )
     )
-    assert_equals(
-        sqlquery._scala_command("spark"),
-        Command('spark.sql("""{}""").toJSON.take(120).foreach(println)'.format(query)),
+    assert sqlquery._scala_command("spark") == Command(
+        'spark.sql("""{}""").toJSON.take(120).foreach(println)'.format(query)
     )
-    assert_equals(
-        sqlquery._r_command("spark"),
-        Command(
-            'for ({} in (jsonlite:::toJSON(take(sql("{}"),120)))) {{cat({})}}'.format(
-                longvar, query, longvar
-            )
-        ),
+    assert sqlquery._r_command("spark") == Command(
+        'for ({} in (jsonlite:::toJSON(take(sql("{}"),120)))) {{cat({})}}'.format(
+            longvar, query, longvar
+        )
     )
 
 
-@with_setup(_setup, _teardown)
 def test_pyspark_livy_sql_options_spark2():
     query = "abc"
     sqlquery = SQLQuery(query, samplemethod="take", maxrows=120)
 
-    assert_equals(
-        sqlquery._pyspark_command("spark"),
-        Command(
-            'import sys\nfor {} in spark.sql(u"""{} """).toJSON(use_unicode=(sys.version_info.major > 2)).take(120): print({})'.format(
-                LONG_RANDOM_VARIABLE_NAME, query, LONG_RANDOM_VARIABLE_NAME
-            )
-        ),
+    assert sqlquery._pyspark_command("spark") == Command(
+        'import sys\nfor {} in spark.sql(u"""{} """).toJSON(use_unicode=(sys.version_info.major > 2)).take(120): print({})'.format(
+            LONG_RANDOM_VARIABLE_NAME, query, LONG_RANDOM_VARIABLE_NAME
+        )
     )
 
     sqlquery = SQLQuery(query, samplemethod="take", maxrows=-1)
-    assert_equals(
-        sqlquery._pyspark_command("spark"),
-        Command(
-            'import sys\nfor {} in spark.sql(u"""{} """).toJSON(use_unicode=(sys.version_info.major > 2)).collect(): print({})'.format(
-                LONG_RANDOM_VARIABLE_NAME, query, LONG_RANDOM_VARIABLE_NAME
-            )
-        ),
+    assert sqlquery._pyspark_command("spark") == Command(
+        'import sys\nfor {} in spark.sql(u"""{} """).toJSON(use_unicode=(sys.version_info.major > 2)).collect(): print({})'.format(
+            LONG_RANDOM_VARIABLE_NAME, query, LONG_RANDOM_VARIABLE_NAME
+        )
     )
 
     sqlquery = SQLQuery(query, samplemethod="sample", samplefraction=0.25, maxrows=-1)
-    assert_equals(
-        sqlquery._pyspark_command("spark"),
-        Command(
-            'import sys\nfor {} in spark.sql(u"""{} """).toJSON(use_unicode=(sys.version_info.major > 2)).sample(False, 0.25).collect(): '
-            "print({})".format(
-                LONG_RANDOM_VARIABLE_NAME, query, LONG_RANDOM_VARIABLE_NAME
-            )
-        ),
+    assert sqlquery._pyspark_command("spark") == Command(
+        'import sys\nfor {} in spark.sql(u"""{} """).toJSON(use_unicode=(sys.version_info.major > 2)).sample(False, 0.25).collect(): '
+        "print({})".format(LONG_RANDOM_VARIABLE_NAME, query, LONG_RANDOM_VARIABLE_NAME)
     )
 
     sqlquery = SQLQuery(query, samplemethod="sample", samplefraction=0.33, maxrows=3234)
-    assert_equals(
-        sqlquery._pyspark_command("spark"),
-        Command(
-            'import sys\nfor {} in spark.sql(u"""{} """).toJSON(use_unicode=(sys.version_info.major > 2)).sample(False, 0.33).take(3234): '
-            "print({})".format(
-                LONG_RANDOM_VARIABLE_NAME, query, LONG_RANDOM_VARIABLE_NAME
-            )
-        ),
+    assert sqlquery._pyspark_command("spark") == Command(
+        'import sys\nfor {} in spark.sql(u"""{} """).toJSON(use_unicode=(sys.version_info.major > 2)).sample(False, 0.33).take(3234): '
+        "print({})".format(LONG_RANDOM_VARIABLE_NAME, query, LONG_RANDOM_VARIABLE_NAME)
     )
 
 
-@with_setup(_setup, _teardown)
 def test_scala_livy_sql_options_spark2():
     query = "abc"
     sqlquery = SQLQuery(query, samplemethod="take", maxrows=100)
 
-    assert_equals(
-        sqlquery._scala_command("spark"),
-        Command('spark.sql("""{}""").toJSON.take(100).foreach(println)'.format(query)),
+    assert sqlquery._scala_command("spark") == Command(
+        'spark.sql("""{}""").toJSON.take(100).foreach(println)'.format(query)
     )
 
     sqlquery = SQLQuery(query, samplemethod="take", maxrows=-1)
-    assert_equals(
-        sqlquery._scala_command("spark"),
-        Command('spark.sql("""{}""").toJSON.collect.foreach(println)'.format(query)),
+    assert sqlquery._scala_command("spark") == Command(
+        'spark.sql("""{}""").toJSON.collect.foreach(println)'.format(query)
     )
 
     sqlquery = SQLQuery(query, samplemethod="sample", samplefraction=0.25, maxrows=-1)
-    assert_equals(
-        sqlquery._scala_command("spark"),
-        Command(
-            'spark.sql("""{}""").toJSON.sample(false, 0.25).collect.foreach(println)'.format(
-                query
-            )
-        ),
+    assert sqlquery._scala_command("spark") == Command(
+        'spark.sql("""{}""").toJSON.sample(false, 0.25).collect.foreach(println)'.format(
+            query
+        )
     )
 
     sqlquery = SQLQuery(query, samplemethod="sample", samplefraction=0.33, maxrows=3234)
-    assert_equals(
-        sqlquery._scala_command("spark"),
-        Command(
-            'spark.sql("""{}""").toJSON.sample(false, 0.33).take(3234).foreach(println)'.format(
-                query
-            )
-        ),
+    assert sqlquery._scala_command("spark") == Command(
+        'spark.sql("""{}""").toJSON.sample(false, 0.33).take(3234).foreach(println)'.format(
+            query
+        )
     )
 
 
-@with_setup(_setup, _teardown)
 def test_r_livy_sql_options_spark2():
     query = "abc"
     sqlquery = SQLQuery(query, samplemethod="take", maxrows=100)
 
-    assert_equals(
-        sqlquery._r_command("spark"),
-        Command(
-            'for ({} in (jsonlite:::toJSON(take(sql("{}"),100)))) {{cat({})}}'.format(
-                LONG_RANDOM_VARIABLE_NAME, query, LONG_RANDOM_VARIABLE_NAME
-            )
-        ),
+    assert sqlquery._r_command("spark") == Command(
+        'for ({} in (jsonlite:::toJSON(take(sql("{}"),100)))) {{cat({})}}'.format(
+            LONG_RANDOM_VARIABLE_NAME, query, LONG_RANDOM_VARIABLE_NAME
+        )
     )
 
     sqlquery = SQLQuery(query, samplemethod="take", maxrows=-1)
-    assert_equals(
-        sqlquery._r_command("spark"),
-        Command(
-            'for ({} in (jsonlite:::toJSON(collect(sql("{}"))))) {{cat({})}}'.format(
-                LONG_RANDOM_VARIABLE_NAME, query, LONG_RANDOM_VARIABLE_NAME
-            )
-        ),
+    assert sqlquery._r_command("spark") == Command(
+        'for ({} in (jsonlite:::toJSON(collect(sql("{}"))))) {{cat({})}}'.format(
+            LONG_RANDOM_VARIABLE_NAME, query, LONG_RANDOM_VARIABLE_NAME
+        )
     )
 
     sqlquery = SQLQuery(query, samplemethod="sample", samplefraction=0.25, maxrows=-1)
-    assert_equals(
-        sqlquery._r_command("spark"),
-        Command(
-            'for ({} in (jsonlite:::toJSON(collect(sample(sql("{}"), FALSE, 0.25))))) {{cat({})}}'.format(
-                LONG_RANDOM_VARIABLE_NAME, query, LONG_RANDOM_VARIABLE_NAME
-            )
-        ),
+    assert sqlquery._r_command("spark") == Command(
+        'for ({} in (jsonlite:::toJSON(collect(sample(sql("{}"), FALSE, 0.25))))) {{cat({})}}'.format(
+            LONG_RANDOM_VARIABLE_NAME, query, LONG_RANDOM_VARIABLE_NAME
+        )
     )
 
     sqlquery = SQLQuery(query, samplemethod="sample", samplefraction=0.33, maxrows=3234)
-    assert_equals(
-        sqlquery._r_command("spark"),
-        Command(
-            'for ({} in (jsonlite:::toJSON(take(sample(sql("{}"), FALSE, 0.33),3234)))) {{cat({})}}'.format(
-                LONG_RANDOM_VARIABLE_NAME, query, LONG_RANDOM_VARIABLE_NAME
-            )
-        ),
+    assert sqlquery._r_command("spark") == Command(
+        'for ({} in (jsonlite:::toJSON(take(sample(sql("{}"), FALSE, 0.33),3234)))) {{cat({})}}'.format(
+            LONG_RANDOM_VARIABLE_NAME, query, LONG_RANDOM_VARIABLE_NAME
+        )
     )

--- a/sparkmagic/sparkmagic/tests/test_usercodeparser.py
+++ b/sparkmagic/sparkmagic/tests/test_usercodeparser.py
@@ -1,6 +1,4 @@
 # coding=utf-8
-from nose.tools import assert_equals
-
 from sparkmagic.kernels.wrapperkernel.usercodeparser import UserCodeParser
 from sparkmagic.kernels.kernelmagics import KernelMagics
 
@@ -8,14 +6,14 @@ from sparkmagic.kernels.kernelmagics import KernelMagics
 def test_empty_string():
     parser = UserCodeParser()
 
-    assert_equals("", parser.get_code_to_run(""))
+    assert "" == parser.get_code_to_run("")
 
 
 def test_spark_code():
     parser = UserCodeParser()
     cell = "my code\nand more"
 
-    assert_equals("%%spark\nmy code\nand more", parser.get_code_to_run(cell))
+    assert "%%spark\nmy code\nand more" == parser.get_code_to_run(cell)
 
 
 def test_local_single():
@@ -25,7 +23,7 @@ hi
 hi
 hi"""
 
-    assert_equals("hi\nhi\nhi", parser.get_code_to_run(cell))
+    assert "hi\nhi\nhi" == parser.get_code_to_run(cell)
 
 
 def test_local_double():
@@ -35,7 +33,7 @@ hi
 hi
 hi"""
 
-    assert_equals("hi\nhi\nhi", parser.get_code_to_run(cell))
+    assert "hi\nhi\nhi" == parser.get_code_to_run(cell)
 
 
 def test_our_line_magics():
@@ -43,7 +41,7 @@ def test_our_line_magics():
     magic_name = KernelMagics.info.__name__
     cell = "%{}".format(magic_name)
 
-    assert_equals("%%{}\n ".format(magic_name), parser.get_code_to_run(cell))
+    assert "%%{}\n ".format(magic_name) == parser.get_code_to_run(cell)
 
 
 def test_our_line_magics_with_content():
@@ -55,10 +53,9 @@ more content""".format(
         magic_name
     )
 
-    assert_equals(
-        "%%{}\nmy content\nmore content\n ".format(magic_name),
-        parser.get_code_to_run(cell),
-    )
+    assert "%%{}\nmy content\nmore content\n ".format(
+        magic_name
+    ) == parser.get_code_to_run(cell)
 
 
 def test_other_cell_magic():
@@ -68,7 +65,7 @@ hi
 hi
 hi"""
 
-    assert_equals("{}".format(cell), parser.get_code_to_run(cell))
+    assert "{}".format(cell) == parser.get_code_to_run(cell)
 
 
 def test_other_line_magic():
@@ -78,7 +75,7 @@ hi
 hi
 hi"""
 
-    assert_equals(cell, parser.get_code_to_run(cell))
+    assert cell == parser.get_code_to_run(cell)
 
 
 def test_scala_code():
@@ -88,14 +85,14 @@ def test_scala_code():
 val fruits = sc.textFile("wasb:///example/data/fruits.txt")
 val yellowThings = sc.textFile("wasb:///example/data/yellowthings.txt")"""
 
-    assert_equals("%%spark\n{}".format(cell), parser.get_code_to_run(cell))
+    assert "%%spark\n{}".format(cell) == parser.get_code_to_run(cell)
 
 
 def test_unicode():
     parser = UserCodeParser()
     cell = "print 'è🐙🐙🐙🐙'"
 
-    assert_equals("%%spark\n{}".format(cell), parser.get_code_to_run(cell))
+    assert "%%spark\n{}".format(cell) == parser.get_code_to_run(cell)
 
 
 def test_unicode_in_magics():
@@ -107,10 +104,9 @@ more content""".format(
         magic_name
     )
 
-    assert_equals(
-        "%%{}\nmy content è🐙\nmore content\n ".format(magic_name),
-        parser.get_code_to_run(cell),
-    )
+    assert "%%{}\nmy content è🐙\nmore content\n ".format(
+        magic_name
+    ) == parser.get_code_to_run(cell)
 
 
 def test_unicode_in_double_magics():
@@ -122,7 +118,6 @@ more content""".format(
         magic_name
     )
 
-    assert_equals(
-        "%%{}\nmy content è🐙\nmore content\n ".format(magic_name),
-        parser.get_code_to_run(cell),
-    )
+    assert "%%{}\nmy content è🐙\nmore content\n ".format(
+        magic_name
+    ) == parser.get_code_to_run(cell)

--- a/sparkmagic/sparkmagic/tests/test_utils.py
+++ b/sparkmagic/sparkmagic/tests/test_utils.py
@@ -1,7 +1,6 @@
 from IPython.core.error import UsageError
 from mock import MagicMock
 import numpy as np
-from nose.tools import assert_equals, assert_is
 import pandas as pd
 from pandas.testing import assert_frame_equal
 
@@ -27,7 +26,7 @@ def test_parse_argstring_or_throw():
         )
         assert False
     except BadUserDataException as e:
-        assert_equals(str(e), str(parse_argstring.side_effect))
+        assert str(e) == str(parse_argstring.side_effect)
 
     parse_argstring = MagicMock(side_effect=ValueError("AN UNKNOWN ERROR HAPPENED"))
     try:
@@ -36,7 +35,7 @@ def test_parse_argstring_or_throw():
         )
         assert False
     except ValueError as e:
-        assert_is(e, parse_argstring.side_effect)
+        assert e is parse_argstring.side_effect
 
 
 def test_records_to_dataframe_missing_value_first():


### PR DESCRIPTION
### Description
<!-- FILL IN -->
Relates to https://github.com/jupyter-incubator/sparkmagic/pull/757 

[nose](https://nose.readthedocs.io/en/latest/) has been deprecated for years. We were blocked from adding "official" support for Python versions >3.9 until we migrated off of it. This PR migrates off `nose` by

1. Running [nose2pytest](https://github.com/pytest-dev/nose2pytest) for automated assert conversion
2. Running the following commands in vim for setup/teardown conversion
```
:%s/_setup()/setup_function()/g
:%s/_teardowm()/teardown_function()/g
/@with_setup
:g// norm dd
```
3. Manually converting calls to `@raises` and `assert_raises` to use `with pytest.raises`

### Checklist
- [x] Wrote a description of my changes above 
- [x] Formatted my code with [`black`](https://black.readthedocs.io/en/stable/index.html)
- [ ] Added a bullet point for my changes to the top of the `CHANGELOG.md` file
- [x] Added or modified unit tests to reflect my changes
- [ ] Manually tested with a notebook
- [ ] If adding a feature, there is an example notebook and/or documentation in the `README.md` file
