### PR TITLE
Replace hyphen with underscore to support setuptools setup.cfg

### DIFF
--- a/hdijupyterutils/setup.cfg
+++ b/hdijupyterutils/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-description-file = README.md
+description_file = README.md


### PR DESCRIPTION
### Description

Currently, the `setup.cfg` file uses hyphens in fields. [Setuptools 78.0.0](https://setuptools.pypa.io/en/latest/history.html#v78-0-0) requires all fields to be formatted as `lower_snake_case`.

Given that this backwards-incompatible change broke many installations, [Setuptools 78.0.2](https://setuptools.pypa.io/en/latest/history.html#v78-0-2) temporarily suspends the deprecation until 2026.

This pull request updates `setup.cfg` to adhere to Setuptools' formatting requirements.

### Checklist
- [x] Wrote a description of my changes above 
- [ ] Formatted my code with [`black`](https://black.readthedocs.io/en/stable/index.html)
- [x] Added a bullet point for my changes to the top of the `CHANGELOG.md` file
- [ ] Added or modified unit tests to reflect my changes
- [ ] Manually tested with a notebook
- [ ] If adding a feature, there is an example notebook and/or documentation in the `README.md` file
