### PR TITLE
fix: package install in 0.20.2 release

### DIFF
--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -19,12 +19,12 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      - if: github.event_name == "push" 
+      - if: github.event_name == 'push' 
         name: Run docker compose build with local packages
         run: |
           docker compose build --build-arg dev_mode="true"
 
-      - if: github.event_name == "schedule" 
+      - if: github.event_name == 'schedule' 
         name: Run docker compose build with latest release
         run: |
           docker compose build

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -23,4 +23,4 @@ jobs:
       -
         name: Run docker compose build
         run: |
-          docker compose build
+          docker compose build --build-arg dev_mode="true"

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -10,17 +10,21 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Checkout
+      - name: Checkout
         uses: actions/checkout@v3
-      -
-        name: Set up QEMU
+
+      - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
-      -
-        name: Set up Docker Buildx
+
+      - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      -
-        name: Run docker compose build
+      - if: github.event_name == "push" 
+        name: Run docker compose build with local packages
         run: |
           docker compose build --build-arg dev_mode="true"
+
+      - if: github.event_name == "schedule" 
+        name: Run docker compose build with latest release
+        run: |
+          docker compose build

--- a/autovizwidget/MANIFEST.in
+++ b/autovizwidget/MANIFEST.in
@@ -1,0 +1,1 @@
+include requirements.txt

--- a/hdijupyterutils/MANIFEST.in
+++ b/hdijupyterutils/MANIFEST.in
@@ -1,0 +1,2 @@
+include requirements.txt
+

--- a/sparkmagic/MANIFEST.in
+++ b/sparkmagic/MANIFEST.in
@@ -1,1 +1,2 @@
 recursive-include sparkmagic/kernels *.js *.json
+include requirements.txt


### PR DESCRIPTION
### Description
<!-- FILL IN -->
The `0.20.2` release doesn't include `requirements.txt` in the package distribution causing the build to fail. This should fix it.

I also updated the docker compose workflow to build against local on `push` events to catch issues like this earlier.

### Checklist
- [ ] Wrote a description of my changes above 
- [ ] Formatted my code with [`black`](https://black.readthedocs.io/en/stable/index.html)
- [ ] Added a bullet point for my changes to the top of the `CHANGELOG.md` file
- [ ] Added or modified unit tests to reflect my changes
- [ ] Manually tested with a notebook
- [ ] If adding a feature, there is an example notebook and/or documentation in the `README.md` file
