### PR TITLE
fixed the typo in http session adapter config exception

### DIFF
--- a/sparkmagic/sparkmagic/livyclientlib/exceptions.py
+++ b/sparkmagic/sparkmagic/livyclientlib/exceptions.py
@@ -65,7 +65,7 @@ class SparkStatementException(LivyClientLibException):
 
 
 class HttpSessionAdapterConfigException(LivyClientLibException):
-    """Exception that is thrown when an the http session adapter config is invalid"""
+    """Exception that is thrown when the http session adapter config is invalid"""
 
 
 # It has to be a KeyboardInterrupt to interrupt the notebook


### PR DESCRIPTION
### Description
<!-- FILL IN -->

### Checklist
- [ ] Wrote a description of my changes above 
- [ ] Formatted my code with [`black`](https://black.readthedocs.io/en/stable/index.html)
- [ ] Added a bullet point for my changes to the top of the `CHANGELOG.md` file
- [ ] Added or modified unit tests to reflect my changes
- [ ] Manually tested with a notebook
- [ ] If adding a feature, there is an example notebook and/or documentation in the `README.md` file
