### PR TITLE
feat: support ipywidgets>8 by passing tuples to dropdown instead of dict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Updates
 * Add official support for Python 3.10 and 3.11
 
+### Bug Fixes
+* Support `ipywidgets==8.0.0` 
+
 ## 0.20.1
 
 ### Bug Fixes

--- a/autovizwidget/autovizwidget/tests/test_encodingwidget.py
+++ b/autovizwidget/autovizwidget/tests/test_encodingwidget.py
@@ -55,16 +55,23 @@ def test_encoding_with_all_none_doesnt_throw():
 
     EncodingWidget(df, encoding, change_hook, ipywidget_factory, testing=True)
 
+    #  call(options=[('-', None), ('buildingID', 'buildingID'), ('date', 'date'), ('temp_diff', 'temp_diff')], description='X', value=None),
+    #  call().on_trait_change(<bound method EncodingWidget._x_changed_callback of EncodingWidget(children=(<MagicMock name='mock.get_vbox()' spec='Widget' id='4770343872'>,))>, 'value'),
+    #  call(options=[('-', None), ('buildingID', 'buildingID'), ('date', 'date'), ('temp_diff', 'temp_diff')], description='Y', value=None),
+    #  call().on_trait_change(<bound method EncodingWidget._y_changed_callback of EncodingWidget(children=(<MagicMock name='mock.get_vbox()' spec='Widget' id='4770343872'>,))>, 'value'),
+    #  call(options=[('-', 'None'), ('Avg', 'Avg'), ('Min', 'Min'), ('Max', 'Max'), ('Sum', 'Sum'), ('Count', 'Count')], description='Func.', value='none'),
+    #  call().on_trait_change(<bound method EncodingWidget._y_agg_changed_callback of EncodingWidget(children=(<MagicMock name='mock.get_vbox()' spec='Widget' id='4770343872'>,))>, 'value')
+
     assert (
         call(
             description="X",
             value=None,
-            options={
-                "date": "date",
-                "temp_diff": "temp_diff",
-                "-": None,
-                "buildingID": "buildingID",
-            },
+            options=[
+                ("-", None),
+                ("buildingID", "buildingID"),
+                ("date", "date"),
+                ("temp_diff", "temp_diff"),
+            ],
         )
         in ipywidget_factory.get_dropdown.mock_calls
     )
@@ -72,12 +79,12 @@ def test_encoding_with_all_none_doesnt_throw():
         call(
             description="Y",
             value=None,
-            options={
-                "date": "date",
-                "temp_diff": "temp_diff",
-                "-": None,
-                "buildingID": "buildingID",
-            },
+            options=[
+                ("-", None),
+                ("buildingID", "buildingID"),
+                ("date", "date"),
+                ("temp_diff", "temp_diff"),
+            ],
         )
         in ipywidget_factory.get_dropdown.mock_calls
     )
@@ -85,14 +92,14 @@ def test_encoding_with_all_none_doesnt_throw():
         call(
             description="Func.",
             value="none",
-            options={
-                "Max": "Max",
-                "Sum": "Sum",
-                "Avg": "Avg",
-                "-": "None",
-                "Min": "Min",
-                "Count": "Count",
-            },
+            options=[
+                ("-", "None"),
+                ("Avg", "Avg"),
+                ("Min", "Min"),
+                ("Max", "Max"),
+                ("Sum", "Sum"),
+                ("Count", "Count"),
+            ],
         )
         in ipywidget_factory.get_dropdown.mock_calls
     )

--- a/autovizwidget/autovizwidget/tests/test_encodingwidget.py
+++ b/autovizwidget/autovizwidget/tests/test_encodingwidget.py
@@ -55,13 +55,6 @@ def test_encoding_with_all_none_doesnt_throw():
 
     EncodingWidget(df, encoding, change_hook, ipywidget_factory, testing=True)
 
