### PR TITLE
Change deprecated import of IPython.core.display to IPython.display

### DIFF
--- a/hdijupyterutils/hdijupyterutils/ipythondisplay.py
+++ b/hdijupyterutils/hdijupyterutils/ipythondisplay.py
@@ -1,4 +1,4 @@
-from IPython.core.display import display, HTML
+from IPython.display import display, HTML
 from IPython import get_ipython
 import sys
 


### PR DESCRIPTION
### Description
This is a simple PR to remove the deprecated import. 

### Checklist
- [x] Wrote a description of my changes above 
- [x] Formatted my code with [`black`](https://black.readthedocs.io/en/stable/index.html)
- [ ] Added a bullet point for my changes to the top of the `CHANGELOG.md` file
- [] Added or modified unit tests to reflect my changes
- [ ] Manually tested with a notebook
- [ ] If adding a feature, there is an example notebook and/or documentation in the `README.md` file
