### PR TITLE
Update readme with Ilum as new compatible implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,10 @@
 
 # sparkmagic
 
-Sparkmagic is a set of tools for interactively working with remote Spark clusters in [Jupyter](http://jupyter.org) notebooks. Sparkmagic interacts with remote Spark clusters through a REST server. Currently there are two server implementations compatible with Spararkmagic: 
+Sparkmagic is a set of tools for interactively working with remote Spark clusters in [Jupyter](http://jupyter.org) notebooks. Sparkmagic interacts with remote Spark clusters through a REST server. Currently there are three server implementations compatible with Spararkmagic: 
 * [Livy](https://livy.apache.org) - for running interactive sessions on Yarn
 * [Lighter](https://github.com/exacaster/lighter) - for running interactive sessions on Yarn or Kubernetes (only PySpark sessions are supported)
+* [Ilum](http://ilum.cloud) - for running interactive sessions on Yarn or Kubernetes
 
 The Sparkmagic project includes a set of magics for interactively running Spark code in multiple languages, as well as some kernels that you can use to turn Jupyter into an integrated Spark environment.
 


### PR DESCRIPTION
This change adds [Ilum](http://ilum.cloud/) to the list of supported server implementations compatible with Sparkmagic.

My name is Oliver, and I am part of project Ilum, which is focused on interactive Spark sessions. We consider Ilum as a modern replacement for Apache Livy and Yarn. Last year, we added support for Sparkmagic, an aspect we are quite proud of. You can read more about how it's used in our [blog post](https://ilum.cloud/blog/how-to-optimize-your-spark-cluster-with-interactive-spark-jobs/). And just recently we added full support for Python, users can now use Sparkmagic in Scala and Python.

Please consider adding a link to Ilum given the alignment between our projects and the potential benefit to our shared user community.

Thanks!