### PR TITLE
fix: pin Docker.jupyter to notebook 6.x.x

### DIFF
--- a/Dockerfile.jupyter
+++ b/Dockerfile.jupyter
@@ -31,7 +31,8 @@ RUN if [ "$dev_mode" = "true" ]; then \
     else pip install sparkmagic ; fi
 
 # Jupyter extensions changed in >7.x.x
-# For now, let's pin to 6 to avoid breaking things
+# For now (workaround), let's pin to 6 to avoid breaking things
+# xref: https://github.com/jupyter-incubator/sparkmagic/issues/825
 RUN pip install notebook==6.5.5
 
 RUN mkdir /home/$NB_USER/.sparkmagic

--- a/Dockerfile.jupyter
+++ b/Dockerfile.jupyter
@@ -30,6 +30,10 @@ RUN if [ "$dev_mode" = "true" ]; then \
       cd sparkmagic && pip install -e . && cd ../ ; \
     else pip install sparkmagic ; fi
 
+# Jupyter extensions changed in >7.x.x
+# For now, let's pin to 6 to avoid breaking things
+RUN pip install notebook==6.48
+
 RUN mkdir /home/$NB_USER/.sparkmagic
 COPY sparkmagic/example_config.json /home/$NB_USER/.sparkmagic/config.json
 RUN sed -i 's/localhost/spark/g' /home/$NB_USER/.sparkmagic/config.json

--- a/Dockerfile.jupyter
+++ b/Dockerfile.jupyter
@@ -32,7 +32,7 @@ RUN if [ "$dev_mode" = "true" ]; then \
 
 # Jupyter extensions changed in >7.x.x
 # For now, let's pin to 6 to avoid breaking things
-RUN pip install notebook==6.48
+RUN pip install notebook==6.5.5
 
 RUN mkdir /home/$NB_USER/.sparkmagic
 COPY sparkmagic/example_config.json /home/$NB_USER/.sparkmagic/config.json


### PR DESCRIPTION
### Description

<!-- FILL IN -->

Closes https://github.com/jupyter-incubator/sparkmagic/issues/825

This is a workaround fix. In future we will want to upgrade the Dockerfile to support `notebook>=7.0.0`

### Checklist

- [x] Wrote a description of my changes above
- [x] Formatted my code with [`black`](https://black.readthedocs.io/en/stable/index.html)
- [x] Added a bullet point for my changes to the top of the `CHANGELOG.md` file
- [x] Added or modified unit tests to reflect my changes
- [x] Manually tested with a notebook
- [x] If adding a feature, there is an example notebook and/or documentation in the `README.md` file
