### PR TITLE
Fix GCP GPG Key Error in Docker Build

### DIFF
--- a/Dockerfile.spark
+++ b/Dockerfile.spark
@@ -7,6 +7,11 @@ USER 0
 # ----------
 # Setup Python and Livy/Spark Deps
 #
+# Install GCP keys to avoid error:
+# "GPG error: https://packages.cloud.google.com/apt cloud-sdk InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY B53DC80D13EDEF05"
+RUN apt-get install apt-transport-https ca-certificates gnupg
+RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
+RUN curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
 # Livy Requires:
 # - mvn (from maven package or maven3 tarball)
 # - openjdk-8-jdk (or Oracle JDK 8)


### PR DESCRIPTION
### Description
<!-- FILL IN -->
CI has been [failing the past few nights](https://github.com/jupyter-incubator/sparkmagic/actions/runs/3936067084/jobs/6732292620) with the following error 

```bash
#6 2.295 W: GPG error: https://packages.cloud.google.com/apt cloud-sdk InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY B53DC80D13EDEF05
#6 2.296 E: The repository 'https://packages.cloud.google.com/apt cloud-sdk InRelease' is not signed.
```

I'm not sure what unpinned underlying dependency changed to cause this issue, but adding GCP keys per [these instructions](https://cloud.google.com/sdk/docs/install#deb) appears to fix it.

### Checklist
- [x] Wrote a description of my changes above 
- [x] Formatted my code with [`black`](https://black.readthedocs.io/en/stable/index.html)
- [x] Added a bullet point for my changes to the top of the `CHANGELOG.md` file
- [x] Added or modified unit tests to reflect my changes
- [x] Manually tested with a notebook
- [x] If adding a feature, there is an example notebook and/or documentation in the `README.md` file
