### PR TITLE
Fix support for IPython 8 and 9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Next Release
 
+### Bug Fixes
+
+- Add support for `ipython>=9.0.0`
+- Remove support for `ipython<4.1.2`
+
 ## 0.22.0
 
 ### Updates

--- a/hdijupyterutils/hdijupyterutils/ipythondisplay.py
+++ b/hdijupyterutils/hdijupyterutils/ipythondisplay.py
@@ -1,4 +1,4 @@
-from IPython.core.display import display, HTML
+from IPython.display import display, HTML
 from IPython import get_ipython
 import sys
 

--- a/hdijupyterutils/requirements.txt
+++ b/hdijupyterutils/requirements.txt
@@ -1,4 +1,4 @@
-ipython>=4.0.2
+ipython>=4.1.2
 ipywidgets>5.0.0
 ipykernel>=4.2.2
 jupyter>=1

--- a/sparkmagic/requirements.txt
+++ b/sparkmagic/requirements.txt
@@ -1,6 +1,6 @@
 hdijupyterutils>=0.6
 autovizwidget>=0.6
-ipython>=4.0.2
+ipython>=4.1.2
 pandas<3.0.0
 numpy
 requests


### PR DESCRIPTION
### Description

A public API for `IPython.display` was introduced in `ipython==4.1.2`.  Access to the tool via the internal API was deprecated in 7.14, warned against through 8.*, and removed in 9.0.

With this change, hdijupyterutils targets the public API which enables support for the most recent versions of IPython, but requires a minor version change for the minimum required version.

Closes #957