-    #  call(options=[('-', None), ('buildingID', 'buildingID'), ('date', 'date'), ('temp_diff', 'temp_diff')], description='X', value=None),
-    #  call().on_trait_change(<bound method EncodingWidget._x_changed_callback of EncodingWidget(children=(<MagicMock name='mock.get_vbox()' spec='Widget' id='4770343872'>,))>, 'value'),
-    #  call(options=[('-', None), ('buildingID', 'buildingID'), ('date', 'date'), ('temp_diff', 'temp_diff')], description='Y', value=None),
-    #  call().on_trait_change(<bound method EncodingWidget._y_changed_callback of EncodingWidget(children=(<MagicMock name='mock.get_vbox()' spec='Widget' id='4770343872'>,))>, 'value'),
-    #  call(options=[('-', 'None'), ('Avg', 'Avg'), ('Min', 'Min'), ('Max', 'Max'), ('Sum', 'Sum'), ('Count', 'Count')], description='Func.', value='none'),
-    #  call().on_trait_change(<bound method EncodingWidget._y_agg_changed_callback of EncodingWidget(children=(<MagicMock name='mock.get_vbox()' spec='Widget' id='4770343872'>,))>, 'value')
-
     assert (
         call(
             description="X",

--- a/autovizwidget/autovizwidget/widget/encodingwidget.py
+++ b/autovizwidget/autovizwidget/widget/encodingwidget.py
@@ -43,8 +43,8 @@ class EncodingWidget(Box):
         )
 
         # X view
-        options_x_view = {text(i): text(i) for i in self.df.columns}
-        options_x_view["-"] = None
+        options_x_view = [(text(i), text(i)) for i in self.df.columns]
+        options_x_view.insert(0, ("-", None))
         self.x_view = self.ipywidget_factory.get_dropdown(
             options=options_x_view, description="X", value=self.encoding.x
         )
@@ -52,8 +52,8 @@ class EncodingWidget(Box):
         self.x_view.layout.width = "200px"
 
         # Y
-        options_y_view = {text(i): text(i) for i in self.df.columns}
-        options_y_view["-"] = None
+        options_y_view = [(text(i), text(i)) for i in self.df.columns]
+        options_y_view.insert(0, ("-", None))
         y_column_view = self.ipywidget_factory.get_dropdown(
             options=options_y_view, description="Y", value=self.encoding.y
         )
@@ -62,15 +62,16 @@ class EncodingWidget(Box):
 
         # Y aggregator
         value_for_view = self._get_value_for_aggregation(self.encoding.y_aggregation)
+        options_y_agg_view = [
+            ("-", Encoding.y_agg_none),
+            (Encoding.y_agg_avg, Encoding.y_agg_avg),
+            (Encoding.y_agg_min, Encoding.y_agg_min),
+            (Encoding.y_agg_max, Encoding.y_agg_max),
+            (Encoding.y_agg_sum, Encoding.y_agg_sum),
+            (Encoding.y_agg_count, Encoding.y_agg_count),
+        ]
         self.y_agg_view = self.ipywidget_factory.get_dropdown(
-            options={
-                "-": Encoding.y_agg_none,
-                Encoding.y_agg_avg: Encoding.y_agg_avg,
-                Encoding.y_agg_min: Encoding.y_agg_min,
-                Encoding.y_agg_max: Encoding.y_agg_max,
-                Encoding.y_agg_sum: Encoding.y_agg_sum,
-                Encoding.y_agg_count: Encoding.y_agg_count,
-            },
+            options=options_y_agg_view,
             description="Func.",
             value=value_for_view,
         )

--- a/sparkmagic/sparkmagic/controllerwidget/addendpointwidget.py
+++ b/sparkmagic/sparkmagic/controllerwidget/addendpointwidget.py
@@ -33,8 +33,9 @@ class AddEndpointWidget(AbstractMenuWidget):
             auth_class = getattr(events_handler_module, class_name)
             self.auth_instances[auth] = auth_class()
 
+        dropdown_options = [(k, v) for k, v in conf.authenticators()]
         self.auth_type = self.ipywidget_factory.get_dropdown(
-            options=conf.authenticators(), description="Auth type:"
+            options=dropdown_options, description="Auth type:"
         )
 
         # combine all authentication instance's widgets into one list to pass to self.children.
@@ -89,9 +90,8 @@ class AddEndpointWidget(AbstractMenuWidget):
             raise
 
     def _update_auth(self):
-        """
-        Create an instance of the chosen auth type maps to in the config file.
-        """
+        """Create an instance of the chosen auth type maps to in the config
+        file."""
         for widget in self.auth.widgets:
             widget.layout.display = "none"
         self.auth = self.auth_instances.get(self.auth_type.value)

--- a/sparkmagic/sparkmagic/controllerwidget/addendpointwidget.py
+++ b/sparkmagic/sparkmagic/controllerwidget/addendpointwidget.py
@@ -33,7 +33,7 @@ class AddEndpointWidget(AbstractMenuWidget):
             auth_class = getattr(events_handler_module, class_name)
             self.auth_instances[auth] = auth_class()
 
-        dropdown_options = [(k, v) for k, v in conf.authenticators()]
+        dropdown_options = [(k, v) for k, v in conf.authenticators().items()]
         self.auth_type = self.ipywidget_factory.get_dropdown(
             options=dropdown_options, description="Auth type:"
         )

--- a/sparkmagic/sparkmagic/controllerwidget/magicscontrollerwidget.py
+++ b/sparkmagic/sparkmagic/controllerwidget/magicscontrollerwidget.py
@@ -61,8 +61,9 @@ class MagicsControllerWidget(AbstractMenuWidget):
         return default_endpoints
 
     def _refresh(self):
+        dropdown_options = [(k, v) for k, v in self.endpoints.items()]
         self.endpoints_dropdown_widget = self.ipywidget_factory.get_dropdown(
-            description="Endpoint:", options=self.endpoints
+            description="Endpoint:", options=dropdown_options
         )
 
         self.manage_session = ManageSessionWidget(


### PR DESCRIPTION
### Description
<!-- FILL IN -->
Closes https://github.com/jupyter-incubator/sparkmagic/issues/769
Relates to https://github.com/jupyter-widgets/ipywidgets/pull/2679

[ipywidgets dropped supported for map types in 8.0.0](https://github.com/jupyter-widgets/ipywidgets/issues/1958) because drop downs should be ordered. This PR passes an ordered list of tuples to all of the references to `Dropdown` instead of a dict.

Note: `dict` support was re-added in https://github.com/jupyter-widgets/ipywidgets/pull/3557, but still think it makes sense to move to an ordered list of tuples

### Checklist
- [x] Wrote a description of my changes above 
- [x] Formatted my code with [`black`](https://black.readthedocs.io/en/stable/index.html)
- [x] Added a bullet point for my changes to the top of the `CHANGELOG.md` file
- [x] Added or modified unit tests to reflect my changes
- [x] Manually tested with a notebook
- [ ] If adding a feature, there is an example notebook and/or documentation in the `README.md` file
