### PR TITLE
Run cells with specific language

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Next Release
 
 ### Updates
-
+- Enable cell-specific language to run against the same Spark Session (for polyglot notebooks).
 - Enable automated test run as required step for release process
 - Enable basic DependaBot scanning for pip packages and GitHub actions used in CI
 - Add CI support for release proces with [release.yaml](.github/workflows/release.yml) workflow

--- a/sparkmagic/sparkmagic/kernels/kernelmagics.py
+++ b/sparkmagic/sparkmagic/kernels/kernelmagics.py
@@ -359,6 +359,13 @@ class KernelMagics(SparkMagicBase):
         help="Whether to automatically coerce the types (default, pass True if being explicit) "
         "of the dataframe or not (pass False)",
     )
+    @argument(
+        "-l",
+        "--language",
+        type=str,
+        default=None,
+        help=f"Specific language for the current cell (supported: {','.join(LANGS_SUPPORTED)})",
+    )
     @wrap_unexpected_exceptions
     @handle_expected_exceptions
     def spark(self, line, cell="", local_ns=None):
@@ -377,6 +384,7 @@ class KernelMagics(SparkMagicBase):
             args.samplefraction,
             None,
             coerce,
+            language=args.language,
         )
 
     @cell_magic

--- a/sparkmagic/sparkmagic/magics/sparkmagicsbase.py
+++ b/sparkmagic/sparkmagic/magics/sparkmagicsbase.py
@@ -124,6 +124,7 @@ class SparkMagicBase(Magics):
         session_name,
         coerce,
         output_handler=None,
+        language=None,
     ):
         output_handler = output_handler or SparkOutputHandler(
             html=self.ipython_display.html,
@@ -131,8 +132,9 @@ class SparkMagicBase(Magics):
             default=self.ipython_display.display,
         )
 
+        command = Command(cell).set_language(language)
         (success, out, mimetype) = self.spark_controller.run_command(
-            Command(cell), session_name
+            command, session_name
         )
         if not success:
             if conf.shutdown_session_on_spark_statement_errors():


### PR DESCRIPTION
### Description
Addresses the same functionality as #598 but with some differences, this PR is for allowing users to execute cells with specific languages against the same Spark Session. Given that #598 is nearly 5 years old and seems abandoned, this implementation provides a minimal, backward-compatible solution.

Due to a lack of familiarity with the sparkmagic code base, no tests have been added. **I kindly request guidance on how to implement unit tests.**

The changes have been manually tested on a notebook, ensuring compatibility with shared DataFrames and UDFs between Scala and Python.

### Checklist
- [x] Wrote a description of my changes above 
- [x] Formatted my code with [`black`](https://black.readthedocs.io/en/stable/index.html)
- [x] Added a bullet point for my changes to the top of the `CHANGELOG.md` file
- [ ] Added or modified unit tests to reflect my changes
- [x] Manually tested with a notebook
- [ ] If adding a feature, there is an example notebook and/or documentation in the `README.md` file
