### PR TITLE
fix: Display HTML for IPython.display.display_html 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Next Release
 
+### Bug Fixes
+- Render the output of IPython.display.display_html as HTML
+
 ## 0.20.4
 
 ### Bug Fixes

--- a/sparkmagic/sparkmagic/tests/test_sparkmagicsbase.py
+++ b/sparkmagic/sparkmagic/tests/test_sparkmagicsbase.py
@@ -317,11 +317,7 @@ def test_spark_execution_with_output_var():
         )
 
 
-def test_spark_execution_with_nested_text_html_out():
-    mockSparkCommand = MagicMock()
-    magic._spark_store_command = MagicMock(return_value=mockSparkCommand)
-
-    magic.spark_controller.run_command.side_effect = None
+def test_spark_execution_ipython_display_html():
     magic.spark_controller.run_command.return_value = (
         True,
         "{ 'text/html': '<h1>test</h1>' }",
@@ -336,7 +332,6 @@ def test_spark_exception_with_output_var():
     magic._spark_store_command = MagicMock(return_value=mockSparkCommand)
     exception = BadUserDataException("Ka-boom!")
     output_var = "var_name"
-    df = "df"
 
     magic.spark_controller.run_command.side_effect = [
         (True, "out", MIMETYPE_TEXT_PLAIN),

--- a/sparkmagic/sparkmagic/tests/test_sparkmagicsbase.py
+++ b/sparkmagic/sparkmagic/tests/test_sparkmagicsbase.py
@@ -323,8 +323,16 @@ def test_spark_execution_ipython_display_html():
         "{ 'text/html': '<h1>test</h1>' }",
         MIMETYPE_TEXT_PLAIN,
     )
-    magic.execute_spark("", None, None, None, None, session, True)
-    magic.ipython_display.write.assert_called_once_with("<h1>test</h1>")
+    magic.execute_spark(
+        "",
+        None,
+        None,
+        None,
+        None,
+        session,
+        True,
+    )
+    magic.ipython_display.html.assert_called_once_with("<h1>test</h1>")
 
 
 def test_spark_exception_with_output_var():

--- a/sparkmagic/sparkmagic/tests/test_sparkmagicsbase.py
+++ b/sparkmagic/sparkmagic/tests/test_sparkmagicsbase.py
@@ -317,6 +317,20 @@ def test_spark_execution_with_output_var():
         )
 
 
+def test_spark_execution_with_nested_text_html_out():
+    mockSparkCommand = MagicMock()
+    magic._spark_store_command = MagicMock(return_value=mockSparkCommand)
+
+    magic.spark_controller.run_command.side_effect = None
+    magic.spark_controller.run_command.return_value = (
+        True,
+        "{ 'text/html': '<h1>test</h1>' }",
+        MIMETYPE_TEXT_PLAIN,
+    )
+    magic.execute_spark("", None, None, None, None, session, True)
+    magic.ipython_display.write.assert_called_once_with("<h1>test</h1>")
+
+
 def test_spark_exception_with_output_var():
     mockSparkCommand = MagicMock()
     magic._spark_store_command = MagicMock(return_value=mockSparkCommand)


### PR DESCRIPTION
Fixes #512 

### Description
Add a special case handling for the return type of native IPython `display_html` function

### Checklist
- [x] Wrote a description of my changes above 
- [x] Formatted my code with [`black`](https://black.readthedocs.io/en/stable/index.html)
- [x] Added a bullet point for my changes to the top of the `CHANGELOG.md` file
- [x] Added or modified unit tests to reflect my changes
- [x] Manually tested with a notebook
- [x] If adding a feature, there is an example notebook and/or documentation in the `README.md` file